### PR TITLE
fix(op-dispatch): cache one tcgen05.cp descriptor, patch SMEM addr per cp

### DIFF
--- a/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tcgen05_cp.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tcgen05_cp.py
@@ -372,19 +372,33 @@ def _build_plan(op_call: TilePrimitiveCall, sctx: DispatchContext):
 # add_post_buffer_def_stmt.
 # -----------------------------------------------------------------------------
 def _get_or_create_desc(sctx, s_buf, ldo, sdo, swizzle):
-    cache_key = f"smem_tmem_desc:{hash(s_buf)}:{int(ldo)}:{int(sdo)}:{int(swizzle)}"
+    # Cache descriptor template at SMEM 0; patch addr per cp.
+    cache_key = f"smem_tmem_desc:{int(ldo)}:{int(sdo)}:{int(swizzle)}"
     cached = sctx.cache_get(cache_key)
     if cached is not None:
         return cached
 
     desc_buf = tvm.tirx.decl_buffer((1,), "uint64", name="cp_desc", scope="local")
     encode_call = T.ptx.tcgen05.encode_matrix_descriptor(
-        desc_buf.data, s_buf.ptr_to([0] * len(s_buf.shape)), ldo, sdo, swizzle
+        desc_buf.data, T.reinterpret("handle", T.uint64(0)), ldo, sdo, swizzle
     )
     wrap = SeqStmt([AllocBuffer(desc_buf), Evaluate(encode_call)])
     sctx.add_post_buffer_def_stmt(s_buf, wrap)
     sctx.cache_set(cache_key, desc_buf)
     return desc_buf
+
+
+def _desc_set_addr(desc_val, addr_ptr):
+    """Patch a SMEM matrix descriptor's 14-bit address field with cvta(addr)>>4 —
+    matches the hand-rolled ``replace_smem_desc_addr`` (descriptor encoded at 0)."""
+    start_addr = T.cast(
+        T.bitwise_and(
+            T.shift_right(T.cuda.cvta_generic_to_shared(addr_ptr), T.uint32(4)),
+            T.uint32(0x3FFF),
+        ),
+        "uint64",
+    )
+    return T.bitwise_or(T.bitwise_and(desc_val, T.bitwise_not(T.uint64(0x3FFF))), start_addr)
 
 
 # -----------------------------------------------------------------------------
@@ -402,13 +416,18 @@ def copy_smem_tmem_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> Pr
     init_off_16B = plan["init_off_16B"]
     t_col0 = plan["t_col0"]
 
-    LDO_field = 16  # cp 32x128b ignores LDO; placeholder
+    # cp ignores LDO for data; non-zero LDO bloats the addr-patch codegen.
+    LDO_field = 0
 
     cta_group = op_call.config.get("cta_group", 1)
 
     desc_buf = _get_or_create_desc(sctx, s_buf, LDO_field, SDO_field, sw)
     t_addr = t_buf.allocated_addr
-    from tvm.backend.cuda.operator.tile_primitive.common import smem_desc_add_16B_offset
+    s_rank = len(s_buf.shape)
+
+    def _cp_desc(off_16B):
+        addr = T.ptr_byte_offset(s_buf.ptr_to([0] * s_rank), off_16B * 16, s_buf.dtype)
+        return _desc_set_addr(desc_buf[0], addr)
 
     # Flatten the N-D middle iteration into a single T.unroll. Each iteration's
     # per-dim index is (flat // stride) % extent, summed into the t/s offsets.
@@ -422,7 +441,7 @@ def copy_smem_tmem_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> Pr
         def impl():
             T.ptx.tcgen05.cp(
                 t_addr[0] + t_col0,
-                smem_desc_add_16B_offset(desc_buf[0], init_off_16B),
+                _cp_desc(init_off_16B),
                 shape="32x128b", cta_group=cta_group, multicast="warpx4",
             )
     else:
@@ -443,7 +462,7 @@ def copy_smem_tmem_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> Pr
                 t_off, s_off = T.meta_var(compute_offsets(flat))
                 T.ptx.tcgen05.cp(
                     t_addr[0] + t_col0 + t_off,
-                    smem_desc_add_16B_offset(desc_buf[0], init_off_16B + s_off),
+                    _cp_desc(init_off_16B + s_off),
                     shape="32x128b", cta_group=cta_group, multicast="warpx4",
                 )
     # fmt: on

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_smem_tmem.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_smem_tmem.py
@@ -442,5 +442,34 @@ def test_dispatch_rejects_bad_inputs(bad):
             tvm.compile(tvm.IRModule({"main": kernel}), target=target, tir_pipeline="tirx")
 
 
+def test_multi_cp_encodes_descriptor_once_and_patches_addr():
+    """Compile-only regression for the shared-descriptor cp path.
+
+    A multi-tile smem->tmem copy encodes ONE SMEM matrix descriptor template at
+    SMEM base 0 (so the cache key no longer depends on the buffer identity) and
+    patches its 14-bit address field per cp via ``cvta(addr) >> 4 & 0x3FFF``,
+    instead of re-encoding a descriptor per tile. Verifies the 4-tile copy emits
+    a single ``encode_matrix_descriptor`` reused across four
+    ``tcgen05.cp.32x128b.warpx4`` issues, each with the address-field patch.
+    """
+    s_full = TileLayout(S[(4, 32, 16) : (512, 16, 1)])
+    t_full = TileLayout(S[(4, 32, 16) : (16 @ TCol, 1 @ TLane, 1 @ TCol)] + R[4 : 32 @ TLane])
+    kernel = _make_3d_4tile_kernel(s_full, t_full, [4, 32, 16], [4, 32, 16], "uint8")
+
+    target = tvm.target.Target("cuda")
+    with target:
+        mod = tvm.compile(tvm.IRModule({"main": kernel}), target=target, tir_pipeline="tirx")
+    src = mod.mod.imports[0].inspect_source()
+
+    assert "tcgen05.cp.cta_group::1.32x128b.warpx4" in src, f"cp not emitted; src=\n{src}"
+    # Descriptor encoded once (single matrix-descriptor encode call), then
+    # reused with a per-cp 14-bit SMEM address patch (0x3FFF == 16383 mask).
+    assert "16383" in src, "expected 14-bit SMEM address-field patch (0x3FFF mask)"
+    assert src.count("cp_desc[0] &") == 4, (
+        f"expected 4 address-patched cp's reusing one cp_desc; got "
+        f"{src.count('cp_desc[0] &')}\nsrc=\n{src}"
+    )
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Split out of the `fp4/fp8/tf32 deepgemm tile-primitive dispatch` branch: this PR is the `copy_async/tcgen05_cp.py` slice only.

## Why
The smem->tmem cp dispatch encoded a fresh SMEM matrix descriptor per buffer (the cache key included `hash(s_buf)`) and set `LDO=16` (a placeholder cp ignores for data).

This PR instead encodes **one** descriptor template at SMEM base 0:
- the cache key drops the per-buffer hash, so identical `(ldo, sdo, swizzle)` templates are shared across cps;
- each cp patches the descriptor's 14-bit address field via `cvta(addr) >> 4 & 0x3FFF` (`_desc_set_addr`, mirroring the hand-rolled `replace_smem_desc_addr`);
- `LDO` is set to `0` since cp ignores it for data and a non-zero LDO only bloats the address-patch codegen.

## Test
`test_multi_cp_encodes_descriptor_once_and_patches_addr` (compile-only, no GPU): a 4-tile copy emits a single `encode_matrix_descriptor` reused across four `tcgen05.cp.32x128b.warpx4` issues, each with the per-cp address-field patch (`0x3FFF` mask).