### PR TITLE
refactor(infra): always build and run all reference impls

### DIFF
--- a/python/tvm/tirx/bench.py
+++ b/python/tvm/tirx/bench.py
@@ -395,44 +395,6 @@ def _bench_legacy_callable(func, warmup, repeat, proton_name, debug, nsight, flu
     return start_event.elapsed_time(end_event) / repeat * 1000.0
 
 
-# Labels identifying our own kernel (vs external reference impls). Must match
-# OUR_IMPLS in tir-bench's ratio_diff.py. Used by the TIRX_BENCH_IMPLS filter.
-OURS_IMPLS = frozenset({"tir", "tirx"})
-
-
-def bench_impls_mode():
-    """Current impl-selection mode: 'all' (default), 'ours', or 'baseline'.
-
-    Set via the ``TIRX_BENCH_IMPLS`` env var (by tir-bench ``run.py --impls``).
-    A kernel's ``run_bench`` can use this to skip *building/warming* reference
-    impls (e.g. flashinfer autotune, deepgemm/cublas ext setup) that ``bench``'s
-    filter alone cannot avoid, since that setup runs before ``bench`` is called.
-    """
-    mode = os.environ.get("TIRX_BENCH_IMPLS", "all").lower()
-    if mode not in {"all", "ours", "baseline"}:
-        raise ValueError(f"TIRX_BENCH_IMPLS must be 'all', 'ours', or 'baseline', got {mode!r}")
-    return mode
-
-
-def bench_only_ours():
-    """True when only our own kernel should be benched (reference setup skippable)."""
-    return bench_impls_mode() == "ours"
-
-
-def filter_impls(funcs):
-    """Filter a ``{label: callable}`` impl map per the current ``bench_impls_mode``.
-
-    Call this right after building ``funcs`` so any subsequent
-    ``if "<ref>" in funcs:`` reference-setup blocks are skipped in 'ours' mode.
-    """
-    mode = bench_impls_mode()
-    if mode == "ours":
-        return {n: f for n, f in funcs.items() if n in OURS_IMPLS}
-    if mode == "baseline":
-        return {n: f for n, f in funcs.items() if n not in OURS_IMPLS}
-    return funcs
-
-
 def bench_tk(
     funcs,
     input_factory=None,
@@ -470,10 +432,8 @@ def bench_tk(
         kernel(s); external baselines go in ``references``.
     references : dict[str, callable], optional
         Map of reference-impl name to a no-arg *builder* that does the heavy
-        import/setup and returns the run callable.  Builders run lazily and only
-        when that impl will actually be benched (skipped entirely under
-        ``--impls ours``); a builder that raises is recorded as a
-        ``BASELINE_ERROR`` instead of failing the workload.
+        import/setup and returns the run callable.  A builder that raises is
+        recorded as a ``BASELINE_ERROR`` instead of failing the workload.
     input_factory : callable
         Factory returning ``(case, input_bytes)`` for one benchmark group.
     warmup : int
@@ -532,49 +492,24 @@ def bench_tk(
         if not callable(func):
             raise TypeError(f"funcs[{name!r}] must be callable")
 
-    # Select impls for this run. ``funcs`` holds our own kernel(s); external
-    # baselines are passed as ``references`` (name -> no-arg builder). A builder
-    # is invoked here ONLY when its impl will actually be benched, so --impls
-    # ours skips all reference setup, --impls baseline skips ours, and a builder
-    # that fails is recorded as a BASELINE_ERROR rather than failing the
-    # workload. Legacy kernels that put references directly in ``funcs`` are
-    # still handled by the label filter (filter_impls) below.
-    funcs = filter_impls(funcs)
+    # ``funcs`` holds our own kernel(s); external baselines are passed as
+    # ``references`` (name -> no-arg builder). A builder that fails is recorded
+    # as a BASELINE_ERROR rather than failing the workload.
     build_errors: dict[str, str] = {}
-    if bench_impls_mode() != "ours":
-        for ref_name, builder in (references or {}).items():
-            if not isinstance(ref_name, str) or not callable(builder):
-                raise TypeError("references must map a name to a no-arg builder callable")
-            try:
-                ref_fn = builder()
-            except Exception as e:
-                build_errors[ref_name] = str(e)
-                print(f"BASELINE_ERROR: {ref_name}: {e}", file=sys.stderr)
-                continue
-            if ref_fn is None:
-                continue
-            if not callable(ref_fn):
-                raise TypeError(f"references[{ref_name!r}] builder must return a callable")
-            funcs = {**funcs, ref_name: ref_fn}
-
-    if not funcs:
-        # Nothing to bench in this mode (e.g. 'ours' on a kernel with no tir
-        # impl, or 'baseline' with no references). Return an empty-but-valid
-        # result so the workload is a no-op.
-        return {
-            "impls": {},
-            "round_samples": {},
-            "errors": build_errors,
-            "timer": timer,
-            "benchmark_protocol": {
-                "warmup": warmup,
-                "repeat": repeat,
-                "cooldown_s": cooldown_s,
-                "rounds": rounds,
-                "round_cooldown_s": round_cooldown_s,
-                "order": [],
-            },
-        }
+    for ref_name, builder in (references or {}).items():
+        if not isinstance(ref_name, str) or not callable(builder):
+            raise TypeError("references must map a name to a no-arg builder callable")
+        try:
+            ref_fn = builder()
+        except Exception as e:
+            build_errors[ref_name] = str(e)
+            print(f"BASELINE_ERROR: {ref_name}: {e}", file=sys.stderr)
+            continue
+        if ref_fn is None:
+            continue
+        if not callable(ref_fn):
+            raise TypeError(f"references[{ref_name!r}] builder must return a callable")
+        funcs = {**funcs, ref_name: ref_fn}
 
     inputs, protocol = prepare_input_groups(input_factory, l2_bytes=l2_bytes)
     num_groups = len(inputs)
@@ -1021,10 +956,8 @@ def bench(
         ``references``.
     references : dict[str, callable], optional
         Map of reference-impl name to a no-arg *builder* that does the heavy
-        import/setup and returns the no-arg run callable.  Builders run lazily
-        and only when that impl will actually be benched (skipped entirely under
-        ``--impls ours``); a builder that raises is recorded as a
-        ``BASELINE_ERROR`` instead of failing the workload.
+        import/setup and returns the no-arg run callable.  A builder that raises
+        is recorded as a ``BASELINE_ERROR`` instead of failing the workload.
     warmup : int, optional
         Warmup time budget (ms) for the ``event`` timer. ``None`` (default) defers
         to ``_do_bench_event``'s own default; pass a value only to override. Ignored
@@ -1101,28 +1034,24 @@ def bench(
         if not callable(func):
             raise TypeError(f"funcs[{name!r}] must be callable")
 
-    # Select impls for this run. ``funcs`` holds our own kernel(s); external
-    # baselines are passed as ``references`` (name -> no-arg builder). A builder
-    # is invoked here ONLY when its impl will actually be benched, so --impls
-    # ours skips all reference setup, --impls baseline skips ours, and a builder
-    # that fails is recorded as a BASELINE_ERROR rather than failing the workload.
-    funcs = filter_impls(funcs)
+    # ``funcs`` holds our own kernel(s); external baselines are passed as
+    # ``references`` (name -> no-arg builder). A builder that fails is recorded
+    # as a BASELINE_ERROR rather than failing the workload.
     build_errors: dict[str, str] = {}
-    if bench_impls_mode() != "ours":
-        for ref_name, builder in (references or {}).items():
-            if not isinstance(ref_name, str) or not callable(builder):
-                raise TypeError("references must map a name to a no-arg builder callable")
-            try:
-                ref_fn = builder()
-            except Exception as e:
-                build_errors[ref_name] = str(e)
-                print(f"BASELINE_ERROR: {ref_name}: {e}", file=sys.stderr)
-                continue
-            if ref_fn is None:
-                continue
-            if not callable(ref_fn):
-                raise TypeError(f"references[{ref_name!r}] builder must return a callable")
-            funcs = {**funcs, ref_name: ref_fn}
+    for ref_name, builder in (references or {}).items():
+        if not isinstance(ref_name, str) or not callable(builder):
+            raise TypeError("references must map a name to a no-arg builder callable")
+        try:
+            ref_fn = builder()
+        except Exception as e:
+            build_errors[ref_name] = str(e)
+            print(f"BASELINE_ERROR: {ref_name}: {e}", file=sys.stderr)
+            continue
+        if ref_fn is None:
+            continue
+        if not callable(ref_fn):
+            raise TypeError(f"references[{ref_name!r}] builder must return a callable")
+        funcs = {**funcs, ref_name: ref_fn}
 
     # Resolve the timer function once. Only forward warmup/repeat/cudagraph_rep when a
     # caller explicitly overrode them; otherwise the _do_bench_* signature default
@@ -1158,18 +1087,6 @@ def bench(
         "round_cooldown_s": round_cooldown_s,
         "order": list(funcs.keys()),
     }
-
-    if not funcs:
-        # Nothing to bench in this mode (e.g. 'ours' on a kernel with no tir
-        # impl, or 'baseline' with no references). Return an empty-but-valid
-        # result so the workload is a no-op.
-        return {
-            "impls": {},
-            "round_samples": {},
-            "errors": build_errors,
-            "timer": timer,
-            "benchmark_protocol": protocol,
-        }
 
     round_samples: dict[str, list[float]] = {}
     for round_idx in range(rounds):


### PR DESCRIPTION
## Summary
- Drop the `--impls` / `TIRX_BENCH_IMPLS` filter primitives (`OURS_IMPLS`, `bench_impls_mode`, `bench_only_ours`, `filter_impls`).
- `bench()` and `bench_tk()` now always build and time every reference impl passed via `references`; removed the "ours"-mode skip guard and the now-dead empty-funcs early return.
- A reference builder that raises is still recorded as `BASELINE_ERROR` instead of failing the workload.

## Test plan
- [x] `ruff check` + `ruff format` + `pre-commit` clean
- [x] `python -c "import tvm.tirx.bench"` OK
- [x] Real GPU: tirx-kernels bench suite (with the matching tirx-kernels PR) runs end-to-end, both our kernel and reference impls timed

Pairs with the tirx-kernels PR that removes the `--impls` CLI and collapses the baselines; merge the tirx-kernels PR first so no kernel imports the removed symbols.