### PR TITLE
feat(op-dispatch): add dense fp8 and tf32 tcgen05 gemm_async paths

### DIFF
--- a/python/tvm/backend/cuda/operator/tile_primitive/gemm_async/tcgen05.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/gemm_async/tcgen05.py
@@ -387,6 +387,11 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
     C_type, A_type, B_type = C_buffer.dtype, A_buffer.dtype, B_buffer.dtype
     assert C_type == "float32", f"tcgen05 schedule expected C_type=float32, got {C_type}"
 
+    # fp32/bf16 storage may still use tf32 MMA semantics via is_AB_tf32.
+    is_AB_tf32 = op_call.config.get("is_AB_tf32", False)
+    A_sem = "tf32" if is_AB_tf32 else A_type
+    B_sem = "tf32" if is_AB_tf32 else B_type
+
     # Valid A/B dtypes for block-scaled MMA (low-precision with per-block scale factors)
     _BLOCK_SCALED_DTYPES = ["float4_e2m1fn", "float8_e4m3fn"]
 
@@ -400,14 +405,22 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
             f"tcgen05 block-scaled schedule expected B_type in {_BLOCK_SCALED_DTYPES}, got {B_type}"
         )
     else:
-        assert A_type in ["float16", "bfloat16"], (
-            f"tcgen05 schedule expected A_type=float16 or bfloat16, got {A_type}"
+        _DENSE_DTYPES = [
+            "float16",
+            "bfloat16",
+            "float8_e4m3fn",
+            "float8_e5m2",
+            "tensor_float32",
+            "tf32",
+        ]
+        assert A_sem in _DENSE_DTYPES, (
+            f"tcgen05 schedule expected A dtype in {_DENSE_DTYPES}, got {A_sem}"
         )
-        assert B_type in ["float16", "bfloat16"], (
-            f"tcgen05 schedule expected B_type=float16 or bfloat16, got {B_type}"
+        assert B_sem in _DENSE_DTYPES, (
+            f"tcgen05 schedule expected B dtype in {_DENSE_DTYPES}, got {B_sem}"
         )
-    assert A_type == B_type, (
-        f"tcgen05 schedule expect A_type and B_type to be the same, got A_type={A_type}, B_type={B_type}"  # noqa: E501
+    assert A_sem == B_sem, (
+        f"tcgen05 schedule expect A and B MMA dtype to be the same, got A={A_sem}, B={B_sem}"
     )
 
     # Parse SFA/SFB and transA/transB/accum based on arg layout
@@ -686,12 +699,13 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
     # transA=False [M, K]: K = dim[-1]; transA=True [K, M]: K = dim[-2]
     K = A_dim2 if transA else A_dim1
 
-    # tcgen05 MMA hardware constraints
-    # K dimension per MMA iteration depends on A/B dtype
-    if A_type == "float4_e2m1fn":
+    # tcgen05 MMA hardware constraints (MMA_K keyed on semantic dtype A_sem).
+    if A_sem == "float4_e2m1fn":
         MMA_K = 64
-    elif A_type in ["float8_e4m3fn", "float8_e5m2"]:
+    elif A_sem in ["float8_e4m3fn", "float8_e5m2"]:
         MMA_K = 32
+    elif A_sem in ["tensor_float32", "tf32"]:
+        MMA_K = 8
     else:  # float16, bfloat16
         MMA_K = 16
     MMA_N_MIN = 8 if cta_group == 1 else 16  # Minimum N dimension
@@ -961,7 +975,7 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
                         T.ptx.tcgen05.mma(
                             T.cuda.get_tmem_addr(tmem_addr, mi * M_mma, tmem_col),
                             a_val, descB_val, descI_in,
-                            d_dtype="float32", a_dtype=A_type, b_dtype=B_type,
+                            d_dtype="float32", a_dtype=A_sem, b_dtype=B_sem,
                             use_a_tmem=a_is_tmem, cta_group=cta_group,
                             enable_input_d=should_accum,
                         )
@@ -990,8 +1004,8 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
             M=M_mma * cta_group,
             N=N_mma,
             d_dtype="float32",
-            a_dtype=A_type,
-            b_dtype=B_type,
+            a_dtype=A_sem,
+            b_dtype=B_sem,
             trans_a=a_mn_major,
             trans_b=b_mn_major,
         )

--- a/tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py
@@ -2067,5 +2067,121 @@ def test_gemm_tcgen05_contiguous_kslice_partial_k(k_lo, k_hi):
     np.testing.assert_allclose(C_t.numpy(), C_ref, atol=1e-2, rtol=1e-2)
 
 
+def _run_dense_gemm(
+    A_dtype, B_dtype, C_dtype, K, *, is_AB_tf32=False, tma_dtype_B=None, atol=1e-3, rtol=1e-3
+):
+    M, N = 128, 128
+    A_shape = (M, K)
+    B_shape = (N, K)
+    C_shape = (M, N)
+    A_swizzle, B_swizzle = 3, 3
+    A_layout = mma_shared_layout(A_dtype, A_swizzle, A_shape)
+    B_layout = mma_shared_layout(B_dtype, B_swizzle, B_shape)
+    C_elem_32b = 4 // (tvm.runtime.DataType(C_dtype).bits // 8)
+    cols_alloc = max(32, next_power_of_2(N // C_elem_32b))
+    total_bytes = functools.reduce(operator.mul, A_shape, 1) * (
+        tvm.runtime.DataType(A_dtype).bits // 8
+    ) + functools.reduce(operator.mul, B_shape, 1) * (tvm.runtime.DataType(B_dtype).bits // 8)
+    gemm_kw = {"dispatch": "tcgen05"}
+    if is_AB_tf32:
+        gemm_kw["is_AB_tf32"] = True
+    b_tma_kw = {"dispatch": "tma"}
+    if tma_dtype_B is not None:
+        b_tma_kw["tma_dtype"] = tma_dtype_B
+
+    @T.prim_func
+    def gemm_async(A_ptr: T.handle, B_ptr: T.handle, C_ptr: T.handle) -> None:
+        A = T.match_buffer(A_ptr, A_shape, A_dtype)
+        B = T.match_buffer(B_ptr, B_shape, B_dtype)
+        C = T.match_buffer(C_ptr, C_shape, C_dtype)
+        T.device_entry()
+        warp_id = T.warp_id([4])
+        T.cta_id([1])
+        wg_id = T.warpgroup_id([1])
+        tid_in_wg = T.thread_id_in_wg([128])
+        A_smem = T.alloc_buffer(A_shape, A_dtype, scope="shared", layout=A_layout)
+        B_smem = T.alloc_buffer(B_shape, B_dtype, scope="shared", layout=B_layout)
+        tmem_addr = T.alloc_shared([1], "uint32")
+        tma_mbar = T.alloc_shared([1], "uint64")
+        mma_mbar = T.alloc_shared([1], "uint64")
+        if tid_in_wg == 0:
+            T.ptx.mbarrier.init(tma_mbar.ptr_to([0]), 1)
+            T.ptx.mbarrier.init(mma_mbar.ptr_to([0]), 1)
+        T.ptx.fence.proxy_async("shared::cta")
+        T.cuda.cta_sync()
+        if warp_id == 0:
+            T.ptx.tcgen05.alloc(T.address_of(tmem_addr), n_cols=cols_alloc, cta_group=1)
+        T.cuda.cta_sync()
+        tmem = T.decl_buffer(
+            (128, N),
+            C_dtype,
+            scope="tmem",
+            allocated_addr=tmem_addr[0],
+            layout=TileLayout(S[(128, N) : (1 @ TLane, 1 @ TCol)]),
+        )
+        if tid_in_wg == 0:
+            Tx.copy_async(A_smem[:, :], A[:, :], dispatch="tma", mbar=tma_mbar.ptr_to([0]))
+            Tx.copy_async(B_smem[:, :], B[:, :], mbar=tma_mbar.ptr_to([0]), **b_tma_kw)
+            T.ptx.mbarrier.arrive.expect_tx(tma_mbar.ptr_to([0]), total_bytes)
+        T.ptx.mbarrier.try_wait(tma_mbar.ptr_to([0]), 0)
+        T.cuda.cta_sync()
+        if tid_in_wg == 0:
+            Tx.gemm_async(tmem[:, :], A_smem[:, :], B_smem[:, :], **gemm_kw)
+            T.ptx.tcgen05.commit(mma_mbar.ptr_to([0]), cta_group=1)
+        T.ptx.mbarrier.try_wait(mma_mbar.ptr_to([0]), 0)
+        T.cuda.cta_sync()
+        T.ptx.tcgen05.fence.after_thread_sync()
+        C_reg = T.alloc_local(N, dtype=C_dtype)
+        C_view = C_reg.view(128, N, layout=TileLayout(S[(128, N) : (1 @ axis_tid_in_wg, 1)]))
+        if wg_id == 0:
+            Tx.wg.copy_async(C_view[:, :], tmem[:, :])
+            T.ptx.tcgen05.wait.ld()
+        T.cuda.cta_sync()
+        Tx.copy(C[tid_in_wg, 0:N], C_reg[:])
+        if warp_id == 0:
+            T.ptx.tcgen05.relinquish_alloc_permit(cta_group=1)
+            T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=cols_alloc, cta_group=1)
+
+    dev = tvm.cuda(0)
+    np.random.seed(0)
+    target = tvm.target.Target("cuda")
+    with target:
+        mod = tvm.compile(tvm.IRModule({"main": gemm_async}), target=target, tir_pipeline="tirx")
+
+    def _rand(shape, dtype):
+        f = np.random.randn(*shape).astype("float32")
+        return f.astype(dtype) if ml_dtypes is not None or "float8" not in dtype else f
+
+    A_np = _rand(A_shape, A_dtype)
+    B_np = _rand(B_shape, B_dtype)
+    C_np = np.zeros(C_shape, dtype=C_dtype)
+    A_t, B_t, C_t = (tvm.runtime.tensor(x, dev) for x in (A_np, B_np, C_np))
+    mod["main"](A_t, B_t, C_t)
+    C_ref = A_np.astype("float32") @ B_np.astype("float32").T
+    np.testing.assert_allclose(C_t.numpy().astype("float32"), C_ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_cuda_compute(10), reason="need cuda compute >= 10.0")
+@pytest.mark.skipif(ml_dtypes is None, reason="Requires ml_dtypes for fp8")
+def test_gemm_dense_fp8():
+    _run_dense_gemm("float8_e4m3fn", "float8_e4m3fn", "float32", 128, atol=2.0, rtol=0.15)
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_cuda_compute(10), reason="need cuda compute >= 10.0")
+def test_gemm_tf32_with_tfloat32_tma():
+    _run_dense_gemm(
+        "float32",
+        "float32",
+        "float32",
+        64,
+        is_AB_tf32=True,
+        tma_dtype_B="tf32",
+        atol=2e-2,
+        rtol=2e-2,
+    )
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
## Summary
- Extend tcgen05 dense `gemm_async` dispatch to accept fp8 and tf32 MMA semantics (`is_AB_tf32`, `A_sem`/`B_sem`, `MMA_K`, dense instr descriptor).
- Add end-to-end tests: `test_gemm_dense_fp8` and `test_gemm_tf32_with_tfloat32_tma`.

Split from `tile-primitive-cursor` by hunk (dense dtype path only; smem_desc/descI dispatch refactors stay in the main dispatch PR).

## Test plan
- [ ] `pytest tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py::test_gemm_dense_fp8 -v`
- [ ] `pytest tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py::test_gemm_tf32_with_tfloat32_tma -v`