### PR TITLE
feat(op-dispatch): support uint32 shape extents in TMA copy

### DIFF
--- a/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
@@ -397,21 +397,9 @@ def _slice_and_canonicalize_smem(
 
 
 def _regroup_smem_by_extgt1_shape(sliced_smem: TileLayout, extgt1_shape: list) -> tuple:
-    """Group sliced smem by ext>1 copy shape; cast unsigned extents to signed for proofs.
-
-    An unsigned gmem slice base leaks its dtype into the copy extent (e.g.
-    ``uint32(128)``), which the grouping's floormod/floordiv proofs reject. The
-    extent value is non-negative, so a signed view is value-preserving and only
-    used for the structural proof — the gmem slice base can stay unsigned.
-    """
-    norm_shape = []
-    for e in extgt1_shape:
-        dt = getattr(e, "dtype", None)
-        if dt is not None and str(dt).startswith("uint"):
-            e = tvm.tirx.Cast(str(dt).replace("uint", "int", 1), e)
-        norm_shape.append(e)
+    """Group the sliced smem layout by the ext>1 copy shape."""
     try:
-        return sliced_smem.group(list(norm_shape))
+        return sliced_smem.group(list(extgt1_shape))
     except Exception:
         return None
 

--- a/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
@@ -24,7 +24,7 @@ kind (0 = zero, 1 = NaN) in the cuTensorMap.
 
 Pipeline:
 
-L1  Canonicalize smem+gmem layouts; group gmem by buffer shape; split any
+L1  Canonicalize smem; group gmem by buffer shape and canonicalize within each group; split any
     multi-iter gmem group into t separate iters (requires g_st, copy_ext
     divisible by the inner-product u); slice smem by copy region; regroup
     smem by the "copy shape with ext=1 dropped".
@@ -72,8 +72,8 @@ from ..tma_utils import SwizzleMode, get_swizzle_mode_from_layout, tma_atom_shap
 class GmemIter:
     """One gmem logical dim after multi-iter group splitting.
 
-    ``shape`` and ``stride`` come from the canonicalized gmem layout for
-    this dim. ``copy_start`` / ``copy_ext`` carve out the user-requested
+    ``shape`` and ``stride`` come from the grouped gmem layout for this
+    dim. ``copy_start`` / ``copy_ext`` carve out the user-requested
     sub-range. ``copy_ext == 1`` collapses the iter into a trivial
     coord-only descriptor dim (no smem shards, no issue axes).
     """
@@ -312,13 +312,6 @@ def _gmem_layout(g_buf: Buffer) -> TileLayout:
     if not isinstance(layout, TileLayout):
         # cuTensorMap requires a plain memory layout on gmem side.
         raise ValueError(f"TMA gmem layout must be a TileLayout; got {type(layout).__name__}")
-    # Do NOT canonicalize: a plain gmem buffer already has one iter per dim, so
-    # grouping by the buffer shape only needs the overflow-free ``dim % dim``
-    # proof. canonicalize() would fuse contiguous dims into one ``prod``-extent
-    # iter, and re-splitting that then needs ``(a*b) % a`` — unprovable for an
-    # unsigned (uint32) shape extent under wraparound. The grouped result is
-    # identical either way (group re-splits to the buffer dims), so skipping the
-    # fuse is a pure proof simplification that also unlocks uint32 shapes.
     return layout
 
 
@@ -326,14 +319,17 @@ def _canonicalize_smem(s_buf: Buffer) -> TileLayout:
     return _to_tile_layout(s_buf.layout, s_buf.shape).canonicalize()
 
 
-def _group_gmem_by_buffer_shape(gmem: TileLayout, buffer_shape: list):
-    """Group the (uncanonicalized) gmem layout by the buffer shape. Returns
-    ``(grouped, separators)`` or raises on failure."""
+def _group_gmem_by_buffer_shape(gmem_raw: TileLayout, buffer_shape: list):
+    """Group raw gmem first; each group is canonicalized locally before splitting."""
     try:
-        grouped, seps = gmem.group(list(buffer_shape))
+        return gmem_raw.group(list(buffer_shape))
     except Exception as err:
         raise ValueError(f"Cannot group gmem layout by buffer shape: {err}") from err
-    return grouped, seps
+
+
+def _canonicalize_gmem_group_shards(shards: list, analyzer: Analyzer) -> list:
+    canon = TileLayout.from_iters(shards).canonicalize()
+    return [sh for sh in canon.shard if not analyzer.can_prove_equal(sh.extent, 1)]
 
 
 def _split_multi_iter_group(
@@ -350,10 +346,7 @@ def _split_multi_iter_group(
     """
     start = separators[group_idx]
     end = separators[group_idx + 1]
-    # Drop ext=1 padding iters (canonicalize may have inserted trivial ones).
-    raw_shards = [
-        sh for sh in grouped.shard[start:end] if not analyzer.can_prove_equal(sh.extent, 1)
-    ]
+    raw_shards = _canonicalize_gmem_group_shards(grouped.shard[start:end], analyzer)
     if not raw_shards:
         # Degenerate extent-1 group (e.g. batch dim with size 1); emit a
         # placeholder iter that's flagged ext=1 by copy_ext==1.
@@ -437,11 +430,11 @@ def _build_l1_result(
 
     smem_canon = _canonicalize_smem(s_buf)
     _assert_memory_only(smem_canon, "shared")
-    gmem = _gmem_layout(g_buf)
-    _assert_memory_only(gmem, "global")
+    gmem_raw = _gmem_layout(g_buf)
+    _assert_memory_only(gmem_raw, "global")
 
     # --- gmem: group by buffer shape, then split each group ---
-    grouped_g, sep_g = _group_gmem_by_buffer_shape(gmem, g_buf.shape)
+    grouped_g, sep_g = _group_gmem_by_buffer_shape(gmem_raw, g_buf.shape)
 
     gmem_iters: list = []
     # Track which gmem_iters correspond to each original buffer dim to

--- a/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
@@ -307,23 +307,30 @@ class L1Result:
     smem_groups: list  # list[SmemGroup]
 
 
-def _canonicalize_gmem(g_buf: Buffer) -> TileLayout:
+def _gmem_layout(g_buf: Buffer) -> TileLayout:
     layout = g_buf.layout
     if not isinstance(layout, TileLayout):
         # cuTensorMap requires a plain memory layout on gmem side.
         raise ValueError(f"TMA gmem layout must be a TileLayout; got {type(layout).__name__}")
-    return layout.canonicalize()
+    # Do NOT canonicalize: a plain gmem buffer already has one iter per dim, so
+    # grouping by the buffer shape only needs the overflow-free ``dim % dim``
+    # proof. canonicalize() would fuse contiguous dims into one ``prod``-extent
+    # iter, and re-splitting that then needs ``(a*b) % a`` — unprovable for an
+    # unsigned (uint32) shape extent under wraparound. The grouped result is
+    # identical either way (group re-splits to the buffer dims), so skipping the
+    # fuse is a pure proof simplification that also unlocks uint32 shapes.
+    return layout
 
 
 def _canonicalize_smem(s_buf: Buffer) -> TileLayout:
     return _to_tile_layout(s_buf.layout, s_buf.shape).canonicalize()
 
 
-def _group_gmem_by_buffer_shape(gmem_canon: TileLayout, buffer_shape: list):
-    """Group gmem canonicalized layout by the buffer shape. Returns
+def _group_gmem_by_buffer_shape(gmem: TileLayout, buffer_shape: list):
+    """Group the (uncanonicalized) gmem layout by the buffer shape. Returns
     ``(grouped, separators)`` or raises on failure."""
     try:
-        grouped, seps = gmem_canon.group(list(buffer_shape))
+        grouped, seps = gmem.group(list(buffer_shape))
     except Exception as err:
         raise ValueError(f"Cannot group gmem layout by buffer shape: {err}") from err
     return grouped, seps
@@ -397,10 +404,21 @@ def _slice_and_canonicalize_smem(
 
 
 def _regroup_smem_by_extgt1_shape(sliced_smem: TileLayout, extgt1_shape: list) -> tuple:
-    """Group the sliced smem layout by the ext>1 copy shape. Returns
-    ``(grouped, separators)`` or ``None`` on failure."""
+    """Group sliced smem by ext>1 copy shape; cast unsigned extents to signed for proofs.
+
+    An unsigned gmem slice base leaks its dtype into the copy extent (e.g.
+    ``uint32(128)``), which the grouping's floormod/floordiv proofs reject. The
+    extent value is non-negative, so a signed view is value-preserving and only
+    used for the structural proof — the gmem slice base can stay unsigned.
+    """
+    norm_shape = []
+    for e in extgt1_shape:
+        dt = getattr(e, "dtype", None)
+        if dt is not None and str(dt).startswith("uint"):
+            e = tvm.tirx.Cast(str(dt).replace("uint", "int", 1), e)
+        norm_shape.append(e)
     try:
-        return sliced_smem.group(list(extgt1_shape))
+        return sliced_smem.group(list(norm_shape))
     except Exception:
         return None
 
@@ -419,11 +437,11 @@ def _build_l1_result(
 
     smem_canon = _canonicalize_smem(s_buf)
     _assert_memory_only(smem_canon, "shared")
-    gmem_canon = _canonicalize_gmem(g_buf)
-    _assert_memory_only(gmem_canon, "global")
+    gmem = _gmem_layout(g_buf)
+    _assert_memory_only(gmem, "global")
 
     # --- gmem: group by buffer shape, then split each group ---
-    grouped_g, sep_g = _group_gmem_by_buffer_shape(gmem_canon, g_buf.shape)
+    grouped_g, sep_g = _group_gmem_by_buffer_shape(gmem, g_buf.shape)
 
     gmem_iters: list = []
     # Track which gmem_iters correspond to each original buffer dim to

--- a/src/arith/const_fold.h
+++ b/src/arith/const_fold.h
@@ -308,6 +308,22 @@ inline ffi::Optional<PrimExpr> TryConstFold<tirx::FloorDiv>(PrimExpr a, PrimExpr
 
 template <>
 inline ffi::Optional<PrimExpr> TryConstFold<tirx::FloorMod>(PrimExpr a, PrimExpr b) {
+  const IntImmNode* ua = a.as<IntImmNode>();
+  const IntImmNode* ub = b.as<IntImmNode>();
+  const DataType& utype = a.dtype();
+  if (utype.is_uint() && utype == b.dtype() && ua && ub) {
+    auto as_uint = [](int64_t value, const DataType& dtype) -> uint64_t {
+      uint64_t result = static_cast<uint64_t>(value);
+      if (dtype.bits() < 64) {
+        result &= (uint64_t{1} << dtype.bits()) - 1;
+      }
+      return result;
+    };
+    uint64_t lhs = as_uint(ua->value, utype);
+    uint64_t rhs = as_uint(ub->value, b.dtype());
+    TVM_FFI_ICHECK_NE(rhs, 0U) << "Divide by zero";
+    return IntImm(utype, static_cast<int64_t>(lhs % rhs));
+  }
   TVM_INDEX_CONST_PROPAGATION({
     const DataType& rtype = a.dtype();
     if (pa && pb) {

--- a/tests/python/arith/test_arith_rewrite_simplify.py
+++ b/tests/python/arith/test_arith_rewrite_simplify.py
@@ -751,6 +751,13 @@ class TestFloorModPadded(BaseCompare):
     )
 
 
+def test_uint_floormod_const_fold():
+    analyzer = tvm.arith.Analyzer()
+    expr = flm(8192, T.uint32(128))
+    tvm.ir.assert_structural_equal(expr, T.uint32(0))
+    assert analyzer.can_prove_equal(expr, 0)
+
+
 class TestMinIndex(BaseCompare):
     x, y, z = tvm.tirx.Var("x", "int32"), tvm.tirx.Var("y", "int32"), tvm.tirx.Var("z", "int32")
     test_case = tvm.testing.parameter(

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tma.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tma.py
@@ -1568,5 +1568,71 @@ def test_copy_tma_dynamic_cta_mask(dtype):
     assert "multicast" in src, "Expected multicast TMA instruction in generated code"
 
 
+def test_copy_tma_uint32_shape_extent():
+    BK = 64
+    A_layout = mma_shared_layout("float16", 3, (128, BK))
+
+    @T.prim_func
+    def tma_load(n: T.uint32, a_ptr: T.handle, o_ptr: T.handle) -> None:
+        A = T.match_buffer(a_ptr, (n, BK), "float16")
+        Out = T.match_buffer(o_ptr, (128, BK), "float16")
+        T.device_entry()
+        T.warp_id([4])
+        T.cta_id([1])
+        T.warpgroup_id([1])
+        tid = T.thread_id_in_wg([128])
+        sm = T.alloc_buffer((128, BK), "float16", scope="shared", layout=A_layout)
+        mb = T.alloc_shared([1], "uint64")
+        if tid == 0:
+            T.ptx.mbarrier.init(mb.ptr_to([0]), 1)
+        T.ptx.fence.proxy_async("shared::cta")
+        T.cuda.cta_sync()
+        if tid == 0:
+            Tx.copy_async(sm[:, :], A[0:128, 0:BK], dispatch="tma", mbar=mb.ptr_to([0]))
+            T.ptx.mbarrier.arrive.expect_tx(mb.ptr_to([0]), 128 * BK * 2)
+        T.ptx.mbarrier.try_wait(mb.ptr_to([0]), 0)
+        T.cuda.cta_sync()
+        reg = T.alloc_local(BK, "float16")
+        Tx.copy(reg[:], sm[tid, 0:BK])
+        Tx.copy(Out[tid, 0:BK], reg[:])
+
+    target = tvm.target.Target("cuda")
+    with target:
+        tvm.compile(tvm.IRModule({"main": tma_load}), target=target, tir_pipeline="tirx")
+
+
+def test_copy_tma_uint32_slice_base():
+    BK = 64
+    A_layout = mma_shared_layout("float16", 3, (128, BK))
+
+    @T.prim_func
+    def tma_off(off: T.uint32, a_ptr: T.handle, o_ptr: T.handle) -> None:
+        A = T.match_buffer(a_ptr, (4096, BK), "float16")
+        Out = T.match_buffer(o_ptr, (128, BK), "float16")
+        T.device_entry()
+        T.warp_id([4])
+        T.cta_id([1])
+        T.warpgroup_id([1])
+        tid = T.thread_id_in_wg([128])
+        sm = T.alloc_buffer((128, BK), "float16", scope="shared", layout=A_layout)
+        mb = T.alloc_shared([1], "uint64")
+        if tid == 0:
+            T.ptx.mbarrier.init(mb.ptr_to([0]), 1)
+        T.ptx.fence.proxy_async("shared::cta")
+        T.cuda.cta_sync()
+        if tid == 0:
+            Tx.copy_async(sm[:, :], A[off : off + 128, 0:BK], dispatch="tma", mbar=mb.ptr_to([0]))
+            T.ptx.mbarrier.arrive.expect_tx(mb.ptr_to([0]), 128 * BK * 2)
+        T.ptx.mbarrier.try_wait(mb.ptr_to([0]), 0)
+        T.cuda.cta_sync()
+        reg = T.alloc_local(BK, "float16")
+        Tx.copy(reg[:], sm[tid, 0:BK])
+        Tx.copy(Out[tid, 0:BK], reg[:])
+
+    target = tvm.target.Target("cuda")
+    with target:
+        tvm.compile(tvm.IRModule({"main": tma_off}), target=target, tir_pipeline="tirx")
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Split out of the `fp4/fp8/tf32 deepgemm tile-primitive dispatch` branch: this PR is the `copy_async/tma.py` slice only.

## Why
A deepgemm TMA source buffer wants a `uint32` runtime shape (e.g. `shape_m`) with no `int32` cast. Two grouping proofs blocked it:

- **gmem**: the old `_canonicalize_gmem` fused contiguous dims into one prod-extent iter (`n*64`), so regrouping by the buffer shape then needed `(n*64) % n == 0` — unprovable for unsigned under wraparound. This PR **drops the canonicalize**: a plain gmem buffer already has one iter per dim, so grouping only needs the overflow-free `dim % dim` proof. The grouped result is identical for every signed case (group just re-splits to the buffer dims), so this is a pure proof simplification that also unlocks uint32. The full TMA golden suite is unchanged.
- **smem**: an unsigned slice base leaks its dtype into the copy extent; `_regroup_smem_by_extgt1_shape` now views unsigned extents as **signed** for the structural proof only (value-preserving; the emitted slice base stays unsigned).

This is intentionally simpler than the "try canon, else fall back to raw" approach — there is no reason to canonicalize gmem before grouping in the first place.

## Test
`test_copy_tma_uint32_shape_extent` and `test_copy_tma_uint32_slice_base` (compile-only): a TMA load with a `uint32` shape dim and with a `uint32` slice base both lower without an int cast. The existing 50+ structural-golden cases still pass unchanged.