### PR TITLE
Fix TIRx PrimType dtype compatibility

### DIFF
--- a/python/tvm/backend/cuda/operator/tile_primitive/elementwise/_common.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/elementwise/_common.py
@@ -55,14 +55,25 @@ def buffer_regions(plan) -> list[BufferRegion]:
     return out
 
 
+def dtype_name(dtype) -> str:
+    dtype_obj = getattr(dtype, "dtype", None)
+    if dtype_obj is not None:
+        return str(dtype_obj)
+    return str(dtype)
+
+
+def dtype_bits(dtype) -> int:
+    return DataType(dtype_name(dtype)).bits
+
+
 def compute_dtype_of(plan) -> str:
     """Widest dtype in bits across dst + buffer/scalar srcs (dst breaks ties)."""
-    candidates = [plan.dst.buffer.dtype]
+    candidates = [dtype_name(plan.dst.buffer.dtype)]
     for s in plan.srcs:
         if s.buf_region is not None:
-            candidates.append(s.buf_region.buffer.dtype)
+            candidates.append(dtype_name(s.buf_region.buffer.dtype))
         elif s.scalar is not None:
-            candidates.append(s.scalar.dtype)
+            candidates.append(scalar_dtype(s.scalar))
     widest = candidates[0]
     widest_bits = DataType(widest).bits
     for d in candidates[1:]:
@@ -70,6 +81,19 @@ def compute_dtype_of(plan) -> str:
         if b > widest_bits:
             widest, widest_bits = d, b
     return widest
+
+
+def scalar_dtype(scalar) -> str:
+    dtype = getattr(scalar, "dtype", None)
+    if dtype is not None:
+        return str(dtype)
+    ty = getattr(scalar, "ty", None)
+    if ty is None and hasattr(scalar, "expr_ty"):
+        ty = scalar.expr_ty()
+    dtype = getattr(ty, "dtype", None)
+    if dtype is None:
+        raise AttributeError(f"{type(scalar).__name__} has no dtype-bearing PrimType")
+    return str(dtype)
 
 
 def n_elements(buf_region: BufferRegion) -> int:
@@ -375,6 +399,8 @@ __all__ = [
     "align_operands_to_anchor",
     "buffer_regions",
     "compute_dtype_of",
+    "dtype_bits",
+    "dtype_name",
     "emit_scope_sync",
     "fetch_src_value",
     "n_elements",

--- a/python/tvm/backend/cuda/operator/tile_primitive/elementwise/ops/unary.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/elementwise/ops/unary.py
@@ -30,6 +30,7 @@ from tvm.script import tirx as T
 from tvm.tirx import BufferRegion, TilePrimitiveCall
 from tvm.tirx.expr import FloatImm
 
+from .._common import scalar_dtype
 from . import OpSpec, Plan, SrcSpec
 
 
@@ -62,11 +63,14 @@ def _parse_unary(op: TilePrimitiveCall) -> tuple[Plan | None, str | None]:
 
 def _check_unary_extras(extras: dict, compute_dtype: str) -> tuple[bool, str | None]:
     scale = extras.get("scale")
-    if scale is not None and scale.dtype != compute_dtype:
-        return False, f"scale dtype {scale.dtype} != compute dtype {compute_dtype}"
+    if scale is not None and scalar_dtype(scale) != compute_dtype:
+        return False, f"scale dtype {scalar_dtype(scale)} != compute dtype {compute_dtype}"
     bias_const = extras.get("bias_const")
-    if bias_const is not None and bias_const.dtype != compute_dtype:
-        return False, f"bias_const dtype {bias_const.dtype} != compute dtype {compute_dtype}"
+    if bias_const is not None and scalar_dtype(bias_const) != compute_dtype:
+        return (
+            False,
+            f"bias_const dtype {scalar_dtype(bias_const)} != compute dtype {compute_dtype}",
+        )
     return True, None
 
 

--- a/python/tvm/backend/cuda/operator/tile_primitive/elementwise/smem.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/elementwise/smem.py
@@ -44,6 +44,7 @@ from ._common import (
     _tensor_shape_of,
     buffer_regions,
     compute_dtype_of,
+    dtype_bits,
     emit_scope_sync,
     fetch_src_value,
     n_elements,
@@ -99,10 +100,10 @@ def is_smem_ewise(spec):
 def _max_layout_vec(plan, total: int, thread_cnt: int) -> int:
     """Widest vec_chunk dividing all operands' innermost extents AND
     ``total / thread_cnt``, within dtype-bit candidates ``{128,64,32,16,8}``."""
-    max_bits = plan.dst.buffer.dtype.dtype.bits
+    max_bits = dtype_bits(plan.dst.buffer.dtype)
     for s in plan.srcs:
         if s.buf_region is not None:
-            max_bits = max(max_bits, s.buf_region.buffer.dtype.dtype.bits)
+            max_bits = max(max_bits, dtype_bits(s.buf_region.buffer.dtype))
     per_thread = total // thread_cnt if thread_cnt > 0 else total
     if total % thread_cnt != 0:
         return 1

--- a/python/tvm/backend/cuda/operator/tile_primitive/elementwise/vec_emit/binary_f32x2.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/elementwise/vec_emit/binary_f32x2.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 from tvm.ir.expr import PrimExpr
 from tvm.script import tirx as T
 
+from .._common import dtype_name, scalar_dtype
 from ..ops import VecImpl
 
 
@@ -49,7 +50,7 @@ def _f32x2_applies(op_name):
     def applies(op_call, sctx, plan):
         from ...common import sm_version_ok
 
-        if plan.dst.buffer.dtype != "float32":
+        if dtype_name(plan.dst.buffer.dtype) != "float32":
             return False, "dst dtype not f32"
         if not sm_version_ok(op_call, sctx, min_version=100)[0]:
             return False, "sm version < 100"
@@ -57,10 +58,10 @@ def _f32x2_applies(op_name):
             return False, "binary requires 2 srcs"
         for s in plan.srcs:
             if s.is_scalar:
-                if s.scalar.dtype != "float32":
+                if scalar_dtype(s.scalar) != "float32":
                     return False, "scalar src dtype not f32"
             else:
-                if s.buf_region.buffer.dtype != "float32":
+                if dtype_name(s.buf_region.buffer.dtype) != "float32":
                     return False, "buffer src dtype not f32"
                 if s.index_fn is not None:
                     return False, "broadcasting src not supported by f32x2 packed"

--- a/python/tvm/backend/cuda/operator/tile_primitive/elementwise/vec_emit/cast_vec2.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/elementwise/vec_emit/cast_vec2.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from tvm.ir.expr import PrimExpr
 from tvm.script import tirx as T
 
+from .._common import dtype_name
 from ..ops import VecImpl
 
 _VEC2_CAST_INTRINSICS = {
@@ -60,8 +61,8 @@ def _cast_vec2_applies(op_call, sctx, plan):
     src = plan.srcs[0]
     if src.index_fn is not None:
         return False, "broadcasting src not supported by cast vec2"
-    src_dtype = src.buf_region.buffer.dtype
-    dst_dtype = plan.dst.buffer.dtype
+    src_dtype = dtype_name(src.buf_region.buffer.dtype)
+    dst_dtype = dtype_name(plan.dst.buffer.dtype)
     if (src_dtype, dst_dtype) not in _VEC2_CAST_INTRINSICS:
         return False, f"no vec2 intrinsic for {src_dtype}->{dst_dtype}"
     return True, None
@@ -72,8 +73,10 @@ def _emit_cast_vec2(dst_buf, dst_lane_indices, src_args, extras) -> PrimExpr:
     # cast_vec2 requires buffer src (guarded by applies()).
     assert isinstance(src_arg, tuple), "cast vec2 src must be a buffer"
     src_buf, src_lane_indices = src_arg
-    func_name = _intrinsic_name(src_buf.dtype, dst_buf.dtype)
-    source_code = _intrinsic_source(src_buf.dtype, dst_buf.dtype)
+    src_dtype = dtype_name(src_buf.dtype)
+    dst_dtype = dtype_name(dst_buf.dtype)
+    func_name = _intrinsic_name(src_dtype, dst_dtype)
+    source_code = _intrinsic_source(src_dtype, dst_dtype)
     return T.cuda.func_call(
         func_name,
         T.address_of(dst_buf[tuple(dst_lane_indices[0])]),

--- a/python/tvm/backend/cuda/operator/tile_primitive/elementwise/vec_emit/fma_f32x2.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/elementwise/vec_emit/fma_f32x2.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from tvm.ir.expr import PrimExpr
 from tvm.script import tirx as T
 
+from .._common import dtype_name, scalar_dtype
 from ..ops import VecImpl
 from .binary_f32x2 import _lane
 
@@ -33,7 +34,7 @@ from .binary_f32x2 import _lane
 def _fma_f32x2_applies(op_call, sctx, plan):
     from ...common import sm_version_ok
 
-    if plan.dst.buffer.dtype != "float32":
+    if dtype_name(plan.dst.buffer.dtype) != "float32":
         return False, "dst dtype not f32"
     if not sm_version_ok(op_call, sctx, min_version=100)[0]:
         return False, "sm version < 100"
@@ -42,16 +43,16 @@ def _fma_f32x2_applies(op_call, sctx, plan):
     a, b, c = plan.srcs
     if a.is_scalar:
         return False, "fma 'a' must be a buffer (no scalar-a packed FMA)"
-    if a.buf_region.buffer.dtype != "float32":
+    if dtype_name(a.buf_region.buffer.dtype) != "float32":
         return False, "src a dtype not f32"
     if a.index_fn is not None:
         return False, "broadcasting src a not supported"
     for s in (b, c):
         if s.is_scalar:
-            if s.scalar.dtype != "float32":
+            if scalar_dtype(s.scalar) != "float32":
                 return False, "scalar b/c dtype not f32"
         else:
-            if s.buf_region.buffer.dtype != "float32":
+            if dtype_name(s.buf_region.buffer.dtype) != "float32":
                 return False, "buffer b/c dtype not f32"
             if s.index_fn is not None:
                 return False, "broadcasting src b/c not supported"

--- a/python/tvm/backend/cuda/operator/tile_primitive/gemm_async/tcgen05.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/gemm_async/tcgen05.py
@@ -75,6 +75,13 @@ _INSTR_DESC_FORMAT_MAP = {
 }
 
 
+def _dtype_name(dtype) -> str:
+    dtype_obj = getattr(dtype, "dtype", None)
+    if dtype_obj is not None:
+        return str(dtype_obj)
+    return str(dtype)
+
+
 def _encode_instr_descriptor_dense_uint32(
     M,
     N,
@@ -96,6 +103,9 @@ def _encode_instr_descriptor_dense_uint32(
     local descriptor on every gemm_async call (which forces an inline ``asm``
     block that ptxas cannot hoist out of the i_kv loop body).
     """
+    d_dtype = _dtype_name(d_dtype)
+    a_dtype = _dtype_name(a_dtype)
+    b_dtype = _dtype_name(b_dtype)
     d_format = _INSTR_DESC_FORMAT_MAP[d_dtype]
     a_format = _INSTR_DESC_FORMAT_MAP[a_dtype]
     b_format = _INSTR_DESC_FORMAT_MAP[b_dtype]
@@ -240,8 +250,8 @@ def _compute_sf_mma_k(data_dtype, sf_dtype):
     - fp4 data + e8m0fnu SF: MMA_K=64, SF_VEC=32 → sf_mma_k=2
     - fp4 data + e4m3fn SF (nvfp4): MMA_K=64, SF_VEC=16 → sf_mma_k=4
     """
-    data_dtype = str(data_dtype)
-    sf_dtype = str(sf_dtype)
+    data_dtype = _dtype_name(data_dtype)
+    sf_dtype = _dtype_name(sf_dtype)
     if data_dtype in ("float8_e4m3fn", "float8_e5m2"):
         return 1  # MMA_K=32, one SF per MMA
     elif data_dtype == "float4_e2m1fn":
@@ -384,7 +394,11 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
 
     analyzer = Analyzer()
 
-    C_type, A_type, B_type = C_buffer.dtype, A_buffer.dtype, B_buffer.dtype
+    C_type, A_type, B_type = (
+        _dtype_name(C_buffer.dtype),
+        _dtype_name(A_buffer.dtype),
+        _dtype_name(B_buffer.dtype),
+    )
     assert C_type == "float32", f"tcgen05 schedule expected C_type=float32, got {C_type}"
 
     # fp32/bf16 storage may still use tf32 MMA semantics via is_AB_tf32.
@@ -435,7 +449,7 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
                 f"tcgen05 block-scaled schedule expected SFA_scope=tmem, SFB_scope=tmem, "
                 f"got SFA_scope={SFA_scope}, SFB_scope={SFB_scope}"
             )
-        SFA_type, SFB_type = SFA_buffer.dtype, SFB_buffer.dtype
+        SFA_type, SFB_type = _dtype_name(SFA_buffer.dtype), _dtype_name(SFB_buffer.dtype)
         SFA_slice_layout = SFA_buffer.layout.slice(SFA_buffer.shape, SFA_buffer_region.region)
         SFB_slice_layout = SFB_buffer.layout.slice(SFB_buffer.shape, SFB_buffer_region.region)
         SFA_elem_per_col = 32 // DataType(SFA_type).bits

--- a/python/tvm/backend/trn/operator/tile_primitive/private_alloc.py
+++ b/python/tvm/backend/trn/operator/tile_primitive/private_alloc.py
@@ -35,6 +35,17 @@ from tvm.tirx.operator.tile_primitive.registry import f_op_dispatcher
 from tvm.tirx.stmt import TilePrimitiveCall
 
 
+def _scalar_dtype(scalar) -> str:
+    dtype = getattr(scalar, "dtype", None)
+    if dtype is not None:
+        return str(dtype)
+    ty = getattr(scalar, "ty", None)
+    dtype = getattr(ty, "dtype", None)
+    if dtype is None:
+        raise AttributeError(f"{type(scalar).__name__} has no dtype-bearing PrimType")
+    return str(dtype)
+
+
 def alloc_const_bias_trn(
     op: TilePrimitiveCall, buffer_dict: dict[Any, tuple[Buffer, Stmt | None]], sctx: DispatchContext
 ) -> dict[str, Any]:
@@ -53,7 +64,9 @@ def alloc_const_bias_trn(
             return {"const_bias": ("const_bias", bias.value)}
     else:
         new_shape = (par_size, max_inst_size)
-    new_buffer = T.buffer(new_shape, dtype=bias.dtype, scope="trn.sbuf", buffer_name="const_bias")
+    new_buffer = T.buffer(
+        new_shape, dtype=_scalar_dtype(bias), scope="trn.sbuf", buffer_name="const_bias"
+    )
 
     @T.prim_func
     def const_bias_init():

--- a/python/tvm/tirx/op.py
+++ b/python/tvm/tirx/op.py
@@ -934,6 +934,8 @@ def print_buffer(buffer_var, dtype, is_string, is_scalar, dim_num, *shape):
         final_shape_args = list(shape[0])
     else:
         final_shape_args = list(shape)
+    if isinstance(dtype, tvm.ir.PrimType):
+        dtype = dtype.dtype
     return _ffi_api.print_buffer(
         buffer_var, dtype, is_string, is_scalar, dim_num, *final_shape_args
     )

--- a/python/tvm/tirx/script/builder/ir.py
+++ b/python/tvm/tirx/script/builder/ir.py
@@ -140,6 +140,23 @@ def _get_layout(layout: str | Layout | None, shape: list[PrimExpr], scope: str) 
     return layout
 
 
+def _normalize_prim_type(dtype) -> ir.PrimType:
+    if isinstance(dtype, ir.PrimType):
+        return dtype
+    dtype_str = getattr(dtype, "_dtype_str", None)
+    if dtype_str is not None:
+        return ir.PrimType(dtype_str)
+    if callable(dtype):
+        value = dtype()
+        ty = getattr(value, "ty", None)
+        if isinstance(ty, ir.PrimType):
+            return ty
+        type_annotation = getattr(value, "type_annotation", None)
+        if isinstance(type_annotation, ir.PrimType):
+            return type_annotation
+    return ir.PrimType(dtype)
+
+
 def _get_elem_offset(elem_offset, byte_offset, dtype: str):
     assert elem_offset is None or byte_offset is None, (
         "elem_offset and byte_offset cannot be set at the same time"
@@ -148,7 +165,7 @@ def _get_elem_offset(elem_offset, byte_offset, dtype: str):
         return elem_offset
     if byte_offset is None:
         return None
-    return byte_offset * 8 // (DataType(dtype).bits)
+    return byte_offset * 8 // (DataType(_normalize_prim_type(dtype).dtype).bits)
 
 
 _block_name_suffix = threading.local()
@@ -1801,6 +1818,7 @@ def decl_buffer(
         strides = [Var(s, "int32") if isinstance(s, str) else s for s in strides]
     else:
         strides = []
+    dtype = _normalize_prim_type(dtype)
     decl_frame = _ffi_api.DeclBuffer(  # type: ignore[attr-defined] # pylint: disable=no-member
         shape,
         dtype,

--- a/src/arith/const_fold.h
+++ b/src/arith/const_fold.h
@@ -319,9 +319,9 @@ template <>
 inline ffi::Optional<PrimExpr> TryConstFold<tirx::FloorMod>(PrimExpr a, PrimExpr b) {
   const IntImmNode* ua = a.as<IntImmNode>();
   const IntImmNode* ub = b.as<IntImmNode>();
-  const DataType& utype = a.dtype();
-  if (utype.is_uint() && utype == b.dtype() && ua && ub) {
-    auto as_uint = [](int64_t value, const DataType& dtype) -> uint64_t {
+  PrimType utype = a.ty();
+  if (utype.MatchesCode(DLDataTypeCode::kDLUInt) && utype == b.ty() && ua && ub) {
+    auto as_uint = [](int64_t value, const PrimType& dtype) -> uint64_t {
       uint64_t result = static_cast<uint64_t>(value);
       if (dtype.bits() < 64) {
         result &= (uint64_t{1} << dtype.bits()) - 1;
@@ -329,7 +329,7 @@ inline ffi::Optional<PrimExpr> TryConstFold<tirx::FloorMod>(PrimExpr a, PrimExpr
       return result;
     };
     uint64_t lhs = as_uint(ua->value, utype);
-    uint64_t rhs = as_uint(ub->value, b.dtype());
+    uint64_t rhs = as_uint(ub->value, b.ty());
     TVM_FFI_ICHECK_NE(rhs, 0U) << "Divide by zero";
     return IntImm(utype, static_cast<int64_t>(lhs % rhs));
   }

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -1191,7 +1191,8 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
   // Unsigned (uint32/uint64): the signed IsIndexType block above is skipped for
   // unsigned operands (see the note in the FloorMod handler). Only the
   // OVERFLOW-FREE identities are valid here.
-  if (op->dtype.is_uint() && (op->dtype.bits() == 32 || op->dtype.bits() == 64)) {
+  PrimType op_ty = op->ty();
+  if (op_ty.MatchesCode(DLDataTypeCode::kDLUInt) && (op_ty.bits() == 32 || op_ty.bits() == 64)) {
     TVM_TRY_REWRITE(floordiv(x, x), OneWithTypeLike(x));            // x / x -> 1  (x != 0)
     TVM_TRY_REWRITE_IF(floordiv(x, c1), x, c1.Eval()->value == 1);  // x / 1 -> x
   }
@@ -1318,7 +1319,8 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
   // those rules assume no wraparound, which is UNSOUND for unsigned (e.g.
   // floormod(x*y, y) -> 0 fails when x*y wraps mod 2^bits). Only the
   // OVERFLOW-FREE identities are valid here.
-  if (op->dtype.is_uint() && (op->dtype.bits() == 32 || op->dtype.bits() == 64)) {
+  PrimType op_ty = op->ty();
+  if (op_ty.MatchesCode(DLDataTypeCode::kDLUInt) && (op_ty.bits() == 32 || op_ty.bits() == 64)) {
     TVM_TRY_REWRITE(floormod(x, x), ZeroWithTypeLike(x));  // x % x -> 0  (x != 0)
     TVM_TRY_REWRITE_IF(floormod(x, c1), ZeroWithTypeLike(x),
                        c1.Eval()->value == 1);  // x % 1 -> 0

--- a/tests/python/tirx/test_op_namespace_cleanup.py
+++ b/tests/python/tirx/test_op_namespace_cleanup.py
@@ -95,7 +95,7 @@ def test_builtin_expression_ops_are_not_tile_primitives():
 
     cast = T.cast(x, "float32")
     assert isinstance(cast, tvm.tirx.Cast)
-    assert cast.dtype == "float32"
+    assert cast.ty.dtype == "float32"
 
     sqrt = T.sqrt(y)
     assert sqrt.op.name == "tirx.sqrt"

--- a/tests/python/tirx/transform/test_stmt_functor.py
+++ b/tests/python/tirx/transform/test_stmt_functor.py
@@ -1006,7 +1006,7 @@ class NegateIntImmMutator(StmtExprMutator):
 
     def visit_int_imm_(self, op):
         # Create a new IntImm with negated value
-        return tir.IntImm(op.dtype, -op.value)
+        return tir.IntImm(op.ty, -op.value)
 
 
 def test_mutator_transformation():


### PR DESCRIPTION
## Summary

- Update arithmetic simplifier code for upstream `PrimType` APIs after rebasing onto Apache TVM main.
- Normalize dtype handling across TIRx script builders, buffer printing, CUDA elementwise packed dispatch, TRN private alloc, and TCGEN05 GEMM async descriptor encoding.
- Update tests that still referenced the old `.dtype` field on TIR expressions.

## Root Cause

The latest Apache TVM main moved several TIR expression/type paths from the old `.dtype`/`DataType` style to `PrimType` via `.ty`. Local TIRx code still used dtype objects directly as strings or mapping keys, which caused compile failures and silent packed-dispatch fallbacks after the rebase.

## Validation

- `cmake --build build --parallel`
- `python -m tirx_kernels.tir_bench --check-imports`
- `python -m tirx_kernels.registry --cc 10 --strict`
- `python -m pytest tests/python/tirx/ -n 16` passed with `2033 passed, 39 skipped, 3 xpassed`
- `pre-commit run --files ...`
- Focused regression: `test_cast_vec2_packed_dispatch`, `test_cast_warpgroup_src_layout_to_flat_uses_vec2_intrinsic`, and `test_gemm_tcgen05_cta_group_1[task0]`
