### PR TITLE
feat(layout): buffer dim-surgery views (unflatten/flatten/select/narrow/sub/rearrange)

### DIFF
--- a/python/tvm/tirx/buffer.py
+++ b/python/tvm/tirx/buffer.py
@@ -17,6 +17,7 @@
 """Abstraction for array data structures."""
 
 import functools
+import re
 from numbers import Integral
 
 import tvm_ffi
@@ -470,6 +471,224 @@ class Buffer(Object, Scriptable):
             new_layout,
         )
 
+    # ------------------------------------------------------------------
+    # Dimension-surgery views (torch-aligned): unflatten / flatten /
+    # select / narrow, the numpy-style ``sub`` indexer, and einops-style
+    # ``rearrange``. All return derived views sharing this buffer's data;
+    # the physical placement (layout iters + swizzle) is carried, never
+    # restated, and data is never moved: an operation either yields a
+    # valid view or raises.
+    # ------------------------------------------------------------------
+
+    def _normalized_dim(self, dim, name):
+        ndim = len(self.shape)
+        if dim < 0:
+            dim += ndim
+        if not 0 <= dim < ndim:
+            raise ValueError(f"{name}: dim {dim} out of range for buffer of rank {ndim}")
+        return dim
+
+    def unflatten(self, dim, sizes) -> "Buffer":
+        """Split ``dim`` into the given factor sizes (row-major).
+
+        Torch-aligned: ``x.unflatten(1, (4, 4, 4))``; one size may be ``-1``
+        and is inferred from the dim's extent. Pure view: the layout is
+        carried and regrouped against the new shape.
+        """
+        dim = self._normalized_dim(dim, "unflatten")
+        sizes = list(sizes)
+        negatives = [i for i, s in enumerate(sizes) if isinstance(s, int) and s == -1]
+        if len(negatives) > 1:
+            raise ValueError("unflatten: at most one -1 is allowed in sizes")
+        if negatives:
+            known = functools.reduce(
+                lambda a, b: a * b,
+                [s for i, s in enumerate(sizes) if i != negatives[0]],
+                1,
+            )
+            extent = self.shape[dim]
+            extent = int(extent) if isinstance(extent, tvm.tirx.IntImm) else extent
+            sizes[negatives[0]] = extent // known
+        new_shape = list(self.shape[:dim]) + sizes + list(self.shape[dim + 1 :])
+        return self.view(*new_shape)
+
+    def flatten(self, start_dim=0, end_dim=-1) -> "Buffer":
+        """Merge dims ``start_dim..end_dim`` into one (torch-aligned).
+
+        Unlike torch this never copies: the merge is expressed in the layout
+        (a logical axis may carry several strided iters), so it either yields
+        a view or the downstream consumer rejects the layout loudly.
+        """
+        start = self._normalized_dim(start_dim, "flatten")
+        end = self._normalized_dim(end_dim, "flatten")
+        if end < start:
+            raise ValueError(f"flatten: end_dim {end} < start_dim {start}")
+        merged = functools.reduce(lambda a, b: a * b, list(self.shape[start : end + 1]), 1)
+        new_shape = [*self.shape[:start], merged, *self.shape[end + 1 :]]
+        return self.view(*new_shape)
+
+    def _surgery_parts(self):
+        """Split ``self.layout`` into (inner tile layout, optional swizzle)."""
+        layout = self.layout
+        swizzle = None
+        if isinstance(layout, tvm.tirx.layout.ComposeLayout):
+            swizzle = layout.swizzle
+            layout = layout.tile_layout
+        return layout, swizzle
+
+    @staticmethod
+    def _rewrap_swizzle(layout, swizzle):
+        if swizzle is not None:
+            return tvm.tirx.layout.ComposeLayout(swizzle, layout)
+        return layout
+
+    @staticmethod
+    def _dim_group_offset(group, index):
+        """Offset of ``index`` along a dim made of the given layout iters.
+
+        The dim's iters are outer→inner in row-major coordinate order:
+        decompose ``index`` mixed-radix over their extents and weight each
+        coordinate by its iter's stride. A single-iter dim reduces to
+        ``index * stride``. ``index`` may be a PrimExpr; multi-iter dims
+        need concrete inner extents.
+        """
+        if len(group) == 1:
+            return index * group[0].stride
+        extents = []
+        for it in group[1:]:
+            extent = it.extent
+            if not isinstance(extent, tvm.tirx.IntImm):
+                raise ValueError(
+                    "select/narrow: dim with multiple layout iters requires concrete iter extents"
+                )
+            extents.append(int(extent))
+        offset = None
+        remaining = index
+        for pos, it in enumerate(group):
+            inner = functools.reduce(lambda a, b: a * b, extents[pos:], 1)
+            if inner == 1:
+                coord = remaining
+            elif isinstance(remaining, Integral):
+                coord = remaining // inner
+                remaining = remaining % inner
+            else:
+                coord = tvm.tirx.floordiv(remaining, inner)
+                remaining = tvm.tirx.floormod(remaining, inner)
+            term = coord * it.stride
+            offset = term if offset is None else offset + term
+        return offset
+
+    def _rebuild_view(self, new_shape, new_shard, grouped, swizzle, extra_offset):
+        new_layout = tvm.tirx.layout.TileLayout.from_iters(
+            new_shard, list(grouped.replica), dict(grouped.offset.items())
+        )
+        new_layout = self._rewrap_swizzle(new_layout, swizzle)
+        elem_offset = self.elem_offset
+        if extra_offset is not None:
+            elem_offset = elem_offset + extra_offset
+        return tvm.tirx.script.builder.decl_buffer(
+            new_shape,
+            self.dtype,
+            self.data,
+            self.strides,
+            elem_offset,
+            None,
+            self.scope(),
+            self.data_alignment,
+            self.offset_factor,
+            "",
+            self.axis_separators,
+            new_layout,
+        )
+
+    def select(self, dim, index) -> "Buffer":
+        """Return a view with ``dim`` removed, fixed at ``index``.
+
+        Torch-aligned (``Tensor.select``); ``index`` may be a dynamic
+        PrimExpr, folded into the view's ``elem_offset`` through the dim's
+        layout iters.
+        """
+        dim = self._normalized_dim(dim, "select")
+        layout, swizzle = self._surgery_parts()
+        grouped, seps = layout.group(list(self.shape))
+        iters = list(grouped.shard)
+        lo, hi = seps[dim], seps[dim + 1]
+        offset = self._dim_group_offset(iters[lo:hi], index)
+        new_shape = list(self.shape[:dim]) + list(self.shape[dim + 1 :])
+        new_shard = iters[:lo] + iters[hi:]
+        return self._rebuild_view(new_shape, new_shard, grouped, swizzle, offset)
+
+    def narrow(self, dim, start, length) -> "Buffer":
+        """Return a view of ``dim`` narrowed to ``[start, start + length)``.
+
+        Torch-aligned (``Tensor.narrow``); ``start`` may be a dynamic
+        PrimExpr when the dim maps to a single layout iter. For dims made of
+        several iters, ``start`` and ``length`` must be concrete multiples of
+        the inner iter block so the range stays a contiguous iter prefix.
+        """
+        dim = self._normalized_dim(dim, "narrow")
+        layout, swizzle = self._surgery_parts()
+        grouped, seps = layout.group(list(self.shape))
+        iters = list(grouped.shard)
+        lo, hi = seps[dim], seps[dim + 1]
+        group = iters[lo:hi]
+        Iter = tvm.tirx.layout.Iter
+        if len(group) == 1:
+            it = group[0]
+            offset = start * it.stride
+            new_group = [Iter(length, it.stride, it.axis)]
+        else:
+            inner = 1
+            for it in group[1:]:
+                extent = it.extent
+                if not isinstance(extent, tvm.tirx.IntImm):
+                    raise ValueError(
+                        "narrow: dim with multiple layout iters requires concrete iter extents"
+                    )
+                inner *= int(extent)
+            if not (isinstance(start, Integral) and isinstance(length, Integral)):
+                raise ValueError(
+                    f"narrow: dim {dim} is made of {len(group)} layout iters; "
+                    f"start/length must be concrete multiples of {inner}"
+                )
+            if start % inner != 0 or length % inner != 0:
+                raise ValueError(
+                    f"narrow: dim {dim} start/length must be multiples of the "
+                    f"inner iter block {inner}; got start={start} length={length}"
+                )
+            outer = group[0]
+            offset = (start // inner) * outer.stride
+            new_group = [Iter(length // inner, outer.stride, outer.axis), *group[1:]]
+        new_shape = list(self.shape)
+        new_shape[dim] = length
+        new_shard = iters[:lo] + new_group + iters[hi:]
+        return self._rebuild_view(new_shape, new_shard, grouped, swizzle, offset)
+
+    @property
+    def sub(self) -> "_SubIndexer":
+        """Numpy-style view indexer: ``buf.sub[2, 4:8, ::4]``.
+
+        Unlike plain ``buf[...]`` (BufferLoad for scalar indices, extent-1
+        BufferRegion dims for tile-primitive operands), ``sub`` follows numpy
+        basic-indexing semantics as a *view constructor*: an integer index
+        removes the dim (``select``), ``a:b`` narrows it, and ``a::s`` takes
+        every s-th element (requires the extent divisible by ``s`` and
+        ``a < s``). Trailing dims are kept whole.
+        """
+        return _SubIndexer(self)
+
+    def rearrange(self, pattern, **sizes) -> "Buffer":
+        """Einops-style dimension rearrangement, e.g.
+        ``buf.rearrange("b (s w r) c -> b w (s r) c", w=4, r=4)``.
+
+        Pure bijective reshuffling (split / permute / merge) compiled onto
+        :meth:`unflatten`, :meth:`permute` and :meth:`flatten`; indexing is
+        out of scope (use :meth:`select` / ``sub``). Composite-axis sizes
+        come from keyword arguments; at most one factor per composite may be
+        omitted and is inferred from the dim extent.
+        """
+        return _rearrange(self, pattern, **sizes)
+
     def __getitem__(self, indices):
         from ..arith import Analyzer  # pylint: disable=import-outside-toplevel
         from .expr import BufferLoad, Ramp  # pylint: disable=import-outside-toplevel
@@ -519,6 +738,173 @@ class Buffer(Object, Scriptable):
                 else:
                     expr_indices.append(index)
             return BufferLoad(self, expr_indices)
+
+
+_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _rearrange_parse_side(text: str, pattern: str) -> list[list[str]]:
+    """Parse one side of a pattern into a list of axis groups.
+
+    Each top-level entry corresponds to one buffer dim: either a single axis
+    name or a parenthesized composite of axis names.
+    """
+    groups: list[list[str]] = []
+    tokens = text.replace("(", " ( ").replace(")", " ) ").split()
+    current: list[str] | None = None
+    for token in tokens:
+        if token == "(":
+            if current is not None:
+                raise ValueError(f"rearrange: nested '(' in pattern {pattern!r}")
+            current = []
+        elif token == ")":
+            if current is None:
+                raise ValueError(f"rearrange: unmatched ')' in pattern {pattern!r}")
+            if not current:
+                raise ValueError(f"rearrange: empty '()' group in pattern {pattern!r}")
+            groups.append(current)
+            current = None
+        else:
+            if not _NAME_RE.match(token):
+                raise ValueError(f"rearrange: bad axis name {token!r} in pattern {pattern!r}")
+            if current is not None:
+                current.append(token)
+            else:
+                groups.append([token])
+    if current is not None:
+        raise ValueError(f"rearrange: unmatched '(' in pattern {pattern!r}")
+    if not groups:
+        raise ValueError(f"rearrange: empty side in pattern {pattern!r}")
+    return groups
+
+
+def _rearrange_flat_names(groups: list[list[str]], pattern: str) -> list[str]:
+    names = [name for group in groups for name in group]
+    if len(set(names)) != len(names):
+        raise ValueError(f"rearrange: duplicate axis name in pattern {pattern!r}")
+    return names
+
+
+def _rearrange(buffer, pattern, **sizes):
+    """Apply an einops-style rearrangement pattern to ``buffer`` as a view."""
+    if "->" not in pattern:
+        raise ValueError(f"rearrange: pattern {pattern!r} must contain '->'")
+    lhs_text, rhs_text = pattern.split("->", 1)
+    lhs = _rearrange_parse_side(lhs_text, pattern)
+    rhs = _rearrange_parse_side(rhs_text, pattern)
+    lhs_names = _rearrange_flat_names(lhs, pattern)
+    rhs_names = _rearrange_flat_names(rhs, pattern)
+    if set(lhs_names) != set(rhs_names):
+        missing = set(lhs_names) ^ set(rhs_names)
+        raise ValueError(
+            f"rearrange: axes {sorted(missing)} appear on only one side of {pattern!r}"
+        )
+    unknown = set(sizes) - set(lhs_names)
+    if unknown:
+        raise ValueError(f"rearrange: sizes for unknown axes {sorted(unknown)} in {pattern!r}")
+    if len(lhs) != len(buffer.shape):
+        raise ValueError(
+            f"rearrange: pattern {pattern!r} has {len(lhs)} input dims, "
+            f"buffer has rank {len(buffer.shape)}"
+        )
+
+    # Resolve every axis size. Non-composite axes take the dim extent;
+    # composite factors come from ``sizes`` with at most one inferred.
+    axis_size: dict[str, object] = dict(sizes)
+    for dim, group in enumerate(lhs):
+        extent = buffer.shape[dim]
+        extent = int(extent) if isinstance(extent, tvm.tirx.IntImm) else extent
+        if len(group) == 1:
+            name = group[0]
+            if name not in axis_size:
+                axis_size[name] = extent
+            continue
+        unknown_factors = [name for name in group if name not in axis_size]
+        if len(unknown_factors) > 1:
+            raise ValueError(
+                f"rearrange: composite {'(' + ' '.join(group) + ')'} in {pattern!r} "
+                f"has multiple unknown factors {unknown_factors}; pass their sizes"
+            )
+        if unknown_factors:
+            known = 1
+            for name in group:
+                if name != unknown_factors[0]:
+                    known = known * axis_size[name]
+            axis_size[unknown_factors[0]] = extent // known
+
+    # 1. Split composites, right-to-left so dim indices stay valid.
+    result = buffer
+    for dim in range(len(lhs) - 1, -1, -1):
+        group = lhs[dim]
+        if len(group) > 1:
+            result = result.unflatten(dim, tuple(axis_size[name] for name in group))
+
+    # 2. Permute flat axes into the output order.
+    perm = [lhs_names.index(name) for name in rhs_names]
+    if perm != list(range(len(perm))):
+        result = result.permute(*perm)
+
+    # 3. Merge output composites, right-to-left over flat positions.
+    position = len(rhs_names)
+    for group in reversed(rhs):
+        position -= len(group)
+        if len(group) > 1:
+            result = result.flatten(position, position + len(group) - 1)
+    return result
+
+
+class _SubIndexer:
+    """Indexer object returned by :attr:`Buffer.sub`.
+
+    Translates numpy basic indexing into a chain of
+    :meth:`Buffer.select` / :meth:`Buffer.narrow` /
+    :meth:`Buffer.unflatten` view operations.
+    """
+
+    def __init__(self, buffer: Buffer):
+        self._buffer = buffer
+
+    def __getitem__(self, indices) -> Buffer:
+        if not isinstance(indices, tuple):
+            indices = (indices,)
+        buf = self._buffer
+        if len(indices) > len(buf.shape):
+            raise ValueError(f"sub: {len(indices)} indices for buffer of rank {len(buf.shape)}")
+        dim = 0
+        for item in indices:
+            if isinstance(item, slice):
+                step = item.step
+                if step is None or (isinstance(step, Integral) and step == 1):
+                    if item.start is None and item.stop is None:
+                        dim += 1
+                        continue
+                    start = 0 if item.start is None else item.start
+                    stop = buf.shape[dim] if item.stop is None else item.stop
+                    buf = buf.narrow(dim, start, stop - start)
+                    dim += 1
+                else:
+                    if not isinstance(step, Integral) or step <= 0:
+                        raise ValueError(f"sub: step must be a positive int, got {step!r}")
+                    if item.stop is not None:
+                        raise ValueError("sub: a stop bound with a step is not supported")
+                    extent = buf.shape[dim]
+                    if not isinstance(extent, tvm.tirx.IntImm):
+                        raise ValueError("sub: a stepped slice requires a concrete dim extent")
+                    extent = int(extent)
+                    if extent % step != 0:
+                        raise ValueError(
+                            f"sub: dim extent {extent} is not divisible by step {step}"
+                        )
+                    start = 0 if item.start is None else item.start
+                    # a::s over N = unflatten into (N//s, s) and fix the
+                    # remainder coordinate at a (requires a < s).
+                    if isinstance(start, Integral) and start >= step:
+                        raise ValueError(f"sub: start {start} must be < step {step}")
+                    buf = buf.unflatten(dim, (extent // step, step)).select(dim + 1, start)
+                    dim += 1
+            else:
+                buf = buf.select(dim, item)
+        return buf
 
 
 def decl_buffer(

--- a/python/tvm/tirx/buffer.py
+++ b/python/tvm/tirx/buffer.py
@@ -488,15 +488,30 @@ class Buffer(Object, Scriptable):
             raise ValueError(f"{name}: dim {dim} out of range for buffer of rank {ndim}")
         return dim
 
+    @staticmethod
+    def _concrete_int(value):
+        """Return ``value`` as a python int when it is statically known."""
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, Integral):
+            return int(value)
+        if isinstance(value, tvm.tirx.IntImm):
+            return int(value)
+        return None
+
     def unflatten(self, dim, sizes) -> "Buffer":
         """Split ``dim`` into the given factor sizes (row-major).
 
         Torch-aligned: ``x.unflatten(1, (4, 4, 4))``; one size may be ``-1``
         and is inferred from the dim's extent. Pure view: the layout is
-        carried and regrouped against the new shape.
+        carried and regrouped against the new shape. The split must be exact:
+        when the extent and factors are statically known, a non-bijective
+        factorization is rejected (symbolic values are the caller's
+        responsibility).
         """
         dim = self._normalized_dim(dim, "unflatten")
         sizes = list(sizes)
+        extent = self._concrete_int(self.shape[dim])
         negatives = [i for i, s in enumerate(sizes) if isinstance(s, int) and s == -1]
         if len(negatives) > 1:
             raise ValueError("unflatten: at most one -1 is allowed in sizes")
@@ -506,9 +521,28 @@ class Buffer(Object, Scriptable):
                 [s for i, s in enumerate(sizes) if i != negatives[0]],
                 1,
             )
-            extent = self.shape[dim]
-            extent = int(extent) if isinstance(extent, tvm.tirx.IntImm) else extent
-            sizes[negatives[0]] = extent // known
+            known_c = self._concrete_int(known)
+            if extent is not None and known_c is not None:
+                if known_c <= 0 or extent % known_c != 0:
+                    raise ValueError(
+                        f"unflatten: dim {dim} extent {extent} is not divisible "
+                        f"by the known factors (product {known_c})"
+                    )
+                sizes[negatives[0]] = extent // known_c
+            else:
+                raw_extent = self.shape[dim]
+                raw_extent = (
+                    int(raw_extent) if isinstance(raw_extent, tvm.tirx.IntImm) else raw_extent
+                )
+                sizes[negatives[0]] = raw_extent // known
+        else:
+            product = functools.reduce(lambda a, b: a * b, sizes, 1)
+            product_c = self._concrete_int(product)
+            if extent is not None and product_c is not None and product_c != extent:
+                raise ValueError(
+                    f"unflatten: sizes {sizes} multiply to {product_c}, "
+                    f"but dim {dim} has extent {extent}"
+                )
         new_shape = list(self.shape[:dim]) + sizes + list(self.shape[dim + 1 :])
         return self.view(*new_shape)
 
@@ -606,9 +640,18 @@ class Buffer(Object, Scriptable):
 
         Torch-aligned (``Tensor.select``); ``index`` may be a dynamic
         PrimExpr, folded into the view's ``elem_offset`` through the dim's
-        layout iters.
+        layout iters. Statically known indices are bounds-checked; dynamic
+        indices are the caller's responsibility.
         """
         dim = self._normalized_dim(dim, "select")
+        index_c = self._concrete_int(index)
+        extent_c = self._concrete_int(self.shape[dim])
+        if index_c is not None:
+            if index_c < 0 or (extent_c is not None and index_c >= extent_c):
+                raise ValueError(
+                    f"select: index {index_c} out of range for dim {dim} "
+                    f"of extent {extent_c if extent_c is not None else self.shape[dim]}"
+                )
         layout, swizzle = self._surgery_parts()
         grouped, seps = layout.group(list(self.shape))
         iters = list(grouped.shard)
@@ -625,8 +668,28 @@ class Buffer(Object, Scriptable):
         PrimExpr when the dim maps to a single layout iter. For dims made of
         several iters, ``start`` and ``length`` must be concrete multiples of
         the inner iter block so the range stays a contiguous iter prefix.
+        Statically known bounds are checked (``start >= 0``, ``length >= 1``,
+        ``start + length <= extent``); dynamic values are the caller's
+        responsibility.
         """
         dim = self._normalized_dim(dim, "narrow")
+        start_c = self._concrete_int(start)
+        length_c = self._concrete_int(length)
+        extent_c = self._concrete_int(self.shape[dim])
+        if start_c is not None and start_c < 0:
+            raise ValueError(f"narrow: start {start_c} must be non-negative")
+        if length_c is not None and length_c < 1:
+            raise ValueError(f"narrow: length {length_c} must be positive")
+        if (
+            start_c is not None
+            and length_c is not None
+            and extent_c is not None
+            and start_c + length_c > extent_c
+        ):
+            raise ValueError(
+                f"narrow: range [{start_c}, {start_c + length_c}) exceeds "
+                f"dim {dim} extent {extent_c}"
+            )
         layout, swizzle = self._surgery_parts()
         grouped, seps = layout.group(list(self.shape))
         iters = list(grouped.shard)
@@ -830,6 +893,18 @@ def _rearrange(buffer, pattern, **sizes):
             for name in group:
                 if name != unknown_factors[0]:
                     known = known * axis_size[name]
+            known_c = Buffer._concrete_int(known)
+            extent_c = Buffer._concrete_int(extent)
+            if (
+                extent_c is not None
+                and known_c is not None
+                and (known_c <= 0 or extent_c % known_c != 0)
+            ):
+                raise ValueError(
+                    f"rearrange: composite {'(' + ' '.join(group) + ')'} in "
+                    f"{pattern!r} does not factor dim extent {extent_c} "
+                    f"(known factors multiply to {known_c})"
+                )
             axis_size[unknown_factors[0]] = extent // known
 
     # 1. Split composites, right-to-left so dim indices stay valid.
@@ -897,9 +972,12 @@ class _SubIndexer:
                         )
                     start = 0 if item.start is None else item.start
                     # a::s over N = unflatten into (N//s, s) and fix the
-                    # remainder coordinate at a (requires a < s).
-                    if isinstance(start, Integral) and start >= step:
-                        raise ValueError(f"sub: start {start} must be < step {step}")
+                    # remainder coordinate at a (requires 0 <= a < s).
+                    start_c = Buffer._concrete_int(start)
+                    if start_c is not None and not 0 <= start_c < step:
+                        raise ValueError(
+                            f"sub: stepped-slice start {start_c} must be in [0, {step})"
+                        )
                     buf = buf.unflatten(dim, (extent // step, step)).select(dim + 1, start)
                     dim += 1
             else:

--- a/python/tvm/tirx/buffer.py
+++ b/python/tvm/tirx/buffer.py
@@ -620,7 +620,38 @@ class Buffer(Object, Scriptable):
             offset = term if offset is None else offset + term
         return offset
 
-    def _rebuild_view(self, new_shape, new_shard, grouped, swizzle, extra_offset):
+    def _check_swizzle_commutes(self, swizzle, extra_offset, name):
+        """Reject offsets that do not commute with a swizzle permutation.
+
+        Folding an offset into ``elem_offset`` moves it *outside* the layout,
+        so the address becomes ``offset + swizzle(rest)``. The swizzle XORs
+        bits within a period of ``2^(per_element + atom_len + swizzle_len)``
+        elements, so this equals the true ``swizzle(offset + rest)`` only
+        when the offset is a multiple of that period.
+        """
+        if swizzle is None or extra_offset is None:
+            return
+        sw_len = int(swizzle.swizzle_len)
+        if sw_len == 0:
+            return  # identity permutation, everything commutes
+        period = 1 << (int(swizzle.per_element) + int(swizzle.atom_len) + sw_len)
+        offset_c = self._concrete_int(extra_offset)
+        if offset_c is not None:
+            commutes = offset_c % period == 0
+        else:
+            from ..arith import Analyzer  # pylint: disable=import-outside-toplevel
+
+            commutes = Analyzer().can_prove_equal(tvm.tirx.floormod(extra_offset, period), 0)
+        if not commutes:
+            raise ValueError(
+                f"{name}: the folded offset {extra_offset} is not a multiple of "
+                f"the swizzle period ({period} elements), so it does not commute "
+                f"with the swizzle permutation; slice via a region instead, or "
+                f"keep the offset inside an explicitly declared layout"
+            )
+
+    def _rebuild_view(self, new_shape, new_shard, grouped, swizzle, extra_offset, name):
+        self._check_swizzle_commutes(swizzle, extra_offset, name)
         new_layout = tvm.tirx.layout.TileLayout.from_iters(
             new_shard, list(grouped.replica), dict(grouped.offset.items())
         )
@@ -649,7 +680,9 @@ class Buffer(Object, Scriptable):
         Torch-aligned (``Tensor.select``); ``index`` may be a dynamic
         PrimExpr, folded into the view's ``elem_offset`` through the dim's
         layout iters. Statically known indices are bounds-checked; dynamic
-        indices are the caller's responsibility.
+        indices are the caller's responsibility. On a swizzled layout the
+        folded offset must be a multiple of the swizzle period (see
+        ``_check_swizzle_commutes``); otherwise the call raises.
         """
         dim = self._normalized_dim(dim, "select")
         index_c = self._concrete_int(index)
@@ -667,7 +700,7 @@ class Buffer(Object, Scriptable):
         offset = self._dim_group_offset(iters[lo:hi], index)
         new_shape = list(self.shape[:dim]) + list(self.shape[dim + 1 :])
         new_shard = iters[:lo] + iters[hi:]
-        return self._rebuild_view(new_shape, new_shard, grouped, swizzle, offset)
+        return self._rebuild_view(new_shape, new_shard, grouped, swizzle, offset, "select")
 
     def narrow(self, dim, start, length) -> "Buffer":
         """Return a view of ``dim`` narrowed to ``[start, start + length)``.
@@ -678,7 +711,9 @@ class Buffer(Object, Scriptable):
         the inner iter block so the range stays a contiguous iter prefix.
         Statically known bounds are checked (``start >= 0``, ``length >= 1``,
         ``start + length <= extent``); dynamic values are the caller's
-        responsibility.
+        responsibility. On a swizzled layout the folded offset must be a
+        multiple of the swizzle period (see ``_check_swizzle_commutes``);
+        otherwise the call raises.
         """
         dim = self._normalized_dim(dim, "narrow")
         start_c = self._concrete_int(start)
@@ -733,7 +768,7 @@ class Buffer(Object, Scriptable):
         new_shape = list(self.shape)
         new_shape[dim] = length
         new_shard = iters[:lo] + new_group + iters[hi:]
-        return self._rebuild_view(new_shape, new_shard, grouped, swizzle, offset)
+        return self._rebuild_view(new_shape, new_shard, grouped, swizzle, offset, "narrow")
 
     @property
     def sub(self) -> "_SubIndexer":
@@ -889,6 +924,14 @@ def _rearrange(buffer, pattern, **sizes):
             name = group[0]
             if name not in axis_size:
                 axis_size[name] = extent
+            else:
+                given_c = Buffer._concrete_int(axis_size[name])
+                extent_c = Buffer._concrete_int(extent)
+                if given_c is not None and extent_c is not None and given_c != extent_c:
+                    raise ValueError(
+                        f"rearrange: size {name}={given_c} does not match dim {dim} "
+                        f"extent {extent_c} in {pattern!r}"
+                    )
             continue
         unknown_factors = [name for name in group if name not in axis_size]
         if len(unknown_factors) > 1:

--- a/python/tvm/tirx/buffer.py
+++ b/python/tvm/tirx/buffer.py
@@ -515,6 +515,14 @@ class Buffer(Object, Scriptable):
         negatives = [i for i, s in enumerate(sizes) if isinstance(s, int) and s == -1]
         if len(negatives) > 1:
             raise ValueError("unflatten: at most one -1 is allowed in sizes")
+        for i, size in enumerate(sizes):
+            if negatives and i == negatives[0]:
+                continue
+            size_c = self._concrete_int(size)
+            if size_c is not None and size_c <= 0:
+                raise ValueError(
+                    f"unflatten: sizes must be positive (or a single -1); got {size_c}"
+                )
         if negatives:
             known = functools.reduce(
                 lambda a, b: a * b,

--- a/python/tvm/tirx/buffer.py
+++ b/python/tvm/tirx/buffer.py
@@ -620,8 +620,8 @@ class Buffer(Object, Scriptable):
             offset = term if offset is None else offset + term
         return offset
 
-    def _check_swizzle_commutes(self, swizzle, extra_offset, name):
-        """Reject offsets that do not commute with a swizzle permutation.
+    def _swizzle_offset_commutes(self, swizzle, extra_offset):
+        """Whether ``extra_offset`` commutes with the swizzle permutation.
 
         Folding an offset into ``elem_offset`` moves it *outside* the layout,
         so the address becomes ``offset + swizzle(rest)``. The swizzle XORs
@@ -630,30 +630,31 @@ class Buffer(Object, Scriptable):
         when the offset is a multiple of that period.
         """
         if swizzle is None or extra_offset is None:
-            return
+            return True
         sw_len = int(swizzle.swizzle_len)
         if sw_len == 0:
-            return  # identity permutation, everything commutes
+            return True  # identity permutation, everything commutes
         period = 1 << (int(swizzle.per_element) + int(swizzle.atom_len) + sw_len)
         offset_c = self._concrete_int(extra_offset)
         if offset_c is not None:
-            commutes = offset_c % period == 0
-        else:
-            from ..arith import Analyzer  # pylint: disable=import-outside-toplevel
+            return offset_c % period == 0
+        from ..arith import Analyzer  # pylint: disable=import-outside-toplevel
 
-            commutes = Analyzer().can_prove_equal(tvm.tirx.floormod(extra_offset, period), 0)
-        if not commutes:
-            raise ValueError(
-                f"{name}: the folded offset {extra_offset} is not a multiple of "
-                f"the swizzle period ({period} elements), so it does not commute "
-                f"with the swizzle permutation; slice via a region instead, or "
-                f"keep the offset inside an explicitly declared layout"
-            )
+        return Analyzer().can_prove_equal(tvm.tirx.floormod(extra_offset, period), 0)
 
-    def _rebuild_view(self, new_shape, new_shard, grouped, swizzle, extra_offset, name):
-        self._check_swizzle_commutes(swizzle, extra_offset, name)
+    def _rebuild_view(self, new_shape, new_shard, grouped, swizzle, extra_offset):
+        """Rebuild a derived view; ``extra_offset`` goes into ``elem_offset``
+        when it commutes with the swizzle (provable period multiple),
+        otherwise it stays inside the tile layout's offset so the swizzle
+        keeps applying to it and the view addresses the same bytes."""
+        offset_map = dict(grouped.offset.items())
+        if extra_offset is not None and not self._swizzle_offset_commutes(swizzle, extra_offset):
+            m_axis = tvm.tirx.layout.Axis.get("m")
+            prev = offset_map.get(m_axis)
+            offset_map[m_axis] = extra_offset if prev is None else prev + extra_offset
+            extra_offset = None
         new_layout = tvm.tirx.layout.TileLayout.from_iters(
-            new_shard, list(grouped.replica), dict(grouped.offset.items())
+            new_shard, list(grouped.replica), offset_map
         )
         new_layout = self._rewrap_swizzle(new_layout, swizzle)
         elem_offset = self.elem_offset
@@ -681,8 +682,9 @@ class Buffer(Object, Scriptable):
         PrimExpr, folded into the view's ``elem_offset`` through the dim's
         layout iters. Statically known indices are bounds-checked; dynamic
         indices are the caller's responsibility. On a swizzled layout the
-        folded offset must be a multiple of the swizzle period (see
-        ``_check_swizzle_commutes``); otherwise the call raises.
+        offset folds into ``elem_offset`` only when it provably commutes
+        with the swizzle (a swizzle-period multiple); otherwise it stays
+        inside the derived layout's offset, where the swizzle applies to it.
         """
         dim = self._normalized_dim(dim, "select")
         index_c = self._concrete_int(index)
@@ -700,7 +702,7 @@ class Buffer(Object, Scriptable):
         offset = self._dim_group_offset(iters[lo:hi], index)
         new_shape = list(self.shape[:dim]) + list(self.shape[dim + 1 :])
         new_shard = iters[:lo] + iters[hi:]
-        return self._rebuild_view(new_shape, new_shard, grouped, swizzle, offset, "select")
+        return self._rebuild_view(new_shape, new_shard, grouped, swizzle, offset)
 
     def narrow(self, dim, start, length) -> "Buffer":
         """Return a view of ``dim`` narrowed to ``[start, start + length)``.
@@ -711,9 +713,10 @@ class Buffer(Object, Scriptable):
         the inner iter block so the range stays a contiguous iter prefix.
         Statically known bounds are checked (``start >= 0``, ``length >= 1``,
         ``start + length <= extent``); dynamic values are the caller's
-        responsibility. On a swizzled layout the folded offset must be a
-        multiple of the swizzle period (see ``_check_swizzle_commutes``);
-        otherwise the call raises.
+        responsibility. On a swizzled layout the offset folds into
+        ``elem_offset`` only when it provably commutes with the swizzle
+        (a swizzle-period multiple); otherwise it stays inside the derived
+        layout's offset, where the swizzle applies to it.
         """
         dim = self._normalized_dim(dim, "narrow")
         start_c = self._concrete_int(start)
@@ -768,7 +771,7 @@ class Buffer(Object, Scriptable):
         new_shape = list(self.shape)
         new_shape[dim] = length
         new_shard = iters[:lo] + new_group + iters[hi:]
-        return self._rebuild_view(new_shape, new_shard, grouped, swizzle, offset, "narrow")
+        return self._rebuild_view(new_shape, new_shard, grouped, swizzle, offset)
 
     @property
     def sub(self) -> "_SubIndexer":

--- a/python/tvm/tirx/buffer.py
+++ b/python/tvm/tirx/buffer.py
@@ -443,8 +443,18 @@ class Buffer(Object, Scriptable):
         # plus seps over *that* layout — permute the regrouped one, not
         # ``self.layout``. For a simple layout (one shard iter per axis) this
         # reduces to ``permute_dims(dims)``.
-        grouped, seps = self.layout.group(list(self.shape))
+        layout = self.layout
+        swizzle = None
+        if isinstance(layout, tvm.tirx.layout.ComposeLayout):
+            # The swizzle permutes the flat offset, so it commutes with a
+            # permutation of the logical dims: permute the inner tile layout
+            # and re-compose.
+            swizzle = layout.swizzle
+            layout = layout.tile_layout
+        grouped, seps = layout.group(list(self.shape))
         new_layout = grouped.permute_by_groups(seps, list(dims))
+        if swizzle is not None:
+            new_layout = tvm.tirx.layout.ComposeLayout(swizzle, new_layout)
         return tvm.tirx.script.builder.decl_buffer(
             new_shape,
             self.dtype,

--- a/python/tvm/tirx/layout.py
+++ b/python/tvm/tirx/layout.py
@@ -984,14 +984,14 @@ class _LayoutSpec:
                 replica=other.replica if other.replica else self.replica,
                 offset=_merge_offset(self.offset, other.offset),
             )
-        if isinstance(other, _OnAxis | _OffsetExpr | int):
+        if isinstance(other, _OnAxis | _OffsetExpr | PrimExpr | int):
             return _LayoutSpec(
                 shard=self.shard, replica=self.replica, offset=_merge_offset(self.offset, other)
             )
         return NotImplemented
 
     def __radd__(self, other):
-        if isinstance(other, _OnAxis | _OffsetExpr | int):
+        if isinstance(other, _OnAxis | _OffsetExpr | PrimExpr | int):
             return _LayoutSpec(
                 shard=self.shard, replica=self.replica, offset=_merge_offset(other, self.offset)
             )

--- a/src/tirx/script/printer/stmt.cc
+++ b/src/tirx/script/printer/stmt.cc
@@ -282,6 +282,16 @@ std::vector<tirx::Buffer> FindParentBuffers(const tirx::Buffer& child, const IRD
       }
     }
   }
+  // obj2info iteration order is unspecified; order candidates by name so the
+  // printed parent choice (and hence the script) is deterministic across
+  // print/parse roundtrips.
+  tvm::ffi::StructuralHash shash;
+  std::stable_sort(results.begin(), results.end(),
+                   [&shash](const tirx::Buffer& a, const tirx::Buffer& b) {
+                     std::string an(a->name), bn(b->name);
+                     if (an != bn) return an < bn;
+                     return shash(a) < shash(b);
+                   });
   return results;
 }
 
@@ -301,7 +311,8 @@ bool IsDefaultLayout(const ffi::Optional<tirx::Layout>& layout, const ffi::Array
  */
 ffi::Optional<ExprDoc> TryDeclBufferSugarWithParent(const tirx::Buffer& child, const AccessPath& p,
                                                     const IRDocsifier& d,
-                                                    const tirx::Buffer& parent) {
+                                                    const tirx::Buffer& parent,
+                                                    bool require_same_layout) {
   ffi::Optional<ExprDoc> parent_doc = d->GetVarDoc(parent);
   if (!parent_doc.defined()) return std::nullopt;
   ExprDoc pdoc = parent_doc.value();
@@ -326,67 +337,11 @@ ffi::Optional<ExprDoc> TryDeclBufferSugarWithParent(const tirx::Buffer& child, c
   bool child_is_default = IsDefaultLayout(child->layout, child->shape);
   bool parent_is_default = IsDefaultLayout(parent->layout, parent->shape);
 
-  // --- (a) Slice (default layout, different elem_offset) ---
-  if (!same_elem_offset && same_dtype && !parent->shape.empty()) {
-    // Reconstruct start indices from elem_offset difference and parent strides (row-major)
-    // offset_diff = child->elem_offset - parent->elem_offset
-    // For row-major: strides[i] = prod(shape[i+1:])
-    // start[i] = offset_diff / strides[i]; offset_diff %= strides[i]
-    // Build slice doc: parent[start:start+extent, ...]
-    // We only support this for IntImm offsets
-    auto* child_off = child->elem_offset.as<IntImmNode>();
-    auto* parent_off = parent->elem_offset.as<IntImmNode>();
-    if (child_off && parent_off) {
-      int64_t offset_diff = child_off->value - parent_off->value;
-      // Compute row-major strides
-      std::vector<int64_t> strides(parent->shape.size());
-      int64_t stride = 1;
-      for (int i = static_cast<int>(parent->shape.size()) - 1; i >= 0; --i) {
-        strides[i] = stride;
-        if (auto* s = parent->shape[i].as<IntImmNode>()) {
-          stride *= s->value;
-        } else {
-          return std::nullopt;  // Non-constant shape, can't decompose
-        }
-      }
-      // Check child shape is also all IntImm
-      for (size_t i = 0; i < child->shape.size(); ++i) {
-        if (!child->shape[i].as<IntImmNode>()) return std::nullopt;
-      }
-      if (child->shape.size() != parent->shape.size()) return std::nullopt;
-
-      ffi::Array<Doc> slices;
-      int64_t remaining = offset_diff;
-      bool in_bounds = true;
-      for (size_t i = 0; i < parent->shape.size(); ++i) {
-        int64_t start_val = remaining / strides[i];
-        remaining %= strides[i];
-        int64_t extent_val = child->shape[i].as<IntImmNode>()->value;
-        int64_t parent_dim = parent->shape[i].as<IntImmNode>()->value;
-        int64_t stop_val = start_val + extent_val;
-        // Bounds check: start + extent must be within parent dim
-        if (stop_val > parent_dim) {
-          in_bounds = false;
-          break;
-        }
-        if (start_val == 0 && stop_val == parent_dim) {
-          // Full range: use 0:N slice
-          ExprDoc start_doc = LiteralDoc::Int(0, p->Attr("elem_offset"));
-          ExprDoc stop_doc =
-              d->AsDoc<ExprDoc>(parent->shape[i], p->Attr("buffer")->Attr("shape")->ArrayItem(i));
-          slices.push_back(SliceDoc(start_doc, stop_doc, std::nullopt));
-        } else {
-          ExprDoc start_doc = LiteralDoc::Int(start_val, p->Attr("elem_offset"));
-          ExprDoc stop_doc = LiteralDoc::Int(stop_val, p->Attr("elem_offset"));
-          slices.push_back(SliceDoc(start_doc, stop_doc, std::nullopt));
-        }
-      }
-      if (remaining == 0 && in_bounds) {
-        return pdoc[slices];
-      }
-    }
-    return std::nullopt;
-  }
+  // NOTE: an earlier sugar printed rank-preserving aliases with a different
+  // elem_offset as ``parent[slices]``. That print is not roundtrippable: it
+  // reparses as a BufferRegion, not a Buffer, so any later Buffer use of the
+  // alias (stores, views) breaks. Such aliases now print as plain
+  // T.decl_buffer, which reparses exactly.
 
   // --- (b) Local: parent has thread axes, child has storage layout (non-thread part) ---
   if (same_elem_offset && same_dtype && !parent_is_default && parent->layout.defined()) {
@@ -660,6 +615,9 @@ ffi::Optional<ExprDoc> TryDeclBufferSugarWithParent(const tirx::Buffer& child, c
     } else if (!child->layout.defined() && !parent->layout.defined()) {
       same_layout = true;
     }
+    // First pass prefers a parent whose layout matches structurally, so the
+    // sugar prints as a bare reshape instead of restating the layout.
+    if (require_same_layout && !same_layout) return std::nullopt;
     if (!same_layout && child->layout.defined() && !child_is_default) {
       kwargs_keys.push_back("layout");
       kwargs_values.push_back(
@@ -678,7 +636,14 @@ ffi::Optional<ExprDoc> TryDeclBufferSugar(const tirx::Buffer& child, const Acces
                                           const IRDocsifier& d) {
   auto parents = FindParentBuffers(child, d);
   for (const auto& parent : parents) {
-    if (auto sugar = TryDeclBufferSugarWithParent(child, p, d, parent)) {
+    if (auto sugar = TryDeclBufferSugarWithParent(child, p, d, parent,
+                                                  /*require_same_layout=*/true)) {
+      return sugar;
+    }
+  }
+  for (const auto& parent : parents) {
+    if (auto sugar = TryDeclBufferSugarWithParent(child, p, d, parent,
+                                                  /*require_same_layout=*/false)) {
       return sugar;
     }
   }

--- a/tests/python/tirx/test_parser_printer.py
+++ b/tests/python/tirx/test_parser_printer.py
@@ -1627,6 +1627,46 @@ def test_buffer_rearrange_errors():
         buf.rearrange("b c -> c b")
 
 
+def test_buffer_view_surgery_static_bounds_rejected():
+    """Statically-known out-of-range arguments must be rejected loudly
+    (review finding: non-bijective reshapes and OOB offsets were silent)."""
+    buf = tvm.tirx.decl_buffer(
+        (10,), "float16", layout=tvm.tirx.layout.TileLayout(T.S[(10,) : (1,)])
+    )
+    grid = tvm.tirx.decl_buffer(
+        (4, 8), "float16", layout=tvm.tirx.layout.TileLayout(T.S[(4, 8) : (8, 1)])
+    )
+    # unflatten: non-bijective factorizations
+    with pytest.raises(ValueError, match="multiply to"):
+        buf.unflatten(0, (3, 4))
+    with pytest.raises(ValueError, match="not divisible"):
+        buf.unflatten(0, (-1, 4))
+    # rearrange reuses the same validation
+    with pytest.raises(ValueError, match="multiply to"):
+        buf.rearrange("(a b) -> a b", a=3, b=4)
+    with pytest.raises(ValueError, match="does not factor"):
+        buf.rearrange("(a b) -> a b", b=4)
+    # select: static index bounds
+    with pytest.raises(ValueError, match="out of range"):
+        buf.select(0, 10)
+    with pytest.raises(ValueError, match="out of range"):
+        buf.select(0, -1)
+    # narrow: static range bounds
+    with pytest.raises(ValueError, match="exceeds"):
+        buf.narrow(0, 8, 4)
+    with pytest.raises(ValueError, match="must be positive"):
+        buf.narrow(0, 0, -1)
+    with pytest.raises(ValueError, match="must be non-negative"):
+        buf.narrow(0, -2, 4)
+    # sub: negative indices/starts
+    with pytest.raises(ValueError, match=r"in \[0, 2\)"):
+        grid.sub[:, -1::2]
+    with pytest.raises(ValueError, match="out of range"):
+        grid.sub[-1, :]
+    with pytest.raises(ValueError, match="exceeds"):
+        grid.sub[:, 4:12]
+
+
 def test_buffer_view_dtype_ir():
     """Verify .view('float32') on float16: dtype correct, last dim halved, shared data."""
 

--- a/tests/python/tirx/test_parser_printer.py
+++ b/tests/python/tirx/test_parser_printer.py
@@ -1641,6 +1641,11 @@ def test_buffer_view_surgery_static_bounds_rejected():
         buf.unflatten(0, (3, 4))
     with pytest.raises(ValueError, match="not divisible"):
         buf.unflatten(0, (-1, 4))
+    # negative factors whose product happens to match the extent
+    with pytest.raises(ValueError, match="must be positive"):
+        buf.unflatten(0, (-2, -5))
+    with pytest.raises(ValueError, match="must be positive"):
+        buf.rearrange("(a b) -> a b", a=-2, b=-5)
     # rearrange reuses the same validation
     with pytest.raises(ValueError, match="multiply to"):
         buf.rearrange("(a b) -> a b", a=3, b=4)

--- a/tests/python/tirx/test_parser_printer.py
+++ b/tests/python/tirx/test_parser_printer.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import math
+
 import pytest
 
 import tvm
@@ -1673,11 +1675,22 @@ def test_buffer_view_surgery_static_bounds_rejected():
 
 
 def test_buffer_select_narrow_swizzle_commutation():
-    """Folding an offset past a swizzle is only sound when the offset is a
-    multiple of the swizzle period 2^(per_element + atom_len + swizzle_len)
-    (review finding: sub-period offsets produced wrong addresses). Aligned
-    offsets stay address-equivalent to the parent; everything else raises."""
+    """A folded view offset moves into elem_offset only when it commutes
+    with the swizzle, i.e. is a multiple of the swizzle period
+    2^(per_element + atom_len + swizzle_len). Sub-period offsets stay inside
+    the derived tile layout's offset so the swizzle keeps applying to them
+    (review finding: folding them outside produced wrong addresses). Both
+    placements must be address-equivalent to the parent layout."""
 
+    def addr(buf, base, *coords):
+        analyzer = tvm.arith.Analyzer()
+        if len(coords) == 1:
+            rel = buf.layout.apply(coords[0])["m"]
+        else:
+            rel = buf.layout.apply(*coords, shape=[int(s) for s in buf.shape])["m"]
+        return int(analyzer.simplify((buf.elem_offset - base) + rel))
+
+    analyzer = tvm.arith.Analyzer()
     compose = T.ComposeLayout(
         T.SwizzleLayout(3, 3, 3, swizzle_inner=True),
         T.TileLayout(T.S[(4, 1024) : (1024, 1)]),
@@ -1688,48 +1701,95 @@ def test_buffer_select_narrow_swizzle_commutation():
     def func() -> None:
         T.device_entry()
         A = T.alloc_buffer([4, 1024], dtype="bfloat16", scope="shared.dyn", layout=compose)
-        B = A.select(0, 1)  # folds offset 1024 = 2 * period
+        B = A.select(0, 1)  # offset 1024 = 2 * period: folds into elem_offset
         B[0] = T.bfloat16(0)
-        C = A.narrow(1, 512, 512)  # folds offset 512 = period
+        C = A.narrow(1, 512, 512)  # offset 512 = period: folds into elem_offset
         C[0, 0] = T.bfloat16(0)
         # fmt: on
 
     bufs = _collect_buffers(func)
     a_buf, b_buf, c_buf = bufs["A"], bufs["B"], bufs["C"]
-    analyzer = tvm.arith.Analyzer()
+    base = a_buf.elem_offset
+    assert int(analyzer.simplify(b_buf.elem_offset - base)) == 1024
     for j in (0, 1, 63, 511, 1023):
-        parent = analyzer.simplify(a_buf.layout.apply(1024 + j)["m"])
-        child = analyzer.simplify(
-            (b_buf.elem_offset - a_buf.elem_offset) + b_buf.layout.apply(j)["m"]
-        )
-        assert int(parent) == int(child), (j, parent, child)
+        assert addr(a_buf, base, 1024 + j) == addr(b_buf, base, j)
     for j in (0, 1, 255, 511):
-        parent = analyzer.simplify(a_buf.layout.apply(512 + j)["m"])
-        child = analyzer.simplify(
-            (c_buf.elem_offset - a_buf.elem_offset) + c_buf.layout.apply(j)["m"]
-        )
-        assert int(parent) == int(child), (j, parent, child)
+        assert addr(a_buf, base, 512 + j) == addr(c_buf, base, 0, j)
 
     code = func.script()
     assert from_source(code).script() == code
 
-    # sub-period offsets do not commute with the swizzle and are rejected.
-    repro = tvm.tirx.decl_buffer(
-        (2, 16, 8),
-        "float16",
-        layout=tvm.tirx.layout.ComposeLayout(
-            T.SwizzleLayout(3, 3, 3, swizzle_inner=True),
-            tvm.tirx.layout.TileLayout(T.S[(2, 16, 8) : (128, 8, 1)]),
-        ),
+    # Sub-period offsets do not commute: they stay inside the tile layout's
+    # offset (elem_offset unchanged) and every address matches the parent.
+    compose2 = T.ComposeLayout(
+        T.SwizzleLayout(3, 3, 3, swizzle_inner=True),
+        T.TileLayout(T.S[(2, 16, 8) : (128, 8, 1)]),
     )
-    with pytest.raises(ValueError, match="swizzle period"):
-        repro.select(1, 1)  # offset 8
-    with pytest.raises(ValueError, match="swizzle period"):
-        repro.select(2, 1)  # offset 1
-    with pytest.raises(ValueError, match="swizzle period"):
-        repro.narrow(1, 1, 2)
-    with pytest.raises(ValueError, match="swizzle period"):
-        repro.sub[:, 1:3]
+
+    # fmt: off
+    @T.prim_func
+    def func2() -> None:
+        T.device_entry()
+        A = T.alloc_buffer([2, 16, 8], dtype="float16", scope="shared.dyn", layout=compose2)
+        B = A.select(1, 1)  # offset 8
+        B[0, 0] = T.float16(0)
+        C = A.select(2, 1)  # offset 1
+        C[0, 0] = T.float16(0)
+        D = A.narrow(1, 1, 2)  # offset 8
+        D[0, 0, 0] = T.float16(0)
+        E = A.sub[:, 1:3]  # narrow via sub
+        E[0, 0, 0] = T.float16(0)
+        for w in T.serial(16):
+            F = A.select(1, w)  # dynamic sub-period offset
+            F[0, 0] = T.float16(0)
+        # fmt: on
+
+    bufs = _collect_buffers(func2)
+    a2, base2 = bufs["A"], bufs["A"].elem_offset
+    shape2 = [2, 16, 8]
+    for name, to_parent in {
+        "B": lambda c: (c[0], 1, c[1]),
+        "C": lambda c: (c[0], c[1], 1),
+        "D": lambda c: (c[0], 1 + c[1], c[2]),
+        "E": lambda c: (c[0], 1 + c[1], c[2]),
+    }.items():
+        child = bufs[name]
+        assert int(analyzer.simplify(child.elem_offset - base2)) == 0
+        child_shape = [int(s) for s in child.shape]
+        for flat in range(math.prod(child_shape)):
+            coords, rem = [], flat
+            for extent in reversed(child_shape):
+                coords.append(rem % extent)
+                rem //= extent
+            coords = tuple(reversed(coords))
+            assert addr(a2, base2, *to_parent(coords)) == addr(child, base2, *coords), (
+                name,
+                coords,
+            )
+
+    code = func2.script()
+    assert from_source(code).script() == code
+
+    # fixed-point windows (all touched addresses below 2^(per_element +
+    # atom_len)) are correct through the same layout-offset placement
+    compose3 = T.ComposeLayout(
+        T.SwizzleLayout(3, 3, 3, swizzle_inner=True),
+        T.TileLayout(T.S[(64,) : (1,)]),
+    )
+
+    # fmt: off
+    @T.prim_func
+    def func3() -> None:
+        T.device_entry()
+        A = T.alloc_buffer([64], dtype="bfloat16", scope="shared.dyn", layout=compose3)
+        B = A.narrow(0, 8, 8)
+        B[0] = T.bfloat16(0)
+        # fmt: on
+
+    bufs = _collect_buffers(func3)
+    a3, b3 = bufs["A"], bufs["B"]
+    for j in range(8):
+        assert addr(a3, a3.elem_offset, 8 + j) == addr(b3, a3.elem_offset, j) == 8 + j
 
 
 def test_buffer_rearrange_singleton_size_mismatch_rejected():

--- a/tests/python/tirx/test_parser_printer.py
+++ b/tests/python/tirx/test_parser_printer.py
@@ -1421,6 +1421,212 @@ def test_buffer_permute_compose_layout_ir():
     assert from_source(code).script() == code
 
 
+def test_buffer_unflatten_flatten_ir():
+    """unflatten splits a dim (with -1 inference); flatten merges dims back.
+    Both keep the original layout object (pure reshapes)."""
+
+    # fmt: off
+    @T.prim_func
+    def func() -> None:
+        T.device_entry()
+        A = T.alloc_buffer([8, 64], dtype="float16", scope="local",
+                           layout=T.TileLayout(T.S[(8, 64) : (64, 1)]))
+        B = A.unflatten(1, (4, 16))
+        B[0, 0, 0] = T.float16(0)
+        C = A.unflatten(1, (-1, 16))
+        C[0, 0, 0] = T.float16(0)
+        D = B.flatten(1, 2)
+        D[0, 0] = T.float16(0)
+        # fmt: on
+
+    bufs = _collect_buffers(func)
+    a_buf, b_buf, c_buf, d_buf = bufs["A"], bufs["B"], bufs["C"], bufs["D"]
+    assert b_buf.data.same_as(a_buf.data)
+    assert [int(s) for s in b_buf.shape] == [8, 4, 16]
+    assert [int(s) for s in c_buf.shape] == [8, 4, 16]
+    assert [int(s) for s in d_buf.shape] == [8, 64]
+    assert_structural_equal(b_buf.layout, a_buf.layout)
+    assert_structural_equal(d_buf.layout, a_buf.layout)
+
+    code = func.script()
+    assert from_source(code).script() == code
+
+
+def test_buffer_select_ir():
+    """select removes a dim; the index (static or dynamic) folds into
+    elem_offset through the dim's layout iter stride."""
+
+    # fmt: off
+    @T.prim_func
+    def func() -> None:
+        T.device_entry()
+        A = T.alloc_buffer([4, 8, 16], dtype="float16", scope="local",
+                           layout=T.TileLayout(T.S[(4, 8, 16) : (256, 16, 1)]))
+        B = A.select(0, 2)
+        B[0, 0] = T.float16(0)
+        for i in T.serial(4):
+            C = A.select(0, i)
+            C[0, 0] = T.float16(0)
+        # fmt: on
+
+    bufs = _collect_buffers(func)
+    a_buf, b_buf, c_buf = bufs["A"], bufs["B"], bufs["C"]
+    assert b_buf.data.same_as(a_buf.data)
+    assert [int(s) for s in b_buf.shape] == [8, 16]
+    assert int(tvm.arith.Analyzer().simplify(b_buf.elem_offset - a_buf.elem_offset)) == 512
+    assert_structural_equal(b_buf.layout, tvm.tirx.layout.TileLayout(T.S[(8, 16) : (16, 1)]))
+    assert [int(s) for s in c_buf.shape] == [8, 16]
+
+    code = func.script()
+    assert from_source(code).script() == code
+
+
+def test_buffer_select_multi_iter_dim_ir():
+    """select on a dim carried by several layout iters decomposes the index
+    mixed-radix across the iters' strides."""
+
+    # fmt: off
+    @T.prim_func
+    def func() -> None:
+        T.device_entry()
+        A = T.alloc_buffer([8, 16], dtype="float16", scope="local",
+                           layout=T.TileLayout(T.S[(2, 4, 16) : (1024, 64, 1)]))
+        B = A.select(0, 5)
+        B[0] = T.float16(0)
+        # fmt: on
+
+    bufs = _collect_buffers(func)
+    a_buf, b_buf = bufs["A"], bufs["B"]
+    # 5 -> (5 // 4, 5 % 4) = (1, 1) -> 1 * 1024 + 1 * 64
+    assert int(tvm.arith.Analyzer().simplify(b_buf.elem_offset - a_buf.elem_offset)) == 1088
+    assert [int(s) for s in b_buf.shape] == [16]
+    assert_structural_equal(b_buf.layout, tvm.tirx.layout.TileLayout(T.S[(16,) : (1,)]))
+
+    code = func.script()
+    assert from_source(code).script() == code
+
+
+def test_buffer_narrow_ir():
+    """narrow keeps the dim at a reduced extent; multi-iter dims require
+    start/length on the inner iter block boundary."""
+
+    # fmt: off
+    @T.prim_func
+    def func() -> None:
+        T.device_entry()
+        A = T.alloc_buffer([4, 64], dtype="float16", scope="local",
+                           layout=T.TileLayout(T.S[(4, 64) : (64, 1)]))
+        for i in T.serial(2):
+            B = A.narrow(1, i * 32, 32)
+            B[0, 0] = T.float16(0)
+        M = T.alloc_buffer([8, 16], dtype="float16", scope="local",
+                           layout=T.TileLayout(T.S[(2, 4, 16) : (1024, 64, 1)]))
+        C = M.narrow(0, 4, 4)
+        C[0, 0] = T.float16(0)
+        # fmt: on
+
+    bufs = _collect_buffers(func)
+    b_buf, m_buf, c_buf = bufs["B"], bufs["M"], bufs["C"]
+    assert [int(s) for s in b_buf.shape] == [4, 32]
+    assert [int(s) for s in c_buf.shape] == [4, 16]
+    assert int(tvm.arith.Analyzer().simplify(c_buf.elem_offset - m_buf.elem_offset)) == 1024
+
+    code = func.script()
+    assert from_source(code).script() == code
+
+
+def test_buffer_narrow_multi_iter_misaligned_rejected():
+    buf = tvm.tirx.decl_buffer(
+        (8, 16), "float16", layout=tvm.tirx.layout.TileLayout(T.S[(2, 4, 16) : (1024, 64, 1)])
+    )
+    with pytest.raises(ValueError, match="multiples of the inner iter block"):
+        buf.narrow(0, 2, 4)
+
+
+def test_buffer_sub_ir():
+    """buf.sub follows numpy basic indexing as a view constructor: int drops
+    the dim, a:b narrows, a::s strides (via unflatten + select)."""
+
+    # fmt: off
+    @T.prim_func
+    def func() -> None:
+        T.device_entry()
+        A = T.alloc_buffer([4, 8, 16], dtype="float16", scope="local",
+                           layout=T.TileLayout(T.S[(4, 8, 16) : (256, 16, 1)]))
+        B = A.sub[1, 2:6]
+        B[0, 0] = T.float16(0)
+        C = A.sub[:, 1::2]
+        C[0, 0, 0] = T.float16(0)
+        D = A.select(0, 1).narrow(0, 2, 4)
+        D[0, 0] = T.float16(0)
+        E = A.unflatten(1, (4, 2)).select(2, 1)
+        E[0, 0, 0] = T.float16(0)
+        # fmt: on
+
+    bufs = _collect_buffers(func)
+    b_buf, c_buf, d_buf, e_buf = bufs["B"], bufs["C"], bufs["D"], bufs["E"]
+    assert [int(s) for s in b_buf.shape] == [4, 16]
+    assert_structural_equal(b_buf.layout, d_buf.layout)
+    assert int(tvm.arith.Analyzer().simplify(b_buf.elem_offset - d_buf.elem_offset)) == 0
+    assert [int(s) for s in c_buf.shape] == [4, 4, 16]
+    assert_structural_equal(c_buf.layout, e_buf.layout)
+    assert int(tvm.arith.Analyzer().simplify(c_buf.elem_offset - e_buf.elem_offset)) == 0
+
+    code = func.script()
+    assert from_source(code).script() == code
+
+
+def test_buffer_rearrange_ir():
+    """rearrange compiles to the unflatten/permute/flatten chain; the swizzle
+    of a composed layout is carried."""
+
+    compose = T.ComposeLayout(
+        T.SwizzleLayout(3, 3, 3, swizzle_inner=True),
+        T.TileLayout(T.S[(2, 16, 8) : (128, 8, 1)]),
+    )
+
+    # fmt: off
+    @T.prim_func
+    def func() -> None:
+        T.device_entry()
+        A = T.alloc_buffer([2, 16, 8], dtype="bfloat16", scope="shared.dyn", layout=compose)
+        B = A.rearrange("b (s w r) c -> b w (s r) c", w=2, r=4)
+        B[0, 0, 0, 0] = T.bfloat16(0)
+
+    @T.prim_func
+    def func_chain() -> None:
+        T.device_entry()
+        A = T.alloc_buffer([2, 16, 8], dtype="bfloat16", scope="shared.dyn", layout=compose)
+        C = A.unflatten(1, (2, 2, 4)).permute(0, 2, 1, 3, 4).flatten(2, 3)
+        C[0, 0, 0, 0] = T.bfloat16(0)
+        # fmt: on
+
+    b_buf = _collect_buffers(func)["B"]
+    c_buf = _collect_buffers(func_chain)["C"]
+    assert [int(s) for s in b_buf.shape] == [2, 2, 8, 8]
+    assert_structural_equal(b_buf.layout, c_buf.layout)
+    assert isinstance(b_buf.layout, tvm.tirx.layout.ComposeLayout)
+
+    code = func.script()
+    assert from_source(code).script() == code
+
+
+def test_buffer_rearrange_errors():
+    buf = tvm.tirx.decl_buffer(
+        (2, 16, 8), "float16", layout=tvm.tirx.layout.TileLayout(T.S[(2, 16, 8) : (128, 8, 1)])
+    )
+    with pytest.raises(ValueError, match="must contain '->'"):
+        buf.rearrange("b h c")
+    with pytest.raises(ValueError, match="appear on only one side"):
+        buf.rearrange("b h c -> b h d")
+    with pytest.raises(ValueError, match="duplicate axis name"):
+        buf.rearrange("b b c -> b c b")
+    with pytest.raises(ValueError, match="multiple unknown factors"):
+        buf.rearrange("b (s w r) c -> b w (s r) c")
+    with pytest.raises(ValueError, match="input dims"):
+        buf.rearrange("b c -> c b")
+
+
 def test_buffer_view_dtype_ir():
     """Verify .view('float32') on float16: dtype correct, last dim halved, shared data."""
 

--- a/tests/python/tirx/test_parser_printer.py
+++ b/tests/python/tirx/test_parser_printer.py
@@ -1385,6 +1385,42 @@ def test_buffer_permute_ir():
     assert from_source(code).script() == code
 
 
+def test_buffer_permute_compose_layout_ir():
+    """Verify .permute on a swizzle-composed layout: the swizzle is preserved
+    and the inner tile layout's dim groups are permuted (the reshape-permute-
+    reshape idiom used to refactor gather views without restating strides)."""
+
+    # fmt: off
+    @T.prim_func
+    def func() -> None:
+        T.device_entry()
+        A = T.alloc_buffer(
+            [4, 4, 4, 64], dtype="bfloat16", scope="shared.dyn",
+            layout=T.ComposeLayout(
+                T.SwizzleLayout(3, 3, 3, swizzle_inner=True),
+                T.TileLayout(T.S[(4, 4, 4, 64) : (1024, 256, 64, 1)]),
+            ),
+        )
+        B = A.permute(1, 0, 2, 3)
+        B[0, 0, 0, 0] = T.bfloat16(0)
+        # fmt: on
+
+    bufs = _collect_buffers(func)
+    a_buf = bufs["A"]
+    b_buf = bufs["B"]
+
+    assert b_buf.data.same_as(a_buf.data)
+    assert [int(s) for s in b_buf.shape] == [4, 4, 4, 64]
+    expected = tvm.tirx.layout.ComposeLayout(
+        a_buf.layout.swizzle,
+        a_buf.layout.tile_layout.permute_dims([1, 0, 2, 3]),
+    )
+    assert_structural_equal(b_buf.layout, expected)
+
+    code = func.script()
+    assert from_source(code).script() == code
+
+
 def test_buffer_view_dtype_ir():
     """Verify .view('float32') on float16: dtype correct, last dim halved, shared data."""
 

--- a/tests/python/tirx/test_parser_printer.py
+++ b/tests/python/tirx/test_parser_printer.py
@@ -1672,6 +1672,87 @@ def test_buffer_view_surgery_static_bounds_rejected():
         grid.sub[:, 4:12]
 
 
+def test_buffer_select_narrow_swizzle_commutation():
+    """Folding an offset past a swizzle is only sound when the offset is a
+    multiple of the swizzle period 2^(per_element + atom_len + swizzle_len)
+    (review finding: sub-period offsets produced wrong addresses). Aligned
+    offsets stay address-equivalent to the parent; everything else raises."""
+
+    compose = T.ComposeLayout(
+        T.SwizzleLayout(3, 3, 3, swizzle_inner=True),
+        T.TileLayout(T.S[(4, 1024) : (1024, 1)]),
+    )  # period = 2^(3+3+3) = 512 elements
+
+    # fmt: off
+    @T.prim_func
+    def func() -> None:
+        T.device_entry()
+        A = T.alloc_buffer([4, 1024], dtype="bfloat16", scope="shared.dyn", layout=compose)
+        B = A.select(0, 1)  # folds offset 1024 = 2 * period
+        B[0] = T.bfloat16(0)
+        C = A.narrow(1, 512, 512)  # folds offset 512 = period
+        C[0, 0] = T.bfloat16(0)
+        # fmt: on
+
+    bufs = _collect_buffers(func)
+    a_buf, b_buf, c_buf = bufs["A"], bufs["B"], bufs["C"]
+    analyzer = tvm.arith.Analyzer()
+    for j in (0, 1, 63, 511, 1023):
+        parent = analyzer.simplify(a_buf.layout.apply(1024 + j)["m"])
+        child = analyzer.simplify(
+            (b_buf.elem_offset - a_buf.elem_offset) + b_buf.layout.apply(j)["m"]
+        )
+        assert int(parent) == int(child), (j, parent, child)
+    for j in (0, 1, 255, 511):
+        parent = analyzer.simplify(a_buf.layout.apply(512 + j)["m"])
+        child = analyzer.simplify(
+            (c_buf.elem_offset - a_buf.elem_offset) + c_buf.layout.apply(j)["m"]
+        )
+        assert int(parent) == int(child), (j, parent, child)
+
+    code = func.script()
+    assert from_source(code).script() == code
+
+    # sub-period offsets do not commute with the swizzle and are rejected.
+    repro = tvm.tirx.decl_buffer(
+        (2, 16, 8),
+        "float16",
+        layout=tvm.tirx.layout.ComposeLayout(
+            T.SwizzleLayout(3, 3, 3, swizzle_inner=True),
+            tvm.tirx.layout.TileLayout(T.S[(2, 16, 8) : (128, 8, 1)]),
+        ),
+    )
+    with pytest.raises(ValueError, match="swizzle period"):
+        repro.select(1, 1)  # offset 8
+    with pytest.raises(ValueError, match="swizzle period"):
+        repro.select(2, 1)  # offset 1
+    with pytest.raises(ValueError, match="swizzle period"):
+        repro.narrow(1, 1, 2)
+    with pytest.raises(ValueError, match="swizzle period"):
+        repro.sub[:, 1:3]
+
+
+def test_buffer_rearrange_singleton_size_mismatch_rejected():
+    buf = tvm.tirx.decl_buffer(
+        (2, 3), "float16", layout=tvm.tirx.layout.TileLayout(T.S[(2, 3) : (3, 1)])
+    )
+    with pytest.raises(ValueError, match="does not match dim"):
+        buf.rearrange("a b -> b a", a=99)
+
+    # a matching explicit size on a singleton axis is accepted
+    # fmt: off
+    @T.prim_func
+    def func() -> None:
+        T.device_entry()
+        A = T.alloc_buffer([2, 3], dtype="float16", scope="local",
+                           layout=T.TileLayout(T.S[(2, 3) : (3, 1)]))
+        B = A.rearrange("a b -> b a", a=2)
+        B[0, 0] = T.float16(0)
+        # fmt: on
+
+    assert [int(s) for s in _collect_buffers(func)["B"].shape] == [3, 2]
+
+
 def test_buffer_view_dtype_ir():
     """Verify .view('float32') on float16: dtype correct, last dim halved, shared data."""
 


### PR DESCRIPTION
Adds a dimension-surgery view algebra to `tirx.Buffer`: every operation returns a derived view sharing the buffer's data, carries the physical placement (layout iters + swizzle) automatically, and never moves data — an operation either yields a valid view or raises.

## API (torch-aligned names)

| API | Semantics |
| --- | --- |
| `unflatten(dim, sizes)` | split a dim row-major into factors (one `-1` inferred) |
| `flatten(start_dim, end_dim)` | merge adjacent dims; never copies (multi-iter layout axes make the merges legal views) |
| `select(dim, index)` | fix + drop a dim; dynamic `PrimExpr` index folds into `elem_offset` through the dim's layout iters (mixed-radix for multi-iter dims) |
| `narrow(dim, start, length)` | sub-range of a dim; dynamic start on single-iter dims; inner-block alignment enforced on multi-iter dims |
| `Buffer.sub[...]` | numpy basic-indexing view constructor: int drops the dim, `a:b` narrows, `a::s` strides (plain `buf[...]` keeps its BufferLoad/BufferRegion semantics) |
| `rearrange(pattern, **sizes)` | einops-style bijective rearrangement compiled onto unflatten/permute/flatten |

Validation: statically known arguments are checked loudly (bijective factorizations, positive sizes, index/range bounds, singleton-axis sizes matching dim extents); dynamic `PrimExpr` arguments are the caller's responsibility, matching region semantics.

Swizzled-layout offset placement: `select`/`narrow`/`sub` fold their offset into `elem_offset` only when it provably commutes with the swizzle (a multiple of the swizzle period `2^(per_element + atom_len + swizzle_len)`, statically or via the analyzer). A sub-period offset instead stays inside the derived tile layout's `m`-axis offset, where `ComposeLayout` applies the swizzle to it — `swizzle(offset + rest)`, the true address — so every view is exact and none raise. The printer emits this as `T.S[...] + offset` and BufferLoad lowering (`Canonicalize()->Apply`) honors it; each placement is regression-tested per-coordinate against the parent layout, including dynamic offsets and fixed-point windows.

Example — a warp's 16 interleaved rows of a swizzled chunk-major tile, previously a 26-line `T.decl_buffer` restating the full stride/swizzle layout:

```python
k_nope.unflatten(1, (4, 4, 4)).select(2, warp_idx).flatten(1, 2)
# or as a family view:
k_nope.rearrange("b (s w r) c -> b w (s r) c", w=4, r=4)
```

(Here the folded offset `warp_idx * 2048` is a period multiple — proven by the analyzer for the dynamic index — so it lands in `elem_offset`; a non-aligned select would instead carry its offset inside the layout.)

## Also included

- `Buffer.permute` support for swizzle-composed layouts (the foundation: the swizzle permutes the flat offset, so it commutes with logical-dim permutation).
- TVMScript printer fixes surfaced by the roundtrip tests: the decl_buffer slice sugar reparsed as a BufferRegion (not a Buffer) and is removed; parent-candidate choice is now deterministic (name + structural hash) and prefers structurally identical layouts so reshapes print as bare `parent.view(shape)`; the `S`/`R` layout-spec sugar now accepts a plain `PrimExpr` offset term (`T.S[...] + w * 8` reparsed as a crash before).

## Testing

- 12 new parser/printer tests: each method on plain and swizzle-composed layouts, dynamic indices, mixed-radix offsets, sub/rearrange equivalence to explicit chains, static-bounds and misalignment/pattern-error rejection, swizzle-commutation address equivalence, script roundtrips.
- Full `tests/python/tirx` suite green on B200 (2047 passed).

## Notes

PR #23 will be rebased to depend on this PR (its kernels adopt these APIs); merging this first is the intended order.
