### PR TITLE
fix(infra): apply cooldown before every benchmark implementation

### DIFF
--- a/python/tvm/tirx/bench.py
+++ b/python/tvm/tirx/bench.py
@@ -306,13 +306,17 @@ def prepare_input_groups(input_factory, l2_bytes=None):
     }
 
 
+def _sleep_before_impl(cooldown_s):
+    if cooldown_s > 0:
+        time.sleep(cooldown_s)
+
+
 def _bench_event_groups(funcs, groups, warmup, repeat, cooldown_s):
     num_groups = len(groups)
     results = {}
 
-    for idx, (name, func) in enumerate(funcs.items()):
-        if idx > 0:
-            time.sleep(cooldown_s)
+    for name, func in funcs.items():
+        _sleep_before_impl(cooldown_s)
 
         for i in range(warmup):
             func(groups[i % num_groups])
@@ -329,19 +333,25 @@ def _bench_event_groups(funcs, groups, warmup, repeat, cooldown_s):
         torch.cuda.synchronize()
         results[name] = start_event.elapsed_time(end_event) / repeat * 1000.0
 
-        time.sleep(cooldown_s)
-
     return results
 
 
 def _bench_proton_groups(
-    funcs, groups, warmup, repeat, cooldown_s, proton_name, debug, nsight, *, kernel=""
+    funcs,
+    groups,
+    warmup,
+    repeat,
+    cooldown_s,
+    proton_name,
+    debug,
+    nsight,
+    *,
+    kernel="",
 ):
     num_groups = len(groups)
     with ProtonContext(proton_name, debug=debug, nsight=nsight, kernel=kernel) as ctx:
-        for idx, (name, func) in enumerate(funcs.items()):
-            if idx > 0:
-                time.sleep(cooldown_s)
+        for name, func in funcs.items():
+            _sleep_before_impl(cooldown_s)
 
             for i in range(warmup):
                 func(groups[i % num_groups])
