### PR TITLE
perf(op-dispatch): per-MMA SMEM descriptor with hoist/recompute in gemm_async

### DIFF
--- a/python/tvm/backend/cuda/operator/tile_primitive/gemm_async/tcgen05.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/gemm_async/tcgen05.py
@@ -551,8 +551,15 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
                 tiler_shape = [s // a for s, a in zip(shape_2d, atom_shape)]
                 tiler_grouped, seps = tiler.canonicalize().group(tiler_shape)
                 elem_per_128b = 128 // tvm.DataType(dtype).bits
-                ldo = (tiler_grouped.shard[-1].stride * atom_size) // elem_per_128b
-                sdo = (tiler_grouped.shard[-2].stride * atom_size) // elem_per_128b
+
+                # extent==1 leading dim -> unused LBO/SBO offset.
+                def _atom_off(dim):
+                    if int(dim.extent) == 1:
+                        return 0
+                    return (dim.stride * atom_size) // elem_per_128b
+
+                ldo = _atom_off(tiler_grouped.shard[-1])
+                sdo = _atom_off(tiler_grouped.shard[-2])
                 return mode, ldo, sdo
 
             for mode in (
@@ -803,15 +810,12 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
     if not a_is_tmem:
         A_elem_per_16B = 128 // DataType(A_type).bits
 
-    # Allocate descriptor cells and encode once, right after A/B buffer defs.
-    # The callback is inserted as a flat SeqStmt after the target buffer def.
-    # Descriptors with identical construction parameters are cached and reused
-    # across dispatch calls via sctx.shared_state.
-    B_base = [0] * len(B_buffer.shape)
-    krp = Evaluate(tirx_op.tvm_kernel_replace_point())
+    elect_pred = T.ptx.elect_sync() if warp_scope else True
+
+    _SWIZZLE_TO_LAYOUT = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}
+    _krp = Evaluate(tirx_op.tvm_kernel_replace_point())
 
     def _make_lo_uniform(desc):
-        """Shuffle the lower 32 bits of the descriptor to ensure warp-uniformity."""
         func_name = "smem_desc_make_lo_uniform_"
         source_code = f"""
         __forceinline__ __device__ void {func_name}(uint64_t* desc) {{
@@ -823,56 +827,74 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
             func_name, T.address_of(desc), source_code=source_code, return_type="void"
         )
 
-    def _make_desc_wrap(desc_buf, smem_buf, base, ldo, sdo, swizzle_val):
-        """Build: { AllocBuffer(desc); encode(desc, smem); krp }"""
+    def _make_desc(smem_buf, ldo, sdo, swizzle_val, name):
+        desc_buf = tvm.tirx.decl_buffer((1,), "uint64", name=name, scope="local")
         encode_call = tvm.tirx.call_intrin(
             "",
             "tirx.ptx.tcgen05_encode_matrix_descriptor",
             tvm.tirx.address_of(desc_buf[0]),
-            smem_buf.ptr_to(base),
+            smem_buf.ptr_to([0] * len(smem_buf.shape)),
             ldo,
             sdo,
             swizzle_val,
         )
-        return SeqStmt(
+        wrap = SeqStmt(
             [
                 AllocBuffer(desc_buf),
                 Evaluate(encode_call),
                 Evaluate(_make_lo_uniform(desc_buf[0])),
-                krp,
+                _krp,
             ]
         )
-
-    # Per-dispatch-call descriptor (no kernel-scope cache). Each gemm_async
-    # call allocates + encodes its own ``alignas(64) uint64_t descX[1]``
-    # right after the smem buffer definition. Without the previous cache the
-    # descriptor's lifetime is bounded by the surrounding loop scope rather
-    # than the entire kernel, which lets ptxas free the register sooner and
-    # reduces register pressure on the fa4 hot path. The descriptor base is
-    # the buffer origin (stage=0); the per-MMA operand still adds the
-    # stage-dependent offset via ``smem_desc_add_16B_offset``.
-    def _make_desc(smem_buf, base, ldo, sdo, swizzle_val, name):
-        desc_buf = tvm.tirx.decl_buffer((1,), "uint64", name=name, scope="local")
-        wrap = _make_desc_wrap(desc_buf, smem_buf, base, ldo, sdo, swizzle_val)
         sctx.add_post_buffer_def_stmt(smem_buf, wrap)
         return desc_buf
 
-    B_base = [0] * len(B_buffer.shape)
-    descB_buf = _make_desc(B_buffer, B_base, B_ldo, B_sdo, B_swizzle_mode.value, "descB")
-    if not a_is_tmem:
-        A_base = [0] * len(A_buffer.shape)
-        descA_buf = _make_desc(A_buffer, A_base, A_ldo, A_sdo, A_swizzle_mode.value, "descA")
-    elect_pred = T.ptx.elect_sync() if warp_scope else True
+    def _uniform_desc(smem_buf, off16, ldo, sdo, swizzle):
+        layout = _SWIZZLE_TO_LAYOUT[int(swizzle)]
+        const_hi = (int(sdo) & 0x3FFF) | (1 << 14) | (layout << 29)
+        lo_const = (int(ldo) & 0x3FFF) << 16
+        base_ptr = smem_buf.ptr_to([0] * len(smem_buf.shape))
+        addr = T.ptr_byte_offset(base_ptr, off16 * 16, smem_buf.dtype)
+        sa = T.bitwise_and(
+            T.shift_right(T.cuda.cvta_generic_to_shared(addr), T.uint32(4)),
+            T.uint32(0x3FFF),
+        )
+        lo = T.bitwise_or(T.uint32(lo_const), sa) if lo_const else sa
+        return T.bitwise_or(T.shift_left(T.uint64(const_hi), T.uint64(32)), T.cast(lo, "uint64"))
 
-    # Helper: compute B descriptor value for a given (ni, ki) tile
-    def _b_desc_val(descB_in, ni, ki):
+    def _b_offset(ni, ki):
         B_linear = (
             ki * MMA_K * B_extent[-1] + ni * N_mma_per_cta
             if transB
             else ni * N_mma_per_cta * B_extent[-1] + ki * MMA_K
         )
-        B_offset = tvm.tirx.floordiv(B_slice_tile.apply(B_linear)["m"], B_elem_per_16B)
-        return smem_desc_add_16B_offset(descB_in, B_offset)
+        return tvm.tirx.floordiv(B_slice_tile.apply(B_linear)["m"], B_elem_per_16B)
+
+    def _a_offset(mi, ki):
+        A_linear = (
+            ki * MMA_K * A_extent[-1] + mi * M_mma
+            if transA
+            else mi * M_mma * A_extent[-1] + ki * MMA_K
+        )
+        return tvm.tirx.floordiv(A_slice_tile.apply(A_linear)["m"], A_elem_per_16B)
+
+    # smem_desc: "hoist" (default) or "recompute" per-MMA descriptor update.
+    use_add = op_call.config.get("smem_desc", "hoist") != "recompute"
+    descB_buf = (
+        _make_desc(B_buffer, B_ldo, B_sdo, B_swizzle_mode.value, "descB") if use_add else None
+    )
+    A_use_add = use_add and not a_is_tmem
+    descA_buf = (
+        _make_desc(A_buffer, A_ldo, A_sdo, A_swizzle_mode.value, "descA") if A_use_add else None
+    )
+    B_use_add = use_add
+
+    # Helper: compute B descriptor value for a given (ni, ki) tile
+    def _b_desc_val(descB_in, ni, ki):
+        B_offset = _b_offset(ni, ki)
+        if B_use_add:
+            return smem_desc_add_16B_offset(descB_buf[0], B_offset)
+        return _uniform_desc(B_buffer, B_offset, B_ldo, B_sdo, B_swizzle_mode.value)
 
     # Helper: compute A operand (TMEM address or SMEM descriptor) for a given (mi, ki) tile
     def _a_operand(mi, ki, descA_in=None):
@@ -881,14 +903,10 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
             a_row = mi * M_mma
             a_col = A_tmem_offset_32b + ki * (MMA_K // A_elem_per_32b)
             return T.cuda.get_tmem_addr(A_tmem_addr, a_row, a_col)
-        else:
-            A_linear = (
-                ki * MMA_K * A_extent[-1] + mi * M_mma
-                if transA
-                else mi * M_mma * A_extent[-1] + ki * MMA_K
-            )
-            A_offset = tvm.tirx.floordiv(A_slice_tile.apply(A_linear)["m"], A_elem_per_16B)
-            return smem_desc_add_16B_offset(descA_in, A_offset)
+        A_offset = _a_offset(mi, ki)
+        if A_use_add:
+            return smem_desc_add_16B_offset(descA_buf[0], A_offset)
+        return _uniform_desc(A_buffer, A_offset, A_ldo, A_sdo, A_swizzle_mode.value)
 
     if is_block_scaled:
         # Compute per-ki SF element steps from region extents
@@ -909,10 +927,11 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
             sfb_base + tvm.tirx.floordiv(sfb_tcol_0, SFB_elem_per_col)
         )
 
-        # Determine if sf_id rotation is needed:
-        # sf_mma_k < epc means multiple ki's pack in one column, AND we need per-ki
-        # distinct SF (i.e. sfa_elems_per_ki > 0 so each ki advances to a new element)
-        needs_sf_id = sfa_sf_mma_k < SFA_elem_per_col and sfa_elems_per_ki > 0 and descI is None
+        # Rotate sf_id per ki when multiple ki share one SF column.
+        needs_sf_id = sfa_sf_mma_k < SFA_elem_per_col and sfa_elems_per_ki > 0
+
+    else:
+        needs_sf_id = False
 
     # Physical TMEM columns per MMA N tile.
     # 2x2 layout (Layout B): each MMA tile spans N_mma/2 physical columns
@@ -927,19 +946,27 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
             for mi in T.unroll(M_tiles):
               for ni in T.unroll(N_tiles):
                 for ki in T.unroll(K_iters):
-                    a_val = _a_operand(mi, ki, descA_in)
-                    descB_val = _b_desc_val(descB_in, ni, ki)
-                    should_accum = tvm.tirx.any(ki != 0, accum_expr)
+                    # meta_var inlines operands into mma.block_scale (avoids LMEM temps).
+                    a_val = T.meta_var(_a_operand(mi, ki, descA_in))
+                    descB_val = T.meta_var(_b_desc_val(descB_in, ni, ki))
+                    should_accum = T.meta_var(tvm.tirx.any(ki != 0, accum_expr))
                     sfa_linear = mi * M_mma * SFA_K_total + ki * sfa_elems_per_ki
                     sfb_linear = ni * N_mma_per_cta * SFB_K_total + ki * sfb_elems_per_ki
-                    sfa_tcol = SFA_slice_layout.apply(sfa_linear).get("TCol", 0)
-                    sfb_tcol = SFB_slice_layout.apply(sfb_linear).get("TCol", 0)
-                    sfa_addr = sfa_base + tvm.tirx.floordiv(sfa_tcol, SFA_elem_per_col)
-                    sfb_addr = sfb_base + tvm.tirx.floordiv(sfb_tcol, SFB_elem_per_col)
+                    # Fold tcol to constants shared by SF addr and sf_id.
+                    sfa_tcol = T.meta_var(analyzer.simplify(SFA_slice_layout.apply(sfa_linear).get("TCol", 0)))  # noqa: E501
+                    sfb_tcol = T.meta_var(analyzer.simplify(SFB_slice_layout.apply(sfb_linear).get("TCol", 0)))  # noqa: E501
+                    sfa_addr = T.meta_var(
+                        analyzer.simplify(sfa_base + tvm.tirx.floordiv(sfa_tcol, SFA_elem_per_col))
+                    )
+                    sfb_addr = T.meta_var(
+                        analyzer.simplify(sfb_base + tvm.tirx.floordiv(sfb_tcol, SFB_elem_per_col))
+                    )
                     if needs_sf_id:
                         sf_id = T.meta_var(analyzer.simplify(tvm.tirx.floormod(sfa_tcol, SFA_elem_per_col)))  # noqa: E501
                         T.cuda.runtime_instr_desc(T.address_of(descI_in), sf_id)
-                    tmem_col = tmem_offset_32b + ni * (N_mma_phys_cols // C_elem_per_32b)
+                    tmem_col = T.meta_var(
+                        tmem_offset_32b + ni * (N_mma_phys_cols // C_elem_per_32b)
+                    )
                     if elect_pred:
                         T.ptx.tcgen05.mma.block_scale(
                             T.cuda.get_tmem_addr(tmem_addr, mi * M_mma, tmem_col),
@@ -980,12 +1007,19 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
                             enable_input_d=should_accum,
                         )
 
-    descA_val = None if a_is_tmem else descA_buf[0]
+    descA_val = None  # descriptors built per-MMA from SMEM addr via _uniform_desc
 
-    if descI is not None:
+    if descI is not None and not needs_sf_id:
         @T.prim_func(check_well_formed=False)
         def impl():
-            main_impl(descA_val, descB_buf[0], descI)
+            main_impl(descA_val, None, descI)
+    elif descI is not None:
+        # Local copy: main_impl rotates descI in-place per ki.
+        @T.prim_func(check_well_formed=False)
+        def impl():
+            descI_local: T.uint32
+            descI_local = descI
+            main_impl(descA_val, None, descI_local)
     elif is_block_scaled:
         @T.prim_func(check_well_formed=False)
         def impl():
@@ -993,7 +1027,7 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
             T.ptx.tcgen05.encode_instr_descriptor_block_scaled(T.address_of(descI_local), d_dtype=C_type, a_dtype=A_type, b_dtype=B_type, sfa_dtype=SFA_type, sfb_dtype=SFB_type,  # noqa: E501, F821
                                                                sfa_tmem_addr=SFA_init_addr, sfb_tmem_addr=SFB_init_addr,  # noqa: E501
                                                                M=M_mma * cta_group, N=N_mma, K=MMA_K, trans_a=a_mn_major, trans_b=b_mn_major, n_cta_groups=cta_group)  # noqa: E501
-            main_impl(descA_val, descB_buf[0], descI_local)  # noqa: F821
+            main_impl(descA_val, None, descI_local)  # noqa: F821
     else:
         # Pre-compute the dense instruction descriptor at dispatcher time so
         # the MMA's 4th operand is a literal ``uint32`` instead of a per-call
@@ -1013,7 +1047,7 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
 
         @T.prim_func(check_well_formed=False)
         def impl():
-            main_impl(descA_val, descB_buf[0], descI_const)
+            main_impl(descA_val, None, descI_const)
     # fmt: on
 
     return impl

--- a/tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py
@@ -2183,5 +2183,109 @@ def test_gemm_tf32_with_tfloat32_tma():
     )
 
 
+def _build_smem_desc_kernel(smem_desc):
+    """Minimal cta_group=1 fp16 gemm_async kernel parametrized on ``smem_desc``."""
+    C_shape, C_dtype, C_region = (128, 512), "float32", [(0, 128), (256, 384)]
+    A_shape, A_dtype, A_sw = (3, 128, 64), "float16", 3
+    B_shape, B_dtype, B_sw = (3, 128, 64), "float16", 3
+    width = C_region[1][1] - C_region[1][0]
+    A_layout = mma_shared_layout(A_dtype, A_sw, A_shape)
+    B_layout = mma_shared_layout(B_dtype, B_sw, B_shape)
+    r_gmem_A = [slice(0, A_shape[i]) for i in range(len(A_shape))]
+    r_gmem_B = [slice(0, B_shape[i]) for i in range(len(B_shape))]
+    total_bytes = (
+        functools.reduce(operator.mul, A_shape, 1) * 2
+        + functools.reduce(operator.mul, B_shape, 1) * 2
+    )
+    r_tmem_C = [slice(C_region[i][0], C_region[i][1]) for i in range(len(C_shape))]
+    r_smem_A = [slice(1, 2), slice(0, 128), slice(0, 64)]
+    r_smem_B = [slice(2, 3), slice(0, 128), slice(0, 64)]
+
+    # fmt: off
+    @T.prim_func
+    def gemm_async(A_ptr: T.handle, B_ptr: T.handle, C_ptr: T.handle) -> None:
+        A = T.match_buffer(A_ptr, A_shape, A_dtype)
+        B = T.match_buffer(B_ptr, B_shape, B_dtype)
+        C = T.match_buffer(C_ptr, C_shape, C_dtype)
+        T.device_entry()
+        warp_id = T.warp_id([4])
+        cta_id = T.cta_id([1])
+        wg_id = T.warpgroup_id([1])
+        tid_in_wg = T.thread_id_in_wg([128])
+        A_smem = T.alloc_buffer(A_shape, A_dtype, scope="shared", layout=A_layout)
+        B_smem = T.alloc_buffer(B_shape, B_dtype, scope="shared", layout=B_layout)
+        tmem_addr = T.alloc_shared([1], "uint32")
+        tma_mbar = T.alloc_shared([1], "uint64")
+        mma_mbar = T.alloc_shared([1], "uint64")
+        if tid_in_wg == 0:
+            T.ptx.mbarrier.init(tma_mbar.ptr_to([0]), 1)
+            T.ptx.mbarrier.init(mma_mbar.ptr_to([0]), 1)
+        T.ptx.fence.proxy_async("shared::cta")
+        T.cuda.cta_sync()
+        if warp_id == 0:
+            T.ptx.tcgen05.alloc(T.address_of(tmem_addr), n_cols=128, cta_group=1)
+        T.cuda.cta_sync()
+        tmem = T.decl_buffer((128, C_shape[1]), C_dtype, scope="tmem", allocated_addr=tmem_addr[0], layout=TileLayout(S[(128, C_shape[1]) : (1 @ TLane, 1 @ TCol)]))  # noqa: E501
+        if tid_in_wg == 0:
+            tma_args = T.meta_var({"dispatch": "tma", "mbar": tma_mbar.ptr_to([0])})
+            Tx.copy_async(A_smem[tuple(r_gmem_A)], A[tuple(r_gmem_A)], **tma_args)
+            Tx.copy_async(B_smem[tuple(r_gmem_B)], B[tuple(r_gmem_B)], **tma_args)
+            T.ptx.mbarrier.arrive.expect_tx(tma_mbar.ptr_to([0]), total_bytes)
+        T.ptx.mbarrier.try_wait(tma_mbar.ptr_to([0]), 0)
+        T.cuda.cta_sync()
+        if tid_in_wg == 0:
+            Tx.gemm_async(tmem[tuple(r_tmem_C)], A_smem[tuple(r_smem_A)], B_smem[tuple(r_smem_B)], dispatch="tcgen05", smem_desc=smem_desc)  # noqa: E501
+            T.ptx.tcgen05.commit(mma_mbar.ptr_to([0]), cta_group=1)
+        T.ptx.mbarrier.try_wait(mma_mbar.ptr_to([0]), 0)
+        T.cuda.cta_sync()
+        T.ptx.tcgen05.fence.after_thread_sync()
+        C_reg = T.alloc_local(width, dtype=C_dtype)
+        C_view = C_reg.view(128, width, layout=TileLayout(S[(128, width) : (1@axis_tid_in_wg, 1)]))
+        if wg_id == 0:
+            Tx.wg.copy_async(C_view[:, :], tmem[tuple(r_tmem_C)])
+            T.ptx.tcgen05.wait.ld()
+        T.cuda.cta_sync()
+        Tx.copy(C[tid_in_wg, C_region[1][0]:C_region[1][1]], C_reg[:])
+        if warp_id == 0:
+            T.ptx.tcgen05.relinquish_alloc_permit(cta_group=1)
+            T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=128, cta_group=1)
+        # fmt: on
+
+    return gemm_async
+
+
+@pytest.mark.parametrize("smem_desc", ["hoist", "recompute"])
+def test_gemm_smem_desc_hoist_vs_recompute(smem_desc):
+    """Compile-only: the SMEM matrix descriptor is built per-MMA from the buffer
+    base address, selected by the ``smem_desc`` config.
+
+    - ``hoist`` (default): allocate + encode one warp-uniform descriptor per
+      operand (``descA`` / ``descB`` + ``smem_desc_make_lo_uniform``) and add the
+      per-MMA 16B offset via ``smem_desc_add_16B_offset``.
+    - ``recompute``: build the full descriptor inline per MMA (``_uniform_desc``)
+      with no allocated/encoded descriptor cell — trades a few ALU ops for one
+      fewer live register on the hot path.
+
+    Both must emit the MMA; the descriptor-construction fingerprints differ.
+    """
+    target = tvm.target.Target("cuda")
+    with target:
+        mod = tvm.compile(
+            tvm.IRModule({"main": _build_smem_desc_kernel(smem_desc)}),
+            target=target,
+            tir_pipeline="tirx",
+        )
+    src = mod.mod.imports[0].inspect_source()
+    assert "tcgen05.mma" in src, f"mma not emitted; src=\n{src}"
+
+    if smem_desc == "hoist":
+        assert "smem_desc_make_lo_uniform" in src, "hoist mode must encode a uniform descriptor"
+        assert "smem_desc_add_16B_offset" in src, "hoist mode must add the per-MMA 16B offset"
+    else:
+        assert "smem_desc_make_lo_uniform" not in src, "recompute mode must not hoist a descriptor"
+        assert "smem_desc_add_16B_offset" not in src, "recompute mode must not add a 16B offset"
+        assert "encode_matrix_descriptor" not in src, "recompute mode must not encode a descriptor"
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Split out of the `fp4/fp8/tf32 deepgemm tile-primitive dispatch` branch: this PR is the `gemm_async/tcgen05.py` slice only.

## Why
Rework the tcgen05 `gemm_async` SMEM matrix-descriptor handling so the descriptor is built **per-MMA from the buffer base address**, selectable by a new `smem_desc` config:

- **`hoist`** (default): allocate + encode one warp-uniform descriptor per operand (`descA` / `descB` + `smem_desc_make_lo_uniform`) and add the per-MMA 16B offset via `smem_desc_add_16B_offset`.
- **`recompute`**: build the full descriptor inline per MMA (`_uniform_desc`) with no allocated/encoded cell — one fewer live register on the fa4 hot path at the cost of a few ALU ops.

The descriptor base is always the buffer origin (stage 0); the per-MMA operand offset is applied on top, so both modes are address-correct.

Other cleanups in the same dispatch:
- `_atom_off`: a leading atom dim of extent 1 contributes no LBO/SBO, so its meaningless stride no longer leaks into the descriptor offset.
- Inline the A/B operands and SF addresses into the MMA call via `T.meta_var` to avoid per-iteration LMEM temporaries.
- Fold `needs_sf_id` / descriptor-rotation handling so the block-scaled and dense paths share one `main_impl`.

## Test
`test_gemm_smem_desc_hoist_vs_recompute` (compile-only, no GPU): asserts both modes emit the MMA and lock the hoist-vs-recompute descriptor-construction fingerprints (`smem_desc_make_lo_uniform` / `smem_desc_add_16B_offset` present only in `hoist`; no `encode_matrix_descriptor` in `recompute`).