### PR TITLE
perf(op-dispatch): direct ld/st.shared for shared->shared warp permute

### DIFF
--- a/python/tvm/backend/cuda/operator/tile_primitive/permute_layout/warp_xor_swizzle.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/permute_layout/warp_xor_swizzle.py
@@ -305,28 +305,70 @@ def _impl(op_call, sctx):
     tid_x = sctx.launch_params["threadIdx.x"]
     dtype = src_buf.dtype
 
+    # Shared 32/64b: base ptr + stride offset avoids buf[] flatten IMAD path.
+    direct = (
+        dtype_bytes in (4, 8)
+        and "shared" in str(src_buf.scope())
+        and "shared" in str(dst_buf.scope())
+    )
+    ptx_t = f"b{dtype_bytes * 8}"
+    # ld/st only move bits, so use an unsigned container of the matching width:
+    # ``ptx.ld(..., bN)`` rejects a float return dtype, and the permute is a pure
+    # byte shuffle, so a float32/float64 tile loads/stores correctly as uint.
+    bits_dtype = f"uint{dtype_bytes * 8}"
+
+    def _iter_off(iter_idx, strides):
+        return sum(iter_idx[d] * strides[d] for d in range(len(strides)))
+
     # fmt: off
-    @T.prim_func
-    def impl():
-        warp_size = T.meta_var(32)
-        lane_id = T.meta_var(tid_x % warp_size)
-        regs = T.alloc_buffer((P,), dtype, scope="local")
-        # Phase 1: read via L_src
-        for r in T.unroll(0, P):
-            j = T.meta_var(r ^ ((lane_id >> shift) & mask))
-            flat = T.meta_var(lane_id + j * warp_size)
-            iter_idx = T.meta_var(get_indices(flat, [0] * len(extent), extent))
-            src_idx = T.meta_var(_project(iter_idx, src_st))
-            regs[r] = src_buf[tuple(src_idx)]
-        T.cuda.warp_sync()
-        # Phase 2: write via L_dst
-        for r in T.unroll(0, P):
-            j = T.meta_var(r ^ ((lane_id >> shift) & mask))
-            flat = T.meta_var(lane_id + j * warp_size)
-            iter_idx = T.meta_var(get_indices(flat, [0] * len(extent), extent))
-            dst_idx = T.meta_var(_project(iter_idx, dst_st))
-            dst_buf[tuple(dst_idx)] = regs[r]
-        T.cuda.warp_sync()
+    if direct:
+        @T.prim_func
+        def impl():
+            warp_size = T.meta_var(32)
+            lane_id = T.meta_var(tid_x % warp_size)
+            regs = T.alloc_buffer((P,), bits_dtype, scope="local")
+            base_src = T.meta_var(src_buf.ptr_to(list(src_st)))
+            base_dst = T.meta_var(dst_buf.ptr_to(list(dst_st)))
+            # Phase 1: read via L_src
+            for r in T.unroll(0, P):
+                j = T.meta_var(r ^ ((lane_id >> shift) & mask))
+                flat = T.meta_var(lane_id + j * warp_size)
+                iter_idx = T.meta_var(get_indices(flat, [0] * len(extent), extent))
+                off = T.meta_var(_iter_off(iter_idx, src_str_))
+                ptr = T.meta_var(T.ptr_byte_offset(base_src, off * dtype_bytes, dtype))
+                regs[r] = T.ptx.ld(ptr, bits_dtype, ptx_t, space="shared")
+            T.cuda.warp_sync()
+            # Phase 2: write via L_dst
+            for r in T.unroll(0, P):
+                j = T.meta_var(r ^ ((lane_id >> shift) & mask))
+                flat = T.meta_var(lane_id + j * warp_size)
+                iter_idx = T.meta_var(get_indices(flat, [0] * len(extent), extent))
+                off = T.meta_var(_iter_off(iter_idx, dst_str_))
+                ptr = T.meta_var(T.ptr_byte_offset(base_dst, off * dtype_bytes, dtype))
+                T.evaluate(T.ptx.st(ptr, regs[r], space="shared", ptx_type=ptx_t))
+            T.cuda.warp_sync()
+    else:
+        @T.prim_func
+        def impl():
+            warp_size = T.meta_var(32)
+            lane_id = T.meta_var(tid_x % warp_size)
+            regs = T.alloc_buffer((P,), dtype, scope="local")
+            # Phase 1: read via L_src
+            for r in T.unroll(0, P):
+                j = T.meta_var(r ^ ((lane_id >> shift) & mask))
+                flat = T.meta_var(lane_id + j * warp_size)
+                iter_idx = T.meta_var(get_indices(flat, [0] * len(extent), extent))
+                src_idx = T.meta_var(_project(iter_idx, src_st))
+                regs[r] = src_buf[tuple(src_idx)]
+            T.cuda.warp_sync()
+            # Phase 2: write via L_dst
+            for r in T.unroll(0, P):
+                j = T.meta_var(r ^ ((lane_id >> shift) & mask))
+                flat = T.meta_var(lane_id + j * warp_size)
+                iter_idx = T.meta_var(get_indices(flat, [0] * len(extent), extent))
+                dst_idx = T.meta_var(_project(iter_idx, dst_st))
+                dst_buf[tuple(dst_idx)] = regs[r]
+            T.cuda.warp_sync()
     # fmt: on
     return impl
 