@@ -357,8 +367,6 @@ def _bench_proton_groups(
                 for i in range(repeat):
                     func(groups[i % num_groups])
             torch.cuda.synchronize()
-
-            time.sleep(cooldown_s)
 
     return ctx.get_impl_times(), ctx.get_baseline_errors()
 
@@ -409,7 +417,6 @@ def bench_tk(
     flush_l2_size=int(8e8 // 4),
     references=None,
     rounds=1,
-    round_cooldown_s=1.0,
     validate_case=None,
 ):
     """Benchmark implementations with a factory-owned input footprint.
@@ -441,12 +448,11 @@ def bench_tk(
     repeat : int
         Number of timed iterations per round.
     cooldown_s : float
-        Seconds to sleep between impls for thermal cooldown.
+        Seconds to sleep immediately before each implementation's warmup and
+        measurement. The first implementation in the first round is included.
     rounds : int
         Independent benchmark rounds (compile + inputs once; each round runs
         warmup + repeat for every selected impl).
-    round_cooldown_s : float
-        Seconds to sleep between rounds (ignored when ``rounds == 1``).
     validate_case : callable, optional
         Called once on the first prepared ``case`` (after ``prepare_input_groups``,
         before warmup/repeat rounds). Under tir-bench, ``run_kernel_bench`` holds
@@ -466,8 +472,8 @@ def bench_tk(
         raise ValueError("warmup must be non-negative")
     if rounds < 1:
         raise ValueError("rounds must be >= 1")
-    if round_cooldown_s < 0:
-        raise ValueError("round_cooldown_s must be non-negative")
+    if cooldown_s < 0:
+        raise ValueError("cooldown_s must be non-negative")
     if timer not in {"event", "proton"}:
         raise ValueError(f"unsupported timer {timer!r}; expected event or proton")
 
@@ -525,7 +531,6 @@ def bench_tk(
                 "repeat": repeat,
                 "cooldown_s": cooldown_s,
                 "rounds": rounds,
-                "round_cooldown_s": round_cooldown_s,
                 "order": list(funcs.keys()),
             },
         }
@@ -535,9 +540,7 @@ def bench_tk(
 
     errors = dict(build_errors)
     round_samples: dict[str, list[float]] = {}
-    for round_idx in range(rounds):
-        if round_idx > 0:
-            time.sleep(round_cooldown_s)
+    for _ in range(rounds):
         if timer == "event":
             impls = _bench_event_groups(funcs, inputs, warmup, repeat, cooldown_s)
             proton_errors = {}
@@ -573,7 +576,6 @@ def bench_tk(
             "repeat": repeat,
             "cooldown_s": cooldown_s,
             "rounds": rounds,
-            "round_cooldown_s": round_cooldown_s,
             "order": list(funcs.keys()),
         },
     }
@@ -934,8 +936,8 @@ def bench(
     cudagraph_rep=None,
     timer=None,
     references=None,
+    cooldown_s=1.0,
     rounds=1,
-    round_cooldown_s=1.0,
 ):
     """Benchmark pure-launch implementations using Triton-standard timing.
 
@@ -987,13 +989,13 @@ def bench(
         Prefer ``proton`` when the reference has heavy host dispatch (flashinfer,
         CuTeDSL) -- ``event`` would over/under-credit us by measuring the wall, not the
         kernel. (Plain no-flush ``do_bench_cudagraph`` is intentionally NOT offered.)
+    cooldown_s : float
+        Seconds to sleep immediately before each implementation's warmup and
+        measurement. The first implementation in the first round is included.
     rounds : int
         Independent measurement rounds; per-impl times are averaged across
         rounds. (Triton times a single fn with no rounds; this is our sampling
         layer on top.)
-    round_cooldown_s : float
-        Seconds to sleep between rounds (ignored when ``rounds == 1``).
-
     Returns
     -------
     dict
@@ -1011,8 +1013,8 @@ def bench(
         raise ValueError("warmup must be non-negative")
     if rounds < 1:
         raise ValueError("rounds must be >= 1")
-    if round_cooldown_s < 0:
-        raise ValueError("round_cooldown_s must be non-negative")
+    if cooldown_s < 0:
+        raise ValueError("cooldown_s must be non-negative")
     # ``timer=None`` means "use the default timer". The default lives in exactly one
     # place -- here -- so kernels forward ``timer=None`` to inherit it and a future
     # change is a one-line edit. proton = pure per-kernel GPU time; it is honest for
@@ -1083,16 +1085,15 @@ def bench(
 
     protocol = {
         **_eff,
+        "cooldown_s": cooldown_s,
         "rounds": rounds,
-        "round_cooldown_s": round_cooldown_s,
         "order": list(funcs.keys()),
     }
 
     round_samples: dict[str, list[float]] = {}
-    for round_idx in range(rounds):
-        if round_idx > 0:
-            time.sleep(round_cooldown_s)
+    for _ in range(rounds):
         for name, func in funcs.items():
+            _sleep_before_impl(cooldown_s)
             ms = _timer_fn(func, **_timer_kwargs)
             # ms -> microseconds (matches bench_tk unit and pinned baselines).
             round_samples.setdefault(name, []).append(ms * 1000.0)

--- a/tests/python/tirx/test_bench_utils.py
+++ b/tests/python/tirx/test_bench_utils.py
@@ -16,6 +16,8 @@
 # under the License.
 """Tests for tvm.tirx.bench utilities."""
 
+import importlib
+
 import pytest
 import torch
 
@@ -29,6 +31,8 @@ from tvm.tirx.bench import (
     bench_tk,
     tensor_bytes,
 )
+
+bench_module = importlib.import_module("tvm.tirx.bench")
 
 # ── _parse_proton_tree ──────────────────────────────────────────────────────
 
@@ -97,6 +101,35 @@ def test_parse_proton_tree_empty():
 # ── bench_tk (ThunderKittens group-input protocol) ──────────────────────────
 
 
+def test_bench_tk_cooldown_precedes_every_impl(monkeypatch):
+    calls = []
+    sleeps = []
+
+    class FakeEvent:
+        def record(self):
+            pass
+
+        def elapsed_time(self, _other):
+            return 1.0
+
+    monkeypatch.setattr(bench_module.torch.cuda, "Event", lambda **_kwargs: FakeEvent())
+    monkeypatch.setattr(bench_module.torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(bench_module.time, "sleep", sleeps.append)
+
+    funcs = {"a": lambda _case: calls.append("a"), "b": lambda _case: calls.append("b")}
+    for _ in range(2):
+        bench_module._bench_event_groups(
+            funcs,
+            [None],
+            warmup=0,
+            repeat=1,
+            cooldown_s=1.0,
+        )
+
+    assert calls == ["a", "b", "a", "b"]
+    assert sleeps == [1.0, 1.0, 1.0, 1.0]
+
+
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_bench_tk_basic():
@@ -159,6 +192,32 @@ def test_bench_tk_multiple_input_groups():
 
 
 # ── bench (Triton-standard, pure-launch) ─────────────────────────────────────
+
+
+def test_bench_cooldown_precedes_every_impl(monkeypatch):
+    calls = []
+    sleeps = []
+
+    def fake_timer(fn, warmup=25, rep=100):
+        del warmup, rep
+        fn()
+        return 0.001
+
+    monkeypatch.setattr(bench_module, "_do_bench_event", fake_timer)
+    monkeypatch.setattr(bench_module.time, "sleep", sleeps.append)
+
+    results = bench(
+        {"a": lambda: calls.append("a"), "b": lambda: calls.append("b")},
+        warmup=0,
+        repeat=1,
+        timer="event",
+        cooldown_s=1.0,
+        rounds=2,
+    )
+
+    assert calls == ["a", "b", "a", "b"]
+    assert sleeps == [1.0, 1.0, 1.0, 1.0]
+    assert results["benchmark_protocol"]["cooldown_s"] == 1.0
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
## Summary

- add one `cooldown_s` control with a default of 1 second to the pure-launch benchmark path
- apply that cooldown immediately before every implementation in every round, including the first implementation
- use the same scheduling rule for pure-launch, event-group, and Proton-group benchmarks
- remove the redundant `round_cooldown_s` control and record the effective cooldown in benchmark metadata

## Why

Multi-implementation comparisons should give every participant the same thermal setup. A separate round-boundary cooldown was redundant once every implementation received a pre-run cooldown, and could give the first implementation in a round a different delay.

With two implementations and two rounds, the schedule is now exactly:

```text
sleep(1) -> A -> sleep(1) -> B -> sleep(1) -> A -> sleep(1) -> B
```

The sleeps occur before warmup and measurement and are not included in kernel timing.

## Validation

- `python -m pytest tests/python/tirx/test_bench_utils.py -q` (21 passed)
- `pre-commit run --files python/tvm/tirx/bench.py tests/python/tirx/test_bench_utils.py`