### PR TITLE
fix(infra): reg-copy R2S/S2R for tcgen05 split-laneid atom layouts

### DIFF
--- a/python/tvm/backend/cuda/operator/tile_primitive/copy/reg.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy/reg.py
@@ -195,28 +195,9 @@ def _compute_perm_r(r):
 def align_layouts_raw(r_sliced, s_sliced, s_region):
     """Returns (r_p, s_p, s_seps, r_perm).
 
-    ``r_sliced`` / ``s_sliced`` are the R/S layouts already sliced to the copy
-    region — sliced OUTSIDE the dispatch target (see ``_align_layouts``); this
-    function canonicalizes them INSIDE it so the scope-aware fusers still run.
-    Slicing under the target pre-fuses split thread axes (e.g. the tcgen05.ld
-    ``16x*b`` atom's ``laneid``, split across two iters) into a partially-fused
-    form that canonicalize then rejects with "conflicting scopes for thread".
-
-    Two views of the permuted R layout are returned:
-
-    - ``r_p`` — the *canonicalized* permuted layout. Its thread axes are fused
-      back to a single per-axis iter (``laneid`` + ``wid_in_wg`` → ``tid_in_wg``),
-      which ``_s_thread_offset`` needs so the per-thread S base offset is one
-      ``apply_to_shape`` over a clean thread iter.
-    - ``r_perm`` — the permuted layout *without* the final canonicalize. Its
-      memory (``m``) iters stay one-per-S-group, so ``_split_thread_loop`` can
-      pair each R ``m``-iter 1:1 with its ``s_seps`` S group. Canonicalizing
-      would fuse a multi-group ``m``-axis (e.g. the ``.16x*b`` atom register
-      axis, which decomposes into several non-contiguous (row, col) groups)
-      into one dense iter, after which the 1:1 pairing breaks and every S group
-      past the first is silently dropped (the m-row-doubling / column-parity
-      bug). For the already-contiguous cases (``.32x32b``, ``wg_local_layout``)
-      the ``m``-axis is a single group, so ``r_perm`` and ``r_p`` agree.
+    Slice outside the dispatch target (see ``_align_layouts``), canonicalize here.
+    ``r_p`` is canonicalized for ``_s_thread_offset``; ``r_perm`` skips that so
+    split-laneid atom ``m`` iters stay 1:1 with ``s_seps`` in ``_split_thread_loop``.
     """
     r = r_sliced.canonicalize()
     s = s_sliced.canonicalize()

--- a/python/tvm/backend/cuda/operator/tile_primitive/copy/reg.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy/reg.py
@@ -122,7 +122,6 @@ def _r_side_layout_valid(
         return False, f"R layout is {type(layout).__name__}, not TileLayout"
 
     scope_rank = _SCOPE_RANK[sctx.scope_kind]
-    seen_thread_axes: set[str] = set()
     for it in layout.shard:
         ax = it.axis
         if not ax.is_thread():
@@ -138,16 +137,6 @@ def _r_side_layout_valid(
                 False,
                 f"R thread axis {ax.name!r} scope={ax_scope.name!r} > exec {sctx.scope_kind!r}",
             )
-        # TODO: lift these two; for now i = thread_value (stride=1, each axis appears once).
-        if int(it.stride) != 1:
-            return (
-                False,
-                f"R thread axis {ax.name!r} stride={int(it.stride)} != 1 (not supported yet)",
-            )
-        if ax.name in seen_thread_axes:
-            return False, f"R thread axis {ax.name!r} appears more than once (not supported yet)"
-        seen_thread_axes.add(ax.name)
-
     r_br = op_call.src if src.scope() == "local" else op_call.dst
     region = [(r.min, r.min + r.extent) for r in r_br.region]
     sliced = layout.slice(list(r_buf.shape), region)
@@ -203,30 +192,60 @@ def _compute_perm_r(r):
     return [i for i, _ in sorted(enumerate(r.shard), key=key)]
 
 
-def align_layouts_raw(r_layout, r_shape, r_region, s_layout, s_shape, s_region):
-    """Returns (r_p, s_p, s_seps)."""
-    r = r_layout.slice(list(r_shape), r_region).canonicalize()
-    s = s_layout.slice(list(s_shape), s_region).canonicalize()
+def align_layouts_raw(r_sliced, s_sliced, s_region):
+    """Returns (r_p, s_p, s_seps, r_perm).
+
+    ``r_sliced`` / ``s_sliced`` are the R/S layouts already sliced to the copy
+    region — sliced OUTSIDE the dispatch target (see ``_align_layouts``); this
+    function canonicalizes them INSIDE it so the scope-aware fusers still run.
+    Slicing under the target pre-fuses split thread axes (e.g. the tcgen05.ld
+    ``16x*b`` atom's ``laneid``, split across two iters) into a partially-fused
+    form that canonicalize then rejects with "conflicting scopes for thread".
+
+    Two views of the permuted R layout are returned:
+
+    - ``r_p`` — the *canonicalized* permuted layout. Its thread axes are fused
+      back to a single per-axis iter (``laneid`` + ``wid_in_wg`` → ``tid_in_wg``),
+      which ``_s_thread_offset`` needs so the per-thread S base offset is one
+      ``apply_to_shape`` over a clean thread iter.
+    - ``r_perm`` — the permuted layout *without* the final canonicalize. Its
+      memory (``m``) iters stay one-per-S-group, so ``_split_thread_loop`` can
+      pair each R ``m``-iter 1:1 with its ``s_seps`` S group. Canonicalizing
+      would fuse a multi-group ``m``-axis (e.g. the ``.16x*b`` atom register
+      axis, which decomposes into several non-contiguous (row, col) groups)
+      into one dense iter, after which the 1:1 pairing breaks and every S group
+      past the first is silently dropped (the m-row-doubling / column-parity
+      bug). For the already-contiguous cases (``.32x32b``, ``wg_local_layout``)
+      the ``m``-axis is a single group, so ``r_perm`` and ``r_p`` agree.
+    """
+    r = r_sliced.canonicalize()
+    s = s_sliced.canonicalize()
     s = _extract_tile(s, s_region)
     perm = _compute_perm_r(r)
     r_shape_for_group = [int(it.extent) for it in r.shard]
     s_grp, seps = s.group(r_shape_for_group)
     s_p = s_grp.permute_by_groups(list(seps), perm)
-    r_p = r.permute_dims(perm).canonicalize()
+    r_perm = r.permute_dims(perm)
+    r_p = r_perm.canonicalize()
     sizes = [seps[i + 1] - seps[i] for i in range(len(seps) - 1)]
     s_seps = [0]
     for p in perm:
         s_seps.append(s_seps[-1] + sizes[p])
-    return r_p, s_p, s_seps
+    return r_p, s_p, s_seps, r_perm
 
 
-def _split_thread_loop(r_p, s_p, s_seps):
+def _split_thread_loop(r_perm, s_p, s_seps):
     """Drop R's thread-axis positions and return per-R-position bundles:
     (r_iters, s_groups) — same length lists; s_groups[k] is the list of S
-    iters belonging to the k-th kept R position."""
+    iters belonging to the k-th kept R position.
+
+    ``r_perm`` is the permuted-but-uncanonicalized R layout: its iter list lines
+    up one-to-one with ``s_seps`` (which is built from the same ``perm``), so a
+    multi-group memory axis keeps each of its groups paired with the matching S
+    group instead of collapsing into one (see ``align_layouts_raw``)."""
     r_iters = []
     s_groups = []
-    for k, r_it in enumerate(r_p.shard):
+    for k, r_it in enumerate(r_perm.shard):
         if r_it.axis.is_thread():
             continue
         r_iters.append(r_it)
@@ -296,17 +315,12 @@ def _align_layouts(op_call: TilePrimitiveCall, sctx: DispatchContext):
     s_buf = s_br.buffer
     r_region = [(r.min, r.min + r.extent) for r in r_br.region]
     s_region = [(r.min, r.min + r.extent) for r in s_br.region]
-    # Push the dispatch target so layout.canonicalize() runs scope-aware
-    # fusers (e.g. laneid+wid_in_wg -> tid_in_wg).
+    # Slice under llvm; canonicalize under cuda in align_layouts_raw.
+    with tvm.target.Target("llvm"):
+        r_sliced = r_buf.layout.slice(list(r_buf.shape), r_region)
+        s_sliced = s_buf.layout.slice(list(s_buf.shape), s_region)
     with sctx.target:
-        return align_layouts_raw(
-            r_buf.layout,
-            r_buf.shape,
-            r_region,
-            s_buf.layout,
-            s_buf.shape,
-            s_region,
-        )
+        return align_layouts_raw(r_sliced, s_sliced, s_region)
 
 
 def _make_thread_placeholders(r_p) -> dict[str, _TirVar]:
@@ -490,8 +504,8 @@ def _emit_reg(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
         r_buf, s_buf, r_is_src = dst, src, False
 
     with sctx.target:
-        r_p, s_p, s_seps = _align_layouts(op_call, sctx)
-    r_iters, s_groups = _split_thread_loop(r_p, s_p, s_seps)
+        r_p, s_p, s_seps, r_perm = _align_layouts(op_call, sctx)
+    r_iters, s_groups = _split_thread_loop(r_perm, s_p, s_seps)
     atoms = _build_atoms(r_iters, s_groups)
     elem_bits = DataType(src.dtype).bits
     vec_len = _choose_vec_len(elem_bits, atoms, r_p, s_p)

--- a/python/tvm/backend/cuda/operator/tile_primitive/copy/reg.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy/reg.py
@@ -195,9 +195,7 @@ def _compute_perm_r(r):
 def align_layouts_raw(r_sliced, s_sliced, s_region):
     """Returns (r_p, s_p, s_seps, r_perm).
 
-    Slice outside the dispatch target (see ``_align_layouts``), canonicalize here.
-    ``r_p`` is canonicalized for ``_s_thread_offset``; ``r_perm`` skips that so
-    split-laneid atom ``m`` iters stay 1:1 with ``s_seps`` in ``_split_thread_loop``.
+    ``r_p`` for ``_s_thread_offset``; ``r_perm`` for ``_split_thread_loop`` pairing.
     """
     r = r_sliced.canonicalize()
     s = s_sliced.canonicalize()
@@ -296,11 +294,9 @@ def _align_layouts(op_call: TilePrimitiveCall, sctx: DispatchContext):
     s_buf = s_br.buffer
     r_region = [(r.min, r.min + r.extent) for r in r_br.region]
     s_region = [(r.min, r.min + r.extent) for r in s_br.region]
-    # Slice under llvm; canonicalize under cuda in align_layouts_raw.
-    with tvm.target.Target("llvm"):
+    with sctx.target:
         r_sliced = r_buf.layout.slice(list(r_buf.shape), r_region)
         s_sliced = s_buf.layout.slice(list(s_buf.shape), s_region)
-    with sctx.target:
         return align_layouts_raw(r_sliced, s_sliced, s_region)
 
 

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
@@ -476,13 +476,17 @@ def test_reg_copy_tcgen05_d_epilogue_deposit_layout_pairing():
         _split_thread_loop,
         align_layouts_raw,
     )
+    from tvm.tirx.exec_scope import ExecScope
+    from tvm.tirx.operator.tile_primitive import DispatchContext
 
     m, n, reg_layout, smem_layout = _tcgen05_d_epilogue_layouts()
     region = [(0, m), (0, n)]
-    with tvm.target.Target("llvm"):
+    sctx = DispatchContext(
+        tvm.target.Target("cuda"), ExecScope("warpgroup"), {}, {}, scope_kind="warpgroup"
+    )
+    with sctx.target:
         r_sliced = reg_layout.slice([m, n], region)
         s_sliced = smem_layout.slice([m, n], region)
-    with tvm.target.Target("cuda"):
         r_p, s_p, s_seps, r_perm = align_layouts_raw(r_sliced, s_sliced, region)
 
     r_iters, s_groups = _split_thread_loop(r_perm, s_p, s_seps)

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
@@ -411,5 +411,76 @@ def test_reg_copy_wg_local_to_swizzled_shared_uses_swizzle_fastpath():
     )
 
 
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_cuda_compute(9), reason="need cuda compute >= 9.0")
+def test_reg_copy_tcgen05_atom_rperm_pairs_all_s_groups():
+    """Split-laneid reg copy must iterate ``r_perm``, not canonicalized ``r_p``.
+
+    The ``.16x256b`` tcgen05 atom fuses its multi-group register ``m`` axis when
+    canonicalized; zipping ``s_seps`` against ``r_p`` then drops S groups and
+    permutes the deposit. This is a layout-only regression (no GPU copy run).
+    """
+    from tvm.backend.cuda.operator.tile_primitive.copy.reg import (
+        _split_thread_loop,
+        align_layouts_raw,
+    )
+    from tvm.tirx.cuda.operator.tile_primitive.tma_utils import mma_shared_layout
+    from tvm.tirx.layout import tcgen05_atom_layout
+
+    M, N = 64, 64
+    r_layout = tcgen05_atom_layout("16x256b", (M, N), "float32")
+    s_layout = mma_shared_layout("float32", 3, (M, N))
+    region = [(0, M), (0, N)]
+    with tvm.target.Target("llvm"):
+        r_sliced = r_layout.slice([M, N], region)
+        s_sliced = s_layout.slice([M, N], region)
+    with tvm.target.Target("cuda"):
+        r_p, s_p, s_seps, r_perm = align_layouts_raw(r_sliced, s_sliced, region)
+
+    r_iters, s_groups = _split_thread_loop(r_perm, s_p, s_seps)
+    r_iters_canon, _ = _split_thread_loop(r_p, s_p, s_seps)
+    mem_iters = [it for it in r_perm.shard if not it.axis.is_thread()]
+
+    assert len(r_iters) == len(mem_iters) == len(s_groups)
+    assert len(r_iters) > 1
+    assert len(r_iters_canon) < len(r_iters)
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_cuda_compute(9), reason="need cuda compute >= 9.0")
+def test_reg_copy_tcgen05_atom_to_swizzled_smem_compiles():
+    """Regression: ``tcgen05_atom_layout`` reg→128B-swizzled SMEM lowers via reg dispatch.
+
+    Models the tf32 D epilogue deposit (``Tx.wg.copy(smem, reg_view)``). Without
+    the split-laneid ``reg.py`` fix this either fails to lower or falls back to
+    scalar copy.
+    """
+    from tvm.tirx.cuda.operator.tile_primitive.tma_utils import mma_shared_layout
+    from tvm.tirx.layout import tcgen05_atom_layout
+
+    M, N = 64, 64
+    smem_layout = mma_shared_layout("float32", 3, (M, N))
+    reg_layout = tcgen05_atom_layout("16x256b", (M, N), "float32")
+
+    @T.prim_func
+    def deposit(reg_view: T.Buffer((M, N), "float32", scope="local", layout=reg_layout)) -> None:
+        smem = T.alloc_buffer((M, N), "float32", scope="shared", layout=smem_layout)
+        T.device_entry()
+        T.cta_id([1])
+        T.warpgroup_id([1])
+        T.warp_id_in_wg([4])
+        T.lane_id([32])
+        T.thread_id_in_wg([128])
+        Tx.wg.copy(smem[:, :], reg_view[:, :])
+
+    target = tvm.target.Target("cuda")
+    with target:
+        mod = tvm.compile(tvm.IRModule({"main": deposit}), target=target, tir_pipeline="tirx")
+        src = mod.mod.imports[0].inspect_source()
+
+    assert "tvm_builtin_ptx_st" in src
+    assert "copy/fallback" not in src
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
@@ -525,5 +525,90 @@ def test_reg_copy_tcgen05_d_epilogue_deposit_codegen():
     )
 
 
+def _tcgen05_16x256b_row_col(tid_wg: T.int32, lane: T.int32, reg_idx: T.int32):
+    """Map ``(tid_in_wg, reg)`` → logical ``(row, col)`` for ``.16x256b`` fp32 atom."""
+    t0 = lane & T.int32(3)
+    t1 = lane >> 2
+    v0p = reg_idx & T.int32(1)
+    va = (reg_idx >> 1) & T.int32(1)
+    vb = reg_idx >> 2
+    wid = tid_wg >> 5
+    row = t1 + T.int32(8) * va + T.int32(16) * wid
+    col = v0p + T.int32(2) * t0 + T.int32(8) * vb
+    return row, col
+
+
+def _build_tcgen05_d_epilogue_deposit_roundtrip():
+    """Fill ``d_reg``, R→S deposit, S→R reload, dump via ``.local()`` to gmem."""
+    from tvm.tirx.cuda.operator.tile_primitive.tma_utils import mma_shared_layout
+    from tvm.tirx.layout import tcgen05_atom_layout
+
+    m, n = _TCGEN05_D_SHAPE
+    regs_per_thread = 32  # ``.16x256b.x8`` fp32: 4 regs/slot x rep=8
+    smem_layout = mma_shared_layout(_TCGEN05_D_DTYPE, _TCGEN05_D_SWIZZLE, (m, n))
+    reg_layout = tcgen05_atom_layout(_TCGEN05_D_ATOM, (m, n), _TCGEN05_D_DTYPE)
+    sl_m, sl_n = _TCGEN05_D_SLICE
+
+    @T.prim_func
+    def kernel(A_ptr: T.handle, B_ptr: T.handle) -> None:
+        A = T.match_buffer(A_ptr, (m, n), _TCGEN05_D_DTYPE)
+        B = T.match_buffer(B_ptr, (m, n), _TCGEN05_D_DTYPE)
+        T.device_entry()
+        T.cta_id([1])
+        T.warpgroup_id([1])
+        T.warp_id_in_wg([4])
+        T.lane_id([32])
+        tid_wg = T.thread_id_in_wg([128])
+        lane = T.lane_id([32])
+        d_reg = T.alloc_buffer((m, n), _TCGEN05_D_DTYPE, scope="local", layout=reg_layout)
+        d_reg_out = T.alloc_buffer((m, n), _TCGEN05_D_DTYPE, scope="local", layout=reg_layout)
+        smem_cd_mma = T.alloc_buffer((m, n), _TCGEN05_D_DTYPE, scope="shared", layout=smem_layout)
+        reg_in = d_reg.local(regs_per_thread)
+        reg_out = d_reg_out.local(regs_per_thread)
+        for r in T.serial(regs_per_thread):
+            row, col = _tcgen05_16x256b_row_col(tid_wg, lane, T.cast(r, "int32"))
+            reg_in[r] = A[row, col]
+        Tx.wg.copy(smem_cd_mma[sl_m, sl_n], d_reg[sl_m, sl_n])
+        T.cuda.cta_sync()
+        Tx.wg.copy(d_reg_out[sl_m, sl_n], smem_cd_mma[sl_m, sl_n])
+        for r in T.serial(regs_per_thread):
+            row, col = _tcgen05_16x256b_row_col(tid_wg, lane, T.cast(r, "int32"))
+            B[row, col] = reg_out[r]
+
+    return kernel
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_cuda_compute(9), reason="need cuda compute >= 9.0")
+def test_reg_copy_tcgen05_d_epilogue_deposit_gpu():
+    """GPU: R→S deposit + S→R reload must preserve the Layout-F register tile.
+
+    Host fills gmem ``A[row,col]=row*100+col``; each thread scatters into ``d_reg``
+    via the ``.16x256b`` (tid,reg)→(row,col) map, runs production
+    ``Tx.wg.copy(smem_cd_mma, d_reg)`` then the inverse
+    ``Tx.wg.copy(d_reg_out, smem_cd_mma)``, and dumps ``d_reg_out`` back to gmem
+    ``B`` through ``.local()``. Pre-fix pairing dropped 2/3 of the S groups —
+    ``max|B-A|`` was hundreds, not 0.
+    """
+    m, n = _TCGEN05_D_SHAPE
+    target = tvm.target.Target("cuda")
+    with target:
+        mod = tvm.compile(
+            tvm.IRModule({"main": _build_tcgen05_d_epilogue_deposit_roundtrip()}),
+            target=target,
+            tir_pipeline="tirx",
+        )
+
+    dev = tvm.cuda(0)
+    rows = np.arange(m, dtype=np.int32)[:, None]
+    cols = np.arange(n, dtype=np.int32)[None, :]
+    a_np = (rows * 100 + cols).astype(np.float32)
+    b_np = np.zeros((m, n), dtype=np.float32)
+    a = tvm.runtime.tensor(a_np, dev)
+    b = tvm.runtime.tensor(b_np, dev)
+    mod(a, b)
+    np.testing.assert_allclose(b.numpy(), a_np, rtol=0, atol=0)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
@@ -411,75 +411,118 @@ def test_reg_copy_wg_local_to_swizzled_shared_uses_swizzle_fastpath():
     )
 
 
-@pytest.mark.gpu
-@pytest.mark.skipif(not env.has_cuda_compute(9), reason="need cuda compute >= 9.0")
-def test_reg_copy_tcgen05_atom_rperm_pairs_all_s_groups():
-    """Split-laneid reg copy must iterate ``r_perm``, not canonicalized ``r_p``.
+# --- tcgen05 D epilogue deposit (tf32_hc_prenorm_gemm) -----------------------
+# Production op: ``Tx.warpgroup.copy(smem_cd_mma, d_reg)`` after ``tcgen05.ld``
+# pulls the M=64 accumulator fragment from TMEM into ``d_reg``, then deposits it
+# into 128B-swizzled MMA SMEM for the subsequent TMA store to gmem D.
+_TCGEN05_D_ATOM = "16x256b"
+_TCGEN05_D_SHAPE = (64, 64)
+_TCGEN05_D_DTYPE = "float32"
+_TCGEN05_D_SWIZZLE = 3  # SwizzleMode 128B → mma_shared_layout(..., 3, shape)
+_TCGEN05_D_SLICE = (slice(0, 64), slice(0, 64))
 
-    The ``.16x256b`` tcgen05 atom fuses its multi-group register ``m`` axis when
-    canonicalized; zipping ``s_seps`` against ``r_p`` then drops S groups and
-    permutes the deposit. This is a layout-only regression (no GPU copy run).
-    """
-    from tvm.backend.cuda.operator.tile_primitive.copy.reg import (
-        _split_thread_loop,
-        align_layouts_raw,
-    )
+
+def _tcgen05_d_epilogue_layouts():
     from tvm.tirx.cuda.operator.tile_primitive.tma_utils import mma_shared_layout
     from tvm.tirx.layout import tcgen05_atom_layout
 
-    M, N = 64, 64
-    r_layout = tcgen05_atom_layout("16x256b", (M, N), "float32")
-    s_layout = mma_shared_layout("float32", 3, (M, N))
-    region = [(0, M), (0, N)]
-    with tvm.target.Target("llvm"):
-        r_sliced = r_layout.slice([M, N], region)
-        s_sliced = s_layout.slice([M, N], region)
-    with tvm.target.Target("cuda"):
-        r_p, s_p, s_seps, r_perm = align_layouts_raw(r_sliced, s_sliced, region)
-
-    r_iters, s_groups = _split_thread_loop(r_perm, s_p, s_seps)
-    r_iters_canon, _ = _split_thread_loop(r_p, s_p, s_seps)
-    mem_iters = [it for it in r_perm.shard if not it.axis.is_thread()]
-
-    assert len(r_iters) == len(mem_iters) == len(s_groups)
-    assert len(r_iters) > 1
-    assert len(r_iters_canon) < len(r_iters)
+    m, n = _TCGEN05_D_SHAPE
+    reg_layout = tcgen05_atom_layout(_TCGEN05_D_ATOM, (m, n), _TCGEN05_D_DTYPE)
+    smem_layout = mma_shared_layout(_TCGEN05_D_DTYPE, _TCGEN05_D_SWIZZLE, (m, n))
+    return m, n, reg_layout, smem_layout
 
 
-@pytest.mark.gpu
-@pytest.mark.skipif(not env.has_cuda_compute(9), reason="need cuda compute >= 9.0")
-def test_reg_copy_tcgen05_atom_to_swizzled_smem_compiles():
-    """Regression: ``tcgen05_atom_layout`` reg→128B-swizzled SMEM lowers via reg dispatch.
-
-    Models the tf32 D epilogue deposit (``Tx.wg.copy(smem, reg_view)``). Without
-    the split-laneid ``reg.py`` fix this either fails to lower or falls back to
-    scalar copy.
-    """
+def _build_tcgen05_d_epilogue_deposit():
+    """``Tx.wg.copy(smem[slice], d_reg[slice])``: R (tcgen05 atom) → S (128B swizzle)."""
     from tvm.tirx.cuda.operator.tile_primitive.tma_utils import mma_shared_layout
     from tvm.tirx.layout import tcgen05_atom_layout
 
-    M, N = 64, 64
-    smem_layout = mma_shared_layout("float32", 3, (M, N))
-    reg_layout = tcgen05_atom_layout("16x256b", (M, N), "float32")
+    m, n = _TCGEN05_D_SHAPE
+    smem_layout = mma_shared_layout(_TCGEN05_D_DTYPE, _TCGEN05_D_SWIZZLE, (m, n))
+    reg_layout = tcgen05_atom_layout(_TCGEN05_D_ATOM, (m, n), _TCGEN05_D_DTYPE)
+    sl_m, sl_n = _TCGEN05_D_SLICE
 
     @T.prim_func
-    def deposit(reg_view: T.Buffer((M, N), "float32", scope="local", layout=reg_layout)) -> None:
-        smem = T.alloc_buffer((M, N), "float32", scope="shared", layout=smem_layout)
+    def deposit(
+        d_reg: T.Buffer((m, n), _TCGEN05_D_DTYPE, scope="local", layout=reg_layout),
+    ) -> None:
+        smem_cd_mma = T.alloc_buffer((m, n), _TCGEN05_D_DTYPE, scope="shared", layout=smem_layout)
         T.device_entry()
         T.cta_id([1])
         T.warpgroup_id([1])
         T.warp_id_in_wg([4])
         T.lane_id([32])
         T.thread_id_in_wg([128])
-        Tx.wg.copy(smem[:, :], reg_view[:, :])
+        Tx.wg.copy(smem_cd_mma[sl_m, sl_n], d_reg[sl_m, sl_n])
 
+    return deposit
+
+
+def _compile_tcgen05_d_epilogue_deposit():
     target = tvm.target.Target("cuda")
     with target:
-        mod = tvm.compile(tvm.IRModule({"main": deposit}), target=target, tir_pipeline="tirx")
-        src = mod.mod.imports[0].inspect_source()
+        mod = tvm.IRModule({"main": _build_tcgen05_d_epilogue_deposit()})
+        return tvm.compile(mod, target=target, tir_pipeline="tirx")
 
+
+def test_reg_copy_tcgen05_d_epilogue_deposit_layout_pairing():
+    """Pre-fix bug: canonical ``r_p`` collapses atom ``m`` groups and drops S pairings.
+
+    Copy: ``Tx.wg.copy(smem_cd_mma[0:64,0:64], d_reg[0:64,0:64])`` (R→S).
+    ``d_reg``: ``(64,64)`` fp32 ``tcgen05_atom_layout("16x256b", ...)``.
+    ``smem_cd_mma``: ``(64,64)`` fp32 ``mma_shared_layout(..., swizzle=128B)``.
+    """
+    from tvm.backend.cuda.operator.tile_primitive.copy.reg import (
+        _split_thread_loop,
+        align_layouts_raw,
+    )
+
+    m, n, reg_layout, smem_layout = _tcgen05_d_epilogue_layouts()
+    region = [(0, m), (0, n)]
+    with tvm.target.Target("llvm"):
+        r_sliced = reg_layout.slice([m, n], region)
+        s_sliced = smem_layout.slice([m, n], region)
+    with tvm.target.Target("cuda"):
+        r_p, s_p, s_seps, r_perm = align_layouts_raw(r_sliced, s_sliced, region)
+
+    r_iters, s_groups = _split_thread_loop(r_perm, s_p, s_seps)
+    r_iters_bug, s_groups_bug = _split_thread_loop(r_p, s_p, s_seps)
+    mem_extents = [int(it.extent) for it in r_iters]
+    bug_extents = [int(it.extent) for it in r_iters_bug]
+
+    # Fixed path: 3 register m-groups stay 1:1 with 3 S-side groups.
+    assert mem_extents == [8, 2, 2]
+    assert len(r_iters) == len(s_groups) == 3
+    # Pre-fix path (what _split_thread_loop used to take): 1 fused m-iter, only
+    # the first S group is paired — the other two are silently dropped.
+    assert bug_extents == [32]
+    assert len(r_iters_bug) == len(s_groups_bug) == 1
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_cuda_compute(9), reason="need cuda compute >= 9.0")
+def test_reg_copy_tcgen05_d_epilogue_deposit_codegen():
+    """``reg`` dispatch lowers the D epilogue deposit; pre-fix loop only covered half.
+
+    Without the ``r_perm`` fix the emitted outer loop ran ``f < 8`` (one fused
+    register group) instead of ``f < 16`` (three atom m-groups x vec tail), and
+    the swizzled SMEM stores landed in the wrong (row, col) slots.
+    """
+    import re
+
+    ex = _compile_tcgen05_d_epilogue_deposit()
+    src = ex.mod.imports[0].inspect_source()
+
+    assert "copy/fallback" not in src, "reg dispatch must not fall back to scalar copy"
+    assert "tvm_builtin_copy_" not in src, "reg dispatch should emit PTX ld/st only"
     assert "tvm_builtin_ptx_st" in src
-    assert "copy/fallback" not in src
+    assert "st.shared.v2.u32" in src, "fp32 vec=2 → 8B shared store per outer iter"
+
+    loop = re.search(r"for \(int f = 0; f < (\d+)", src)
+    assert loop is not None, "expected reg copy outer loop in generated CUDA"
+    assert loop.group(1) == "16", (
+        f"fixed pairing emits 16 outer stores (pre-fix bug collapsed to 8); got f < {loop.group(1)}"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix register copy layout pairing for tcgen05 atom layouts where lane-id splits collapse multiple memory iterators into one canonical thread axis.
- Return `r_perm` from `align_layouts_raw` and use it in `_split_thread_loop` so R2S/S2R copies pair correctly with swizzled SMEM.
- Add unit tests for layout pairing and GPU compile path (`st.shared.v4`, no fallback).

## Test plan
- [x] `pytest tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py::test_reg_copy_tcgen05_atom_rperm_pairs_all_s_groups`
- [x] `pytest tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py::test_reg_copy_tcgen05_atom_to_swizzled_smem_compiles`