--- a/tests/python/tirx/operator/tile_primitive/cuda/permute_layout/test_permute_layout.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/permute_layout/test_permute_layout.py
@@ -414,5 +414,47 @@ def test_reject_non_warp_scope():
     assert "warp" in str(exc_info.value)
 
 
+@pytest.mark.parametrize("dtype", ["uint32", "float32"])
+def test_shared_to_shared_uses_direct_ldst(dtype):
+    """Compile-only: a shared->shared 32b transpose must take the direct
+    base-ptr + byte-offset ``ld.shared`` / ``st.shared`` path.
+
+    For a 4/8-byte dtype with both operands in shared memory, indexing through
+    ``buf[...]`` lowers the swizzled layout to a per-element IMAD flatten. The
+    direct path computes one base ptr (``ptr_to(stride_offset)``) and adds a
+    compile-time ``off * dtype_bytes`` per register slot, then issues
+    ``T.ptx.ld/st(..., space="shared")``. The bits move through a uint
+    container, so ``float32`` (whose ``ld.b32`` cannot return a float) lowers
+    the same way as the ``uint32`` SF case.
+    """
+    shape = (4, 32)
+    pre = TileLayout(S[shape : (32, 1)])  # linear
+    post = TileLayout(S[shape : (1, 4)])  # transposed within the 128-block
+
+    # fmt: off
+    @T.prim_func
+    def f(A: T.handle, B: T.handle):
+        A_buf = T.match_buffer(A, shape, dtype, layout=pre)
+        B_buf = T.match_buffer(B, shape, dtype, layout=post)
+        T.device_entry()
+        T.cta_id([1])
+        tid = T.thread_id([32])
+        sA = T.alloc_buffer(shape, dtype, scope="shared", layout=pre)
+        sB = T.alloc_buffer(shape, dtype, scope="shared", layout=post)
+        Tx.cta.copy(sA[:, :], A_buf[:, :])
+        T.cuda.cta_sync()
+        Tx.warp.permute_layout(sB[:, :], sA[:, :])
+        T.cuda.cta_sync()
+        Tx.cta.copy(B_buf[:, :], sB[:, :])
+        # fmt: on
+
+    target = tvm.target.Target("cuda")
+    with target:
+        mod = tvm.compile(tvm.IRModule({"main": f}), target=target, tir_pipeline="tirx")
+    src = mod.mod.imports[0].inspect_source()
+    assert "ld.shared" in src, f"expected direct ld.shared in permute; src=\n{src}"
+    assert "st.shared" in src, f"expected direct st.shared in permute; src=\n{src}"
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Split out of the `fp4/fp8/tf32 deepgemm tile-primitive dispatch` branch: this PR is the `permute_layout/warp_xor_swizzle.py` slice only.

## Why
A shared->shared `warp_xor_swizzle` permute indexed both operands through `buf[...]`, so the swizzled layout lowered to a per-element IMAD flatten on the hot SF-transpose path. For a 4/8-byte dtype with both operands in shared memory, this PR computes one base ptr via `ptr_to(stride_offset)` and adds a compile-time `off * dtype_bytes` per register slot, then issues `T.ptx.ld/st(..., space="shared")` directly.

The permute only shuffles bits, so the bits move through an **unsigned container** of the matching width: `ld.bN` rejects a float return dtype, so this also lets a `float32`/`float64` shared tile take the direct path (the `dtype_bytes in (4, 8)` predicate already admitted floats — previously they hit a codegen error: `PTX ld type 'b32' cannot return 'float32'`).

## Test
`test_shared_to_shared_uses_direct_ldst[uint32|float32]` (compile-only, no GPU): a shared->shared 32b transpose must emit the direct `ld.shared` / `st.shared` path for both the `uint32` SF case and `float32` (which previously failed to compile via this path).