### PR TITLE
refactor(op-dispatch): drop redundant pre-slice canonicalize in ld_stmatrix

### DIFF
--- a/python/tvm/backend/cuda/operator/tile_primitive/copy/ld_stmatrix.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy/ld_stmatrix.py
@@ -95,17 +95,13 @@ def _emit(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
     s_shape = list(s_buf.shape)
     s_layout = s_buf.layout
 
-    # Step 2: canonicalize, then slice, then canonicalize. Push target so the
-    # scope-aware fusers run (e.g. laneid+wid_in_wg -> tid_in_wg for warpgroup).
-    # Canonicalize *before* slicing too: a frag carrying separate laneid +
-    # wid_in_wg thread axes (e.g. a permuted tcgen05-ld atom) only fuses to a
-    # single tid_in_wg axis on the *full* layout — slicing first leaves a
-    # sub-layout whose scope chain is ill-formed and GetScope rejects it.
     r_region = [(r.min, r.min + r.extent) for r in r_br.region]
     s_region = [(r.min, r.min + r.extent) for r in s_br.region]
     with sctx.target:
-        r = r_layout.canonicalize().slice(r_shape, r_region).canonicalize()
-        s = s_layout.canonicalize().slice(s_shape, s_region).canonicalize()
+        r_sliced = r_layout.slice(r_shape, r_region)
+        s_sliced = s_layout.slice(s_shape, s_region)
+        r = r_sliced.canonicalize()
+        s = s_sliced.canonicalize()
 
     # Step 2.5: peel any S-side swizzle wrapper to expose the underlying
     # TileLayout. The ComposeLayout doesn't have ``.replica`` / ``.shard``,

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_ld_stmatrix.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_ld_stmatrix.py
@@ -457,6 +457,45 @@ def test_ldstmatrix_swizzle_multi_iter_pow2():
     np.testing.assert_allclose(B.numpy(), A_np)
 
 
+def test_ldstmatrix_tcgen05_warpgroup_atom_emits_ldmatrix():
+    """Regression: a warpgroup ``.16x256b`` tcgen05 register atom loaded from a
+    128B-swizzled SMEM tile must dispatch to ``ldmatrix.x4``.
+
+    The atom's laneid is split across two shard iters (stride 4 and stride 1)
+    plus ``wid_in_wg`` — it only fuses to a single ``tid_in_wg`` thread axis
+    after the slice. With the redundant pre-slice ``canonicalize()`` removed,
+    Step 2 relies on ``TileLayout.Slice``'s built-in global pre-canonicalize, so
+    the slice no longer leaves an ill-formed split-laneid sub-layout that
+    ``GetScope`` would reject (which silently fell back to a scalar reg path).
+    Compile-only (no GPU): asserts the instruction appears in generated source.
+    """
+    from tvm.tirx.cuda.operator.tile_primitive.tma_utils import mma_shared_layout
+    from tvm.tirx.layout import tcgen05_atom_layout
+
+    m, k = 64, 64
+    # bf16 payload carrying the *fp32* atom layout (mirrors the tf32-prenorm
+    # cast warp's ``a_bf16``: one element per 32-bit slot).
+    reg_layout = tcgen05_atom_layout("16x256b", (m, k), "float32")
+    smem_layout = mma_shared_layout("bfloat16", 3, (m, k))
+
+    @T.prim_func
+    def kernel(s_ptr: T.handle) -> None:
+        smem = T.match_buffer(s_ptr, (m, k), "bfloat16", scope="shared", layout=smem_layout)
+        T.device_entry()
+        T.cta_id([1])
+        T.warpgroup_id([1])
+        T.warp_id_in_wg([4])
+        T.lane_id([32])
+        T.thread_id_in_wg([128])
+        a_reg = T.alloc_buffer((m, k), "bfloat16", scope="local", layout=reg_layout)
+        Tx.wg.copy(a_reg, smem)
+
+    _, src = _compile_src(kernel)
+    assert "ldmatrix.sync.aligned.m8n8.x4.shared.b16" in src, (
+        f"warpgroup tcgen05 atom did not emit ldmatrix.x4; src=\n{src}"
+    )
+
+
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda_compute(9), reason="need cuda compute >= 9.0")
 def test_ldstmatrix_swizzle_multi_iter_linear():


### PR DESCRIPTION
Split out of the `fp4/fp8/tf32 deepgemm tile-primitive dispatch` branch: this PR is the `copy/ld_stmatrix.py` slice only.

## Why
Step 2 canonicalized the register/shared layout **before** slicing, to fuse a split-laneid tcgen05 atom (separate `laneid` + `wid_in_wg` axes) into a single `tid_in_wg` axis on the full layout. Otherwise slicing first left an ill-formed sub-layout that `GetScope` rejected, silently dropping `ldmatrix` for a scalar reg path.

`TileLayout.Slice` now globally pre-canonicalizes internally before grouping, so the Python pre-slice `canonicalize()` is redundant: `slice().canonicalize()` produces the same layout. Drop it (and the matching explanatory comment block).

## Test
`test_ldstmatrix_tcgen05_warpgroup_atom_emits_ldmatrix` (compile-only, no GPU): a warpgroup `.16x256b` tcgen05 register atom loaded from a 128B-swizzled SMEM tile — the tf32-prenorm cast-warp A load — must emit `ldmatrix.sync.aligned.m8n8.x4.shared.b16`. This locks in the outcome the pre-slice canonicalize used to guard.