### PR TITLE
feat(op): CUDA elementwise dispatch for maximum tile op

### DIFF
--- a/python/tvm/backend/cuda/operator/tile_primitive/elementwise/ops/binary.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/elementwise/ops/binary.py
@@ -15,14 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Binary elementwise ops: add / sub / mul / fdiv.
+"""Binary elementwise ops: add / sub / mul / fdiv / maximum.
 
 Includes constant-lhs commute logic. Broadcasting (extent=1 dims) is
 handled at the layout level in dispatch's ``_broadcast_lift``, not here —
 parser just records each src as-is.
 
 ``add``/``sub``/``mul`` attach a ``VecImpl`` for sm_100+ packed f32x2;
-``fdiv`` has no packed PTX (uses scalar fallback only).
+``fdiv``/``maximum`` have no packed PTX (scalar fallback only — ``max`` lowers
+to a single ``FMNMX``/``max.f32``, which is exact, so there is no rounding/ftz
+variant to pack).
 """
 
 from __future__ import annotations
@@ -31,12 +33,13 @@ import functools
 import operator
 from typing import Any
 
+from tvm.script import tirx as Tx
 from tvm.tirx import BufferRegion, TilePrimitiveCall
 
 from ..vec_emit.binary_f32x2 import BINARY_F32X2_IMPLS
 from . import OpSpec, Plan, SrcSpec
 
-_COMMUTATIVE = frozenset({"add", "mul"})
+_COMMUTATIVE = frozenset({"add", "mul", "maximum"})
 
 
 def _parse_binary_for(op_name: str):
@@ -100,6 +103,10 @@ def _compute_fdiv(src_vals, extras, dt):
     return src_vals[0] / src_vals[1]
 
 
+def _compute_maximum(src_vals, extras, dt):
+    return Tx.max(src_vals[0], src_vals[1])
+
+
 BINARY_OPS: dict[str, OpSpec] = {
     "add": OpSpec(
         "add",
@@ -123,5 +130,10 @@ BINARY_OPS: dict[str, OpSpec] = {
         "fdiv",
         _parse_binary_for("fdiv"),
         _compute_fdiv,
+    ),
+    "maximum": OpSpec(
+        "maximum",
+        _parse_binary_for("maximum"),
+        _compute_maximum,
     ),
 }

--- a/tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_binary.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_binary.py
@@ -781,6 +781,41 @@ def test_binary_add_f32_sm100_packed_f32x2_dispatch():
     ), f"expected packed add_f32x2; got:\n{src[:2000]}"
 
 
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+def test_binary_maximum_reg():
+    N = 128
+
+    @T.prim_func
+    def relu_max(a_ptr: T.handle, b_ptr: T.handle, c_ptr: T.handle) -> None:
+        A = T.match_buffer(a_ptr, (N,), "float32")
+        B = T.match_buffer(b_ptr, (N,), "float32")
+        C = T.match_buffer(c_ptr, (N,), "float32")
+        T.device_entry()
+        T.warp_id([4])
+        T.cta_id([1])
+        T.warpgroup_id([1])
+        tid = T.thread_id_in_wg([N])
+        a_reg = T.alloc_local((1,), "float32")
+        b_reg = T.alloc_local((1,), "float32")
+        Tx.copy(a_reg[:], A[tid : tid + 1])
+        Tx.copy(b_reg[:], B[tid : tid + 1])
+        Tx.maximum(a_reg[:], a_reg[:], b_reg[:])
+        Tx.copy(C[tid : tid + 1], a_reg[:])
+
+    dev = tvm.cuda(0)
+    target = tvm.target.Target("cuda")
+    with target:
+        mod = tvm.compile(tvm.IRModule({"main": relu_max}), target=target, tir_pipeline="tirx")
+    np.random.seed(0)
+    a = np.random.randn(N).astype("float32")
+    b = np.random.randn(N).astype("float32")
+    c = np.zeros(N, dtype="float32")
+    a_t, b_t, c_t = (tvm.runtime.tensor(x, dev) for x in (a, b, c))
+    mod["main"](a_t, b_t, c_t)
+    np.testing.assert_allclose(c_t.numpy(), np.maximum(a, b), atol=0, rtol=0)
+
+
 def test_binary_add_f16_scalar_fallback_dispatch():
     """add f16 has no packed VecImpl → reg.py scalar fallback (T.vectorized)."""
     shape = (64, 32)


### PR DESCRIPTION
## Summary
- Register `maximum` in `elementwise/ops/binary.py`: commutative parse path, `_compute_maximum` → `Tx.max`, scalar-only (no f32x2 `VecImpl` — FMNMX is exact).
- Add `test_binary_maximum_reg`: per-thread register `Tx.maximum` roundtrip vs `np.maximum`.

Split from #1; no dependency on gemm_async / reg-copy / slice workarounds. C++ `tirx.maximum` tile op is already on main.

## Test plan
- [x] `pytest tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_binary.py::test_binary_maximum_reg`
- [x] `pre-commit run --files` on touched paths