### PR TITLE
fix(arith): overflow-free uint floormod/floordiv rewrites

### DIFF
--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -1182,6 +1182,14 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
                        ContainsVscaleCall(y.Eval()) && CanProveGreaterEqual(x.Eval(), 0) &&
                            CanProveGreaterEqual(y.Eval(), 0) && CanProve(x.Eval() < y.Eval()));
   }
+
+  // Unsigned (uint32/uint64): the signed IsIndexType block above is skipped for
+  // unsigned operands (see the note in the FloorMod handler). Only the
+  // OVERFLOW-FREE identities are valid here.
+  if (op->dtype.is_uint() && (op->dtype.bits() == 32 || op->dtype.bits() == 64)) {
+    TVM_TRY_REWRITE(floordiv(x, x), OneWithTypeLike(x));            // x / x -> 1  (x != 0)
+    TVM_TRY_REWRITE_IF(floordiv(x, c1), x, c1.Eval()->value == 1);  // x / 1 -> x
+  }
   return ret;
 }
 
@@ -1298,6 +1306,20 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
         }
       }
     }
+  }
+
+  // Unsigned (uint32/uint64) index arithmetic. The signed IsIndexType rewrite
+  // block above is skipped for unsigned operands: signed-overflow-is-UB lets
+  // those rules assume no wraparound, which is UNSOUND for unsigned (e.g.
+  // floormod(x*y, y) -> 0 fails when x*y wraps mod 2^bits). Only the
+  // OVERFLOW-FREE identities are valid here.
+  if (op->dtype.is_uint() && (op->dtype.bits() == 32 || op->dtype.bits() == 64)) {
+    TVM_TRY_REWRITE(floormod(x, x), ZeroWithTypeLike(x));  // x % x -> 0  (x != 0)
+    TVM_TRY_REWRITE_IF(floormod(x, c1), ZeroWithTypeLike(x),
+                       c1.Eval()->value == 1);  // x % 1 -> 0
+    // Overflow-free: when c1 is a multiple of c2, x * c1 is too (in Z and mod 2^bits).
+    TVM_TRY_REWRITE_IF(floormod(x * c1, c2), ZeroWithTypeLike(x),
+                       c2.Eval()->value != 0 && c1.Eval()->value % c2.Eval()->value == 0);
   }
   return ret;
 }

--- a/tests/python/arith/test_arith_simplify.py
+++ b/tests/python/arith/test_arith_simplify.py
@@ -167,6 +167,16 @@ def test_simplify_floor_mod_with_linear_offset():
     assert ana.can_prove_equal(tvm.tirx.floormod(expr1, divisor2), 0)
 
 
+def test_simplify_uint_floormod_const_scale_divisible():
+    """uint32 floormod(x * c1, c2) -> 0 when c1 % c2 == 0 (overflow-free)."""
+    ana = tvm.arith.Analyzer()
+    q = tirx.Var("q_stage_idx", "uint32")
+    expr = q * tirx.Cast("uint32", 128)
+    mod = expr % tirx.const(4, "uint32")
+    assert ana.can_prove_equal(mod, tirx.const(0, "uint32"))
+    tvm.ir.assert_structural_equal(ana.rewrite_simplify(mod), tirx.const(0, "uint32"))
+
+
 def test_simplify_float_division():
     # Test for the discussion:
     # https://discuss.tvm.apache.org/t/discuss-is-constant-division-to-multiplication-rewrite-in-tvm-necessary/18615


### PR DESCRIPTION
## Summary
- Add overflow-free `floordiv`/`floormod` rewrite rules for `uint32`/`uint64` index arithmetic in `RewriteSimplifier`.
- Fold `floormod(x * c1, c2) -> 0` when `c1 % c2 == 0` (constant-scale case used by unsigned shape/index lowering).
- Signed rewrite paths are unchanged; multiply-cancellation rules stay signed-only because they are unsound under unsigned wraparound.

## Test plan
- [x] `pytest tests/python/arith/test_arith_simplify.py::test_simplify_uint_floormod_const_scale_divisible`