### PR TITLE
feat(infra): TFLOAT32 TMA descriptor for copy_async(tma)

### DIFF
--- a/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
@@ -1118,6 +1118,20 @@ def copy_tma_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc
     l1 = _build_l1_result(s_buf, g_buf, g_st, g_ext, s_st, s_ext)
     plan = _build_plan_with_shrink(l1, g_buf, s_buf)
 
+    # Optional descriptor dtype override. An fp32 buffer feeding a tf32 MMA should
+    # be loaded via a TFLOAT32 (== 11) descriptor so the TMA hardware RN-truncates
+    # fp32 -> tf32 ON LOAD (matching the MMA's operand precision and a torch
+    # allow_tf32 / DeepGEMM reference); leaving it as FLOAT32 loads full fp32 and
+    # the tf32 MMA then RZ-truncates, diverging by ~1 tf32 ULP. -1 = derive from
+    # the buffer dtype (the C++ ``runtime.cuTensorMapEncodeTiled`` default).
+    _TMA_DTYPE_TO_CU = {"tf32": 11, "tfloat32": 11}
+    _tma_dtype = op_call.config.get("tma_dtype", None)
+    if _tma_dtype is not None and _tma_dtype not in _TMA_DTYPE_TO_CU:
+        fail(f"Unsupported tma_dtype={_tma_dtype!r}; expected one of {sorted(_TMA_DTYPE_TO_CU)}")
+    if _tma_dtype is not None and plan.elem_dtype not in ("float32", "tfloat32"):
+        fail(f"tma_dtype={_tma_dtype!r} requires a float32 descriptor; got {plan.elem_dtype}")
+    force_cu_dtype = _TMA_DTYPE_TO_CU.get(_tma_dtype, -1)
+
     # Direction / runtime-config bits that don't affect the plan itself.
     cta_group = op_call.config.get("cta_group", None)
     if cta_group is None:
@@ -1158,7 +1172,7 @@ def copy_tma_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc
         f":{tuple(val_key(v) for v in plan.shape)}"
         f":{tuple(val_key(v) for v in tma_g_strides_for_map)}"
         f":{tuple(val_key(v) for v in plan.box_dim)}"
-        f":{val_key(plan.swizzle_mode.value)}:{oob_fill_kind}"
+        f":{val_key(plan.swizzle_mode.value)}:{oob_fill_kind}:{force_cu_dtype}"
     )
 
     cached_tensormap = sctx.cache_get(tensormap_cache_key)
@@ -1235,6 +1249,10 @@ def copy_tma_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc
                 plan.swizzle_mode.value,
                 2,  # CU_TENSOR_MAP_L2_PROMOTION_L2_128B
                 oob_fill_kind,
+                # Append the dtype override ONLY when requested, so the default
+                # (derive-from-dtype) path emits a byte-identical encode call (the
+                # C++ wrapper treats the trailing arg as optional).
+                *([force_cu_dtype] if force_cu_dtype >= 0 else []),
             )
             T.tvm_kernel_replace_point()
         # fmt: on

--- a/src/backend/cuda/runtime/cuda_device_api.cc
+++ b/src/backend/cuda/runtime/cuda_device_api.cc
@@ -434,12 +434,19 @@ TVM_FFI_STATIC_INIT_BLOCK() {
     uint32_t tensor_rank = static_cast<uint32_t>(raw_tensor_rank);
     void* tensor_ptr = static_cast<void*>(args[arg_cnt++].cast<void*>());
 
-    TVM_FFI_ICHECK_EQ(args.size(), 4 + tensor_rank * 4 + 3)
-        << "cuTensorMapEncodeTiled expects " << 4 + tensor_rank * 4 + 3 << " arguments"
+    // The base arg list ends with oob_fill_kind. An OPTIONAL trailing int
+    // ``force_cu_dtype`` (>= 0) overrides the dtype-derived CUtensorMapDataType
+    // (e.g. 11 == TFLOAT32 for an fp32 gmem buffer feeding a tf32 MMA, so the TMA
+    // hardware RN-truncates fp32->tf32 on load). -1 / absent = derive from
+    // tensor_dtype. Omitting it keeps older callers backward-compatible.
+    int base_arg_count = static_cast<int>(4 + tensor_rank * 4 + 3);
+    TVM_FFI_ICHECK(args.size() == base_arg_count || args.size() == base_arg_count + 1)
+        << "cuTensorMapEncodeTiled expects " << base_arg_count
+        << " (or +1 force_cu_dtype) arguments"
         << "tensor_map, tensor_dtype, tensor_rank, tensor_ptr, global_shape(" << tensor_rank
         << "), global_strides(" << tensor_rank - 1 << "), shared_shape(" << tensor_rank
         << "), shared_strides(" << tensor_rank << "), interleaved_kind, swizzle_kind"
-        << ", l2_promotion_kind, oob_fill_kind";
+        << ", l2_promotion_kind, oob_fill_kind[, force_cu_dtype]";
 
     std::vector<cuuint64_t> global_shape(tensor_rank);
     std::vector<cuuint64_t> global_strides(
@@ -477,6 +484,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
     auto swizzle_kind = static_cast<CUtensorMapSwizzle>(args[arg_cnt++].cast<int>());
     auto l2_promotion_kind = static_cast<CUtensorMapL2promotion>(args[arg_cnt++].cast<int>());
     auto oob_fill_kind = static_cast<CUtensorMapFloatOOBfill>(args[arg_cnt++].cast<int>());
+    int force_cu_dtype =
+        (arg_cnt < static_cast<size_t>(args.size())) ? args[arg_cnt++].cast<int>() : -1;
 
     TVM_FFI_ICHECK_EQ(tensor_dtype.lanes(), 1)
         << "Expect tensor_dtype to have lanes=1, but get " << tensor_dtype;
@@ -568,6 +577,12 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       default:
         TVM_FFI_THROW(InternalError)
             << "Unsupported data type " << ffi::DLDataTypeToString(tensor_dtype);
+    }
+    // Caller override (e.g. TFLOAT32 == 11 for an fp32 buffer in a tf32 GEMM):
+    // bypass the dtype-derived mapping so the descriptor uses the requested
+    // CUtensorMapDataType. Same byte size, different on-load rounding semantics.
+    if (force_cu_dtype >= 0) {
+      cu_dtype = static_cast<CUtensorMapDataType>(force_cu_dtype);
     }
 
     auto is_valid_interleave = interleaved_kind == CU_TENSOR_MAP_INTERLEAVE_NONE ||


### PR DESCRIPTION
## Summary
- Add optional trailing `force_cu_dtype` to `runtime.cuTensorMapEncodeTiled` so callers can override the CUtensorMapDataType derived from the buffer dtype (e.g. `11 == TFLOAT32` for an fp32 gmem buffer feeding a tf32 MMA).
- Wire `copy_async(tma)` `tma_dtype="tf32"` / `"tfloat32"` through to the encode call and tensormap cache key; default path stays byte-identical when unset.

## Motivation
Loading fp32 via a FLOAT32 TMA descriptor and letting a tf32 MMA RZ-truncate at read can diverge by ~1 tf32 ULP from a reference that RN-truncates on load. This matches torch `allow_tf32` / DeepGEMM semantics.

## Test plan
- [x] Default TMA encode path unchanged (no trailing arg when `tma_dtype` unset)
- [ ] `/tir-test` after merge
- [ ] Downstream tf32 GEMM dispatch PR rebases on this