### PR TITLE
feat(op-dispatch): add non-bulk async copy variant

### DIFF
--- a/python/tvm/backend/cuda/operator/tile_primitive/copy_async/cp_async.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy_async/cp_async.py
@@ -15,16 +15,25 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Implementation of copy_async operator dispatches for CUDA targets.
+"""copy_async dispatch variant: non-bulk-copy (cp.async)."""
 
-Registered op: copy_async (4 variants).
-See the @register_dispatch blocks in each submodule for detailed documentation
-with before/after IR examples.
-"""
+from tvm.tirx import PrimFunc
+from tvm.tirx.operator.tile_primitive import DispatchContext, predicate, register_dispatch
+from tvm.tirx.tile_primitive import TilePrimitiveCall
 
-from .cp_async import *
-from .dsmem import *
-from .ldgsts import *
-from .tcgen05_cp import *
-from .tcgen05_ldst import *
-from .tma import *
+from ..common import CopyInstType, copy_vec_load_impl, validate_copy_op
+
+
+@register_dispatch(
+    "copy_async",
+    "cuda",
+    variant="non-bulk-copy",
+    priority=20,
+    when=[
+        predicate(
+            "validate_copy_op", lambda op, sctx: (validate_copy_op(op, sctx), "not a valid copy op")
+        )
+    ],
+)
+def copy_async_dispatch_cp_async(op: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
+    return copy_vec_load_impl(op, sctx, CopyInstType.CP_ASYNC)


### PR DESCRIPTION
## Summary

- Register the CUDA `copy_async` variant `non-bulk-copy` using `cp.async`.
- Import the variant from the CUDA copy-async dispatch package.
- Provide the only TVM-side extension required by MegaKernelMOE in spectrometerHBH/tirx-kernels#1.

This PR does not modify Relax, the VM runtime, FlashInfer integration, parser compatibility, benchmark timers, or unrelated copy code generation.

## Validation

- `cmake --build build --parallel 16`
- `pre-commit run --files python/tvm/backend/cuda/operator/tile_primitive/copy_async/__init__.py python/tvm/backend/cuda/operator/tile_primitive/copy_async/cp_async.py`
- With spectrometerHBH/tirx-kernels#1: `python -m pytest tests/test_megakernel_runtime.py --override-ini=addopts= -q` (`6 passed`)
- Companion benchmark tests: `python -m pytest tests/test_bench_cli.py tests/test_bench_suite.py --override-ini=addopts= -q` (`14 passed`)