### PR TITLE
fix(op-dispatch): uint-safe divisibility proof in tcgen05.ld/st

### DIFF
--- a/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tcgen05_ldst.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tcgen05_ldst.py
@@ -49,6 +49,31 @@ from ..exec_scope_utils import exec_scope_ok
 _TCGEN05_COL_FACTOR_FP32 = {"16x64b": 2, "16x128b": 4, "16x256b": 8}
 
 
+def _can_prove_divisible(analyzer, value, divisor):
+    """Robustly prove ``value`` is a multiple of ``divisor`` (a small positive
+    compile-time constant), including when ``value`` is an *unsigned* index.
+
+    ``Analyzer`` rewrites ``y % 1 -> 0`` and ``y % c`` (constant ``c``) for
+    *signed* operands, but leaves ``x % uint32(1)`` symbolic — so the natural
+    ``floormod(col_start, elem_per_32b) == 0`` proof spuriously fails for a
+    ``uint32`` column start even though it is trivially true. The divisor here
+    is ``elem_per_32b`` ∈ {1, 2, 4} (32 // dtype-bits): ``elem_per_32b == 1``
+    is *always* divisible; otherwise we re-run the proof on a signed view of
+    ``value`` (value-preserving for these non-negative TMEM/local indices, and
+    only used for the divisibility check — the emitted arithmetic keeps the
+    original ``value``).
+    """
+    if divisor == 1:
+        return True
+    if analyzer.can_prove_equal(tvm.tirx.floormod(value, divisor), 0):
+        return True
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None and str(dtype).startswith("uint"):
+        signed = tvm.tirx.Cast(str(dtype).replace("uint", "int", 1), value)
+        return analyzer.can_prove_equal(tvm.tirx.floormod(signed, divisor), 0)
+    return False
+
+
 def _match_tcgen05_atom_layout(buf):
     """Return ``(instr_shape, rep, frag_rows)`` if ``buf.layout`` matches a
     tcgen05 ``.16x*b`` atom layout for some supported ``instr_shape``.
@@ -243,7 +268,7 @@ def _emit_32x32b_path(
     width = local_region.region[1].extent
     candidates = [1, 2, 4, 8, 16, 32, 64, 128]
 
-    if not analyzer.can_prove_equal(tvm.tirx.floormod(width, elem_per_32b), 0):
+    if not _can_prove_divisible(analyzer, width, elem_per_32b):
         raise ValueError(f"Width {width} is not valid for tcgen05.ld/st with shape 32x32b")
 
     num = None
@@ -270,7 +295,7 @@ def _emit_32x32b_path(
     assert analyzer.can_prove_equal(local_extent[0], 128)
 
     offset = tmem_st[1]
-    assert analyzer.can_prove_equal(tvm.tirx.floormod(offset, elem_per_32b), 0)
+    assert _can_prove_divisible(analyzer, offset, elem_per_32b)
     offset_32b = tvm.tirx.floordiv(offset, elem_per_32b)
     assert analyzer.can_prove_equal(tmem_extent[1], width), (
         f"tmem_extent[1]: {tmem_extent[1]}, width: {width}"
@@ -390,10 +415,10 @@ def _emit_16xnb_path(
     del tmem_rows  # only used for the structural check above
 
     col_off = tmem_st[1]
-    assert analyzer.can_prove_equal(tvm.tirx.floormod(col_off, elem_per_32b), 0)
+    assert _can_prove_divisible(analyzer, col_off, elem_per_32b)
     col_off_32b = tvm.tirx.floordiv(col_off, elem_per_32b)
     local_col_off = local_st[1]
-    assert analyzer.can_prove_equal(tvm.tirx.floormod(local_col_off, elem_per_32b), 0)
+    assert _can_prove_divisible(analyzer, local_col_off, elem_per_32b)
     local_col_off_elems = local_col_off
 
     is_load = direction == "tmem2local"

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tcgen05_ldst.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tcgen05_ldst.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, missing-function-docstring
+"""Unit tests for tcgen05.ld/st copy_async dispatch helpers."""
+
+import tvm
+from tvm.backend.cuda.operator.tile_primitive.copy_async.tcgen05_ldst import (
+    _can_prove_divisible,
+)
+from tvm.script import tirx as T
+
+
+def test_can_prove_divisible_uint32_offset():
+    analyzer = tvm.arith.Analyzer()
+    u = T.Var("u", "uint32")
+    assert _can_prove_divisible(analyzer, u, 1) is True
+    assert _can_prove_divisible(analyzer, u * tvm.tirx.const(2, "uint32"), 2) is True
+    assert _can_prove_divisible(analyzer, u, 2) is False
+
+
+def test_can_prove_divisible_signed_unaffected():
+    analyzer = tvm.arith.Analyzer()
+    i = T.Var("i", "int32")
+    assert _can_prove_divisible(analyzer, i, 1) is True
+    assert _can_prove_divisible(analyzer, i * tvm.tirx.const(4, "int32"), 4) is True
+    assert _can_prove_divisible(analyzer, i, 4) is False
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
Split out of the `fp4/fp8/tf32 deepgemm tile-primitive dispatch` branch: this PR is the `copy_async/tcgen05_ldst.py` slice only.

## Why
The `32x32b` / `16xNb` tcgen05.ld/st paths gate column offsets on `floormod(x, elem_per_32b) == 0`. The Analyzer rewrites `y % 1 -> 0` and `y % c` (constant `c`) for **signed** operands, but leaves `x % uint32(1)` symbolic — so the proof spuriously fails for a `uint32` column start even when it is trivially true (e.g. `elem_per_32b == 1`).

`_can_prove_divisible` fixes this:
- short-circuit `divisor == 1` (always divisible);
- otherwise retry the floormod proof on a **signed view** of an unsigned value. The TMEM/local indices here are non-negative, so the signed view is value-preserving and is used only for the check — the emitted arithmetic keeps the original `value`.

Signed behaviour is unchanged. This lets a tcgen05.ld/st operand use a `uint32` column base with no `int32` cast (needed for uint32-shaped deepgemm buffers).

## Test
`test_can_prove_divisible_uint32_offset` / `test_can_prove_divisible_signed_unaffected` (CPU-only) cover the uint32 short-circuit, the signed-retry path, and that signed inputs are unaffected.