### PR TITLE
refactor(infra): benchmark distributed GemmComm kernels

### DIFF
--- a/python/tvm/tirx/bench.py
+++ b/python/tvm/tirx/bench.py
@@ -40,9 +40,7 @@ import tvm
 from tvm.script import tirx as T
 from tvm.support import nvcc
 
-_DISTRIBUTED_EVENT_WARMUP_ITERATIONS = 5
-_DISTRIBUTED_EVENT_REPEAT_ITERATIONS = 30
-_DISTRIBUTED_KINETO_WARMUP_ITERATIONS = 30
+_DISTRIBUTED_KINETO_WARMUP_ITERATIONS = 5
 _DISTRIBUTED_KINETO_REPEAT_ITERATIONS = 30
 _DISTRIBUTED_FLUSH_L2_BYTES = int(8e9)
 _DISTRIBUTED_GPU_SLEEP_CYCLES = int(2e7)
@@ -484,93 +482,62 @@ def _distributed_cold_start(distributed):
     distributed.barrier()
 
 
-def _run_distributed_kineto_batch(name, func, prepare, distributed, iterations):
-    """Run one DeepGEMM-style Kineto phase for a single implementation."""
+def _collect_kineto_span_samples(profiler, scope_names):
+    """Collect one cross-stream GPU activity span for every record-function scope."""
+    scope_events = {scope_name: [] for scope_name in scope_names}
+    for event in profiler.events():
+        if event.device_type == torch.autograd.DeviceType.CUDA and event.name in scope_events:
+            scope_events[event.name].append(event)
+
+    samples = []
+    stream_counts = []
+    for scope_name in scope_names:
+        events = scope_events[scope_name]
+        if not events:
+            raise RuntimeError(
+                f"kineto: profiler attributed no CUDA activity to scope {scope_name!r}"
+            )
+        start_us = min(event.time_range.start for event in events)
+        end_us = max(event.time_range.end for event in events)
+        elapsed_us = float(end_us - start_us)
+        if not math.isfinite(elapsed_us) or elapsed_us <= 0:
+            raise RuntimeError(f"kineto: scope {scope_name!r} has invalid GPU span {elapsed_us} us")
+        samples.append(elapsed_us)
+        stream_counts.append(len({event.device_resource_id for event in events}))
+    return samples, stream_counts
+
+
+def _profile_distributed_kineto_span(name, func, prepare, distributed):
+    """Profile complete correlated GPU activity spans for one implementation."""
     prepare_fn = prepare.get(name)
-    for _ in range(iterations):
-        _distributed_cold_start(distributed)
-        if prepare_fn is not None:
-            prepare_fn()
-        func()
-
-
-def _parse_kineto_time_us(value):
-    units = {"ns": 1e-3, "us": 1.0, "ms": 1e3, "s": 1e6}
-    for unit, scale in units.items():
-        if value.endswith(unit):
-            return float(value[: -len(unit)]) * scale
-    raise RuntimeError(f"kineto: unsupported profiler time value {value!r}")
-
-
-def _collect_named_kineto_time(profiler, kernel_name):
-    """Parse one named CUDA kernel from the standard Kineto table."""
-    lines = (
-        profiler.key_averages()
-        .table(sort_by="cuda_time_total", max_name_column_width=100)
-        .split("\n")
-    )
-    matches = [line for line in lines if kernel_name in line]
-    if len(matches) != 1:
-        raise RuntimeError(
-            f"kineto: expected one profiler row containing {kernel_name!r}, found {len(matches)}"
-        )
-    fields = matches[0].split()
-    try:
-        elapsed_us = _parse_kineto_time_us(fields[-2])
-        call_count = int(fields[-1])
-    except (IndexError, ValueError) as err:
-        raise RuntimeError(
-            f"kineto: could not parse profiler row for {kernel_name!r}: {matches[0]!r}"
-        ) from err
-    if call_count != _DISTRIBUTED_KINETO_REPEAT_ITERATIONS:
-        raise RuntimeError(
-            f"kineto: expected {_DISTRIBUTED_KINETO_REPEAT_ITERATIONS} calls for "
-            f"{kernel_name!r}, found {call_count}"
-        )
-    if not math.isfinite(elapsed_us) or elapsed_us <= 0:
-        raise RuntimeError(
-            f"kineto: named kernel {kernel_name!r} has invalid elapsed time {elapsed_us}"
-        )
-    return elapsed_us
-
-
-def _profile_distributed_kineto(name, func, kernel_name, prepare, distributed):
-    """Faithfully apply DeepGEMM's two-phase named-kernel Kineto protocol."""
     with torch.cuda.stream(distributed.stream):
-        prepare_fn = prepare.get(name)
-        if prepare_fn is not None:
-            prepare_fn()
-        func()
-        distributed.stream.synchronize()
+        for _ in range(_DISTRIBUTED_KINETO_WARMUP_ITERATIONS):
+            _distributed_cold_start(distributed)
+            if prepare_fn is not None:
+                prepare_fn()
+            func()
+            distributed.stream.synchronize()
 
-        schedule = torch.profiler.schedule(wait=0, warmup=1, active=1, repeat=1)
+        scope_names = [
+            f"tirx.bench.{name}.{index:08d}"
+            for index in range(_DISTRIBUTED_KINETO_REPEAT_ITERATIONS)
+        ]
         profiler = torch.profiler.profile(
-            activities=[torch.profiler.ProfilerActivity.CUDA],
-            schedule=schedule,
-            acc_events=True,
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ]
         )
         with profiler:
-            _run_distributed_kineto_batch(
-                name,
-                func,
-                prepare,
-                distributed,
-                _DISTRIBUTED_KINETO_WARMUP_ITERATIONS,
-            )
-            distributed.stream.synchronize()
-            profiler.step()
+            for scope_name in scope_names:
+                _distributed_cold_start(distributed)
+                if prepare_fn is not None:
+                    prepare_fn()
+                with torch.profiler.record_function(scope_name):
+                    func()
+                distributed.stream.synchronize()
 
-            _run_distributed_kineto_batch(
-                name,
-                func,
-                prepare,
-                distributed,
-                _DISTRIBUTED_KINETO_REPEAT_ITERATIONS,
-            )
-            distributed.stream.synchronize()
-            profiler.step()
-
-    return _collect_named_kineto_time(profiler, kernel_name)
+    return _collect_kineto_span_samples(profiler, scope_names)
 
 
 def _distributed_stream_id(stream):
@@ -578,91 +545,31 @@ def _distributed_stream_id(stream):
     return int(value) if value is not None else repr(stream)
 
 
-def _bench_distributed_event(funcs, prepare, distributed, rounds, cooldown_s):
-    """Time complete distributed closures with CUDA events on every rank."""
+def _bench_distributed_kineto_span(funcs, prepare, distributed, rounds, cooldown_s):
+    """Time complete correlated GPU activity spans across all participating streams."""
     items = list(funcs.items())
     round_samples = {name: [] for name in funcs}
+    stream_counts = {name: [] for name in funcs}
     for _ in range(rounds):
         for name, func in items:
             _sleep_before_impl(cooldown_s)
-            distributed.barrier()
-            prepare_fn = prepare.get(name)
-            with torch.cuda.stream(distributed.stream):
-                for _ in range(_DISTRIBUTED_EVENT_WARMUP_ITERATIONS):
-                    _distributed_cold_start(distributed)
-                    if prepare_fn is not None:
-                        prepare_fn()
-                    func()
-            distributed.stream.synchronize()
-
+            local_samples, local_stream_counts = _profile_distributed_kineto_span(
+                name, func, prepare, distributed
+            )
             samples = []
-            for _ in range(_DISTRIBUTED_EVENT_REPEAT_ITERATIONS):
-                start = torch.cuda.Event(enable_timing=True)
-                end = torch.cuda.Event(enable_timing=True)
-                with torch.cuda.stream(distributed.stream):
-                    _distributed_cold_start(distributed)
-                    if prepare_fn is not None:
-                        prepare_fn()
-                    start.record()
-                    func()
-                    end.record()
-                distributed.stream.synchronize()
-                elapsed_us = float(distributed.max_reduce(start.elapsed_time(end) * 1000.0))
+            for local_us in local_samples:
+                elapsed_us = float(distributed.max_reduce(local_us))
                 if not math.isfinite(elapsed_us) or elapsed_us <= 0:
                     raise RuntimeError(
-                        "event: distributed max-reduce returned invalid elapsed time "
+                        "kineto: distributed max-reduce returned invalid activity span "
                         f"for {name!r}: {elapsed_us}"
                     )
                 samples.append(elapsed_us)
             round_samples[name].append(statistics.median(samples))
-            distributed.barrier()
-
-    return {
-        "impls": {name: statistics.mean(samples) for name, samples in round_samples.items()},
-        "round_samples": round_samples,
-        "errors": {},
-        "timer": "event",
-        "benchmark_protocol": {
-            "source": "torch.cuda.Event",
-            "timing_scope": "complete launch closure",
-            "timing_stream": _distributed_stream_id(distributed.stream),
-            "auxiliary_streams_join_timing_stream": True,
-            "warmup_iterations": _DISTRIBUTED_EVENT_WARMUP_ITERATIONS,
-            "repeat_iterations": _DISTRIBUTED_EVENT_REPEAT_ITERATIONS,
-            "flush_l2": True,
-            "flush_l2_bytes": _DISTRIBUTED_FLUSH_L2_BYTES,
-            "gpu_sleep_cycles": _DISTRIBUTED_GPU_SLEEP_CYCLES,
-            "rank_barrier_before_each_launch": True,
-            "cold_start_outside_timing": True,
-            "prepare_outside_timing": True,
-            "rank_aggregate": "sample_wise_max",
-            "sample_aggregate": "median",
-            "round_aggregate": "mean",
-            "world_size": distributed.world_size,
-            "rounds": rounds,
-            "cooldown_s": cooldown_s,
-            "order": [name for name, _ in items],
-        },
-    }
-
-
-def _bench_distributed_kineto(funcs, prepare, distributed, rounds, cooldown_s, kineto_kernel_names):
-    """Run DeepGEMM's named-kernel Kineto table protocol."""
-    items = list(funcs.items())
-    round_samples = {name: [] for name in funcs}
-    for _ in range(rounds):
-        for name, func in items:
-            _sleep_before_impl(cooldown_s)
-            local_us = _profile_distributed_kineto(
-                name, func, kineto_kernel_names[name], prepare, distributed
+            stream_counts[name].append(
+                {"min": min(local_stream_counts), "max": max(local_stream_counts)}
             )
-            elapsed_us = float(distributed.max_reduce(local_us))
-            if not math.isfinite(elapsed_us) or elapsed_us <= 0:
-                raise RuntimeError(
-                    "kineto: distributed max-reduce returned invalid elapsed time "
-                    f"for {name!r}: {elapsed_us}"
-                )
-            round_samples[name].append(elapsed_us)
+            distributed.barrier()
 
     return {
         "impls": {name: statistics.mean(samples) for name, samples in round_samples.items()},
@@ -670,25 +577,27 @@ def _bench_distributed_kineto(funcs, prepare, distributed, rounds, cooldown_s, k
         "errors": {},
         "timer": "kineto",
         "benchmark_protocol": {
-            "source": "DeepGEMM bench_kineto named-kernel table",
-            "timing_scope": "named CUDA kernel only",
-            "kernel_names": dict(kineto_kernel_names),
+            "source": "torch.profiler Kineto correlated CUDA activities",
+            "timing_scope": "complete correlated GPU activity span",
+            "span_definition": "latest activity end minus earliest activity start",
             "timing_stream": _distributed_stream_id(distributed.stream),
-            "preflight_iterations": 1,
+            "all_correlated_streams": True,
             "warmup_iterations": _DISTRIBUTED_KINETO_WARMUP_ITERATIONS,
             "repeat_iterations": _DISTRIBUTED_KINETO_REPEAT_ITERATIONS,
             "flush_l2": True,
             "flush_l2_bytes": _DISTRIBUTED_FLUSH_L2_BYTES,
             "gpu_sleep_cycles": _DISTRIBUTED_GPU_SLEEP_CYCLES,
             "rank_barrier_before_each_launch": True,
-            "prepare_excluded_by_kernel_name": True,
-            "profile_session_scope": "per_implementation",
-            "rank_aggregate": "max",
+            "cold_start_outside_scope": True,
+            "prepare_outside_scope": True,
+            "rank_aggregate": "sample_wise_max",
+            "sample_aggregate": "median",
             "round_aggregate": "mean",
             "world_size": distributed.world_size,
             "rounds": rounds,
             "cooldown_s": cooldown_s,
             "order": [name for name, _ in items],
+            "rank_local_scope_stream_counts": stream_counts,
         },
     }
 
@@ -705,7 +614,6 @@ def bench(
     rounds=1,
     distributed=None,
     prepare=None,
-    kineto_kernel_names=None,
 ):
     """Benchmark pure-launch implementations using Triton-standard timing.
 
@@ -740,7 +648,7 @@ def bench(
         here.
     timer : {None, "event", "proton", "cudagraph_proton", "kineto"}
         ``None`` (default) resolves to ``proton`` for a local benchmark and to
-        ``event`` when ``distributed`` is present.  The default is defined in
+        ``kineto`` when ``distributed`` is present.  The default is defined in
         exactly one place so kernels pass ``None`` to inherit.
         ``event`` -> ported ``do_bench`` (CUDA-event wall of each call).
         ``proton`` -> ported ``do_bench_proton``: same setup as ``event``, differs
@@ -756,22 +664,18 @@ def bench(
         CuTeDSL) -- ``event`` would over/under-credit us by measuring the wall, not the
         kernel. Timer failures are propagated; a result is never silently relabelled
         after falling back to a different measurement method.
-        Distributed ``event`` measures each complete launch closure with CUDA
-        events and performs sample-wise slowest-rank aggregation.  Both distributed
-        timers apply DeepGEMM's 8 GB L2 flush, GPU sleep, and rank barrier before
-        every launch.  Distributed ``kineto`` uses DeepGEMM's two-phase,
-        30-iteration schedule and parses only the named CUDA kernel row.  Both
-        timers use fixed iteration counts and reject local timer budget overrides.
+        A distributed benchmark supports only ``kineto``.  It measures the complete
+        correlated GPU activity span across all streams, performs sample-wise
+        slowest-rank aggregation, and applies DeepGEMM's 8 GB L2 flush, GPU sleep,
+        and rank barrier before every launch.  Distributed timing uses fixed
+        iteration counts and rejects local timer budget overrides.
     distributed : DistributedBenchContext, optional
         Rank-local barrier, max-reduce callback, and actual CUDA timing stream.
         Launch closures that use auxiliary streams must make the timing stream
         wait for them before returning.
     prepare : dict[str, callable], optional
-        Per-implementation reset/preparation callbacks.  CUDA events are recorded
-        after preparation; Kineto excludes preparation through named-kernel parsing.
-    kineto_kernel_names : dict[str, str], optional
-        Required for distributed ``kineto``. Maps each implementation to the
-        unique CUDA kernel-name substring extracted from the Kineto table.
+        Per-implementation reset/preparation callbacks.  Kineto scopes begin after
+        preparation, so preparation activities are excluded from the measured span.
     rounds : int
         Independent measurement rounds; per-impl times are averaged across
         rounds. (Triton times a single fn with no rounds; this is our sampling
@@ -793,8 +697,6 @@ def bench(
     if distributed is None:
         if prepare is not None:
             raise ValueError("prepare is supported only with a distributed context")
-        if kineto_kernel_names is not None:
-            raise ValueError("kineto_kernel_names requires a distributed context")
         if repeat is not None and repeat <= 0:
             raise ValueError("repeat must be positive")
         if warmup is not None and warmup < 0:
@@ -808,9 +710,9 @@ def bench(
     else:
         _validate_distributed_context(distributed)
         if timer is None:
-            timer = "event"
-        elif timer not in {"event", "kineto"}:
-            raise ValueError("a distributed context supports only timer='event' or timer='kineto'")
+            timer = "kineto"
+        elif timer != "kineto":
+            raise ValueError("a distributed context supports only timer='kineto'")
         overrides = [
             name
             for name, value in (
@@ -862,28 +764,9 @@ def bench(
                 raise ValueError(f"prepare contains unknown implementation {name!r}")
             if not callable(prepare_fn):
                 raise TypeError(f"prepare[{name!r}] must be callable")
-        if timer == "event":
-            if kineto_kernel_names is not None:
-                raise ValueError("kineto_kernel_names is valid only for timer='kineto'")
-            result = _bench_distributed_event(
-                funcs, prepare, distributed, rounds=rounds, cooldown_s=cooldown_s
-            )
-        else:
-            if not isinstance(kineto_kernel_names, Mapping):
-                raise TypeError("timer='kineto' requires kineto_kernel_names mapping")
-            if set(kineto_kernel_names) != set(funcs):
-                raise ValueError("kineto_kernel_names must cover every implementation exactly")
-            for name, kernel_name in kineto_kernel_names.items():
-                if not isinstance(kernel_name, str) or not kernel_name:
-                    raise TypeError(f"kineto_kernel_names[{name!r}] must be a non-empty string")
-            result = _bench_distributed_kineto(
-                funcs,
-                prepare,
-                distributed,
-                rounds=rounds,
-                cooldown_s=cooldown_s,
-                kineto_kernel_names=kineto_kernel_names,
-            )
+        result = _bench_distributed_kineto_span(
+            funcs, prepare, distributed, rounds=rounds, cooldown_s=cooldown_s
+        )
         result["errors"] = build_errors
         return result
 

--- a/python/tvm/tirx/bench.py
+++ b/python/tvm/tirx/bench.py
@@ -44,8 +44,8 @@ _DISTRIBUTED_EVENT_WARMUP_ITERATIONS = 5
 _DISTRIBUTED_EVENT_REPEAT_ITERATIONS = 30
 _DISTRIBUTED_KINETO_WARMUP_ITERATIONS = 30
 _DISTRIBUTED_KINETO_REPEAT_ITERATIONS = 30
-_DISTRIBUTED_KINETO_FLUSH_L2_BYTES = int(8e9)
-_DISTRIBUTED_KINETO_GPU_SLEEP_CYCLES = int(2e7)
+_DISTRIBUTED_FLUSH_L2_BYTES = int(8e9)
+_DISTRIBUTED_GPU_SLEEP_CYCLES = int(2e7)
 
 
 @dataclass(frozen=True)
@@ -473,14 +473,14 @@ def _validate_distributed_context(distributed):
         raise TypeError("distributed.stream must be an actual CUDA stream")
 
 
-def _distributed_kineto_cold_start(distributed):
-    """Apply DeepGEMM's cold-cache protocol before one profiled launch."""
+def _distributed_cold_start(distributed):
+    """Apply DeepGEMM's cold-cache protocol before one distributed launch."""
     torch.empty(
-        _DISTRIBUTED_KINETO_FLUSH_L2_BYTES // 4,
+        _DISTRIBUTED_FLUSH_L2_BYTES // 4,
         dtype=torch.int,
         device="cuda",
     ).zero_()
-    torch.cuda._sleep(_DISTRIBUTED_KINETO_GPU_SLEEP_CYCLES)
+    torch.cuda._sleep(_DISTRIBUTED_GPU_SLEEP_CYCLES)
     distributed.barrier()
 
 
@@ -488,7 +488,7 @@ def _run_distributed_kineto_batch(name, func, prepare, distributed, iterations):
     """Run one DeepGEMM-style Kineto phase for a single implementation."""
     prepare_fn = prepare.get(name)
     for _ in range(iterations):
-        _distributed_kineto_cold_start(distributed)
+        _distributed_cold_start(distributed)
         if prepare_fn is not None:
             prepare_fn()
         func()
@@ -589,6 +589,7 @@ def _bench_distributed_event(funcs, prepare, distributed, rounds, cooldown_s):
             prepare_fn = prepare.get(name)
             with torch.cuda.stream(distributed.stream):
                 for _ in range(_DISTRIBUTED_EVENT_WARMUP_ITERATIONS):
+                    _distributed_cold_start(distributed)
                     if prepare_fn is not None:
                         prepare_fn()
                     func()
@@ -599,6 +600,7 @@ def _bench_distributed_event(funcs, prepare, distributed, rounds, cooldown_s):
                 start = torch.cuda.Event(enable_timing=True)
                 end = torch.cuda.Event(enable_timing=True)
                 with torch.cuda.stream(distributed.stream):
+                    _distributed_cold_start(distributed)
                     if prepare_fn is not None:
                         prepare_fn()
                     start.record()
@@ -627,6 +629,11 @@ def _bench_distributed_event(funcs, prepare, distributed, rounds, cooldown_s):
             "auxiliary_streams_join_timing_stream": True,
             "warmup_iterations": _DISTRIBUTED_EVENT_WARMUP_ITERATIONS,
             "repeat_iterations": _DISTRIBUTED_EVENT_REPEAT_ITERATIONS,
+            "flush_l2": True,
+            "flush_l2_bytes": _DISTRIBUTED_FLUSH_L2_BYTES,
+            "gpu_sleep_cycles": _DISTRIBUTED_GPU_SLEEP_CYCLES,
+            "rank_barrier_before_each_launch": True,
+            "cold_start_outside_timing": True,
             "prepare_outside_timing": True,
             "rank_aggregate": "sample_wise_max",
             "sample_aggregate": "median",
@@ -671,8 +678,8 @@ def _bench_distributed_kineto(funcs, prepare, distributed, rounds, cooldown_s, k
             "warmup_iterations": _DISTRIBUTED_KINETO_WARMUP_ITERATIONS,
             "repeat_iterations": _DISTRIBUTED_KINETO_REPEAT_ITERATIONS,
             "flush_l2": True,
-            "flush_l2_bytes": _DISTRIBUTED_KINETO_FLUSH_L2_BYTES,
-            "gpu_sleep_cycles": _DISTRIBUTED_KINETO_GPU_SLEEP_CYCLES,
+            "flush_l2_bytes": _DISTRIBUTED_FLUSH_L2_BYTES,
+            "gpu_sleep_cycles": _DISTRIBUTED_GPU_SLEEP_CYCLES,
             "rank_barrier_before_each_launch": True,
             "prepare_excluded_by_kernel_name": True,
             "profile_session_scope": "per_implementation",
@@ -750,11 +757,11 @@ def bench(
         kernel. Timer failures are propagated; a result is never silently relabelled
         after falling back to a different measurement method.
         Distributed ``event`` measures each complete launch closure with CUDA
-        events and performs sample-wise slowest-rank aggregation.  Distributed
-        ``kineto`` faithfully uses DeepGEMM's two-phase, 30-iteration, 8 GB L2
-        flush and GPU-sleep protocol, then parses only the named CUDA kernel row.
-        Both distributed timers use fixed iteration counts and reject local timer
-        budget overrides.
+        events and performs sample-wise slowest-rank aggregation.  Both distributed
+        timers apply DeepGEMM's 8 GB L2 flush, GPU sleep, and rank barrier before
+        every launch.  Distributed ``kineto`` uses DeepGEMM's two-phase,
+        30-iteration schedule and parses only the named CUDA kernel row.  Both
+        timers use fixed iteration counts and reject local timer budget overrides.
     distributed : DistributedBenchContext, optional
         Rank-local barrier, max-reduce callback, and actual CUDA timing stream.
         Launch closures that use auxiliary streams must make the timing stream

--- a/python/tvm/tirx/bench.py
+++ b/python/tvm/tirx/bench.py
@@ -26,8 +26,9 @@ import sys
 import tempfile
 import time
 import uuid
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager
+from dataclasses import dataclass
 from enum import Enum
 
 import numpy as np
@@ -38,6 +39,41 @@ import tvm_ffi
 import tvm
 from tvm.script import tirx as T
 from tvm.support import nvcc
+
+_DISTRIBUTED_EVENT_WARMUP_ITERATIONS = 5
+_DISTRIBUTED_EVENT_REPEAT_ITERATIONS = 30
+_DISTRIBUTED_KINETO_WARMUP_ITERATIONS = 30
+_DISTRIBUTED_KINETO_REPEAT_ITERATIONS = 30
+_DISTRIBUTED_KINETO_FLUSH_L2_BYTES = int(8e9)
+_DISTRIBUTED_KINETO_GPU_SLEEP_CYCLES = int(2e7)
+
+
+@dataclass(frozen=True)
+class DistributedBenchContext:
+    """Rank-local synchronization needed by the distributed Kineto timer.
+
+    Parameters
+    ----------
+    rank : int
+        Rank of the current process.
+    world_size : int
+        Number of ranks participating in the benchmark.
+    barrier : callable
+        Host callback that blocks until every rank reaches the same point.
+    max_reduce : callable
+        Host callback that returns the maximum of one floating-point value over
+        all ranks.  The distributed timer calls it once per measured launch.
+    stream : torch.cuda.Stream
+        The actual CUDA stream whose launch scope is being timed.  Launch
+        closures that use auxiliary streams must make this stream wait for them
+        before returning.
+    """
+
+    rank: int
+    world_size: int
+    barrier: Callable[[], None]
+    max_reduce: Callable[[float], float]
+    stream: object
 
 
 def is_running_under_pytest():
@@ -414,6 +450,242 @@ def _sleep_before_impl(cooldown_s):
         time.sleep(cooldown_s)
 
 
+def _validate_distributed_context(distributed):
+    if not isinstance(distributed, DistributedBenchContext):
+        raise TypeError("distributed must be a DistributedBenchContext")
+    if (
+        not isinstance(distributed.world_size, int)
+        or isinstance(distributed.world_size, bool)
+        or distributed.world_size < 1
+    ):
+        raise ValueError("distributed.world_size must be a positive integer")
+    if (
+        not isinstance(distributed.rank, int)
+        or isinstance(distributed.rank, bool)
+        or not 0 <= distributed.rank < distributed.world_size
+    ):
+        raise ValueError("distributed.rank must be in [0, world_size)")
+    if not callable(distributed.barrier):
+        raise TypeError("distributed.barrier must be callable")
+    if not callable(distributed.max_reduce):
+        raise TypeError("distributed.max_reduce must be callable")
+    if not hasattr(distributed.stream, "synchronize"):
+        raise TypeError("distributed.stream must be an actual CUDA stream")
+
+
+def _distributed_kineto_cold_start(distributed):
+    """Apply DeepGEMM's cold-cache protocol before one profiled launch."""
+    torch.empty(
+        _DISTRIBUTED_KINETO_FLUSH_L2_BYTES // 4,
+        dtype=torch.int,
+        device="cuda",
+    ).zero_()
+    torch.cuda._sleep(_DISTRIBUTED_KINETO_GPU_SLEEP_CYCLES)
+    distributed.barrier()
+
+
+def _run_distributed_kineto_batch(name, func, prepare, distributed, iterations):
+    """Run one DeepGEMM-style Kineto phase for a single implementation."""
+    prepare_fn = prepare.get(name)
+    for _ in range(iterations):
+        _distributed_kineto_cold_start(distributed)
+        if prepare_fn is not None:
+            prepare_fn()
+        func()
+
+
+def _parse_kineto_time_us(value):
+    units = {"ns": 1e-3, "us": 1.0, "ms": 1e3, "s": 1e6}
+    for unit, scale in units.items():
+        if value.endswith(unit):
+            return float(value[: -len(unit)]) * scale
+    raise RuntimeError(f"kineto: unsupported profiler time value {value!r}")
+
+
+def _collect_named_kineto_time(profiler, kernel_name):
+    """Parse one named CUDA kernel from the standard Kineto table."""
+    lines = (
+        profiler.key_averages()
+        .table(sort_by="cuda_time_total", max_name_column_width=100)
+        .split("\n")
+    )
+    matches = [line for line in lines if kernel_name in line]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"kineto: expected one profiler row containing {kernel_name!r}, found {len(matches)}"
+        )
+    fields = matches[0].split()
+    try:
+        elapsed_us = _parse_kineto_time_us(fields[-2])
+        call_count = int(fields[-1])
+    except (IndexError, ValueError) as err:
+        raise RuntimeError(
+            f"kineto: could not parse profiler row for {kernel_name!r}: {matches[0]!r}"
+        ) from err
+    if call_count != _DISTRIBUTED_KINETO_REPEAT_ITERATIONS:
+        raise RuntimeError(
+            f"kineto: expected {_DISTRIBUTED_KINETO_REPEAT_ITERATIONS} calls for "
+            f"{kernel_name!r}, found {call_count}"
+        )
+    if not math.isfinite(elapsed_us) or elapsed_us <= 0:
+        raise RuntimeError(
+            f"kineto: named kernel {kernel_name!r} has invalid elapsed time {elapsed_us}"
+        )
+    return elapsed_us
+
+
+def _profile_distributed_kineto(name, func, kernel_name, prepare, distributed):
+    """Faithfully apply DeepGEMM's two-phase named-kernel Kineto protocol."""
+    with torch.cuda.stream(distributed.stream):
+        prepare_fn = prepare.get(name)
+        if prepare_fn is not None:
+            prepare_fn()
+        func()
+        distributed.stream.synchronize()
+
+        schedule = torch.profiler.schedule(wait=0, warmup=1, active=1, repeat=1)
+        profiler = torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CUDA],
+            schedule=schedule,
+            acc_events=True,
+        )
+        with profiler:
+            _run_distributed_kineto_batch(
+                name,
+                func,
+                prepare,
+                distributed,
+                _DISTRIBUTED_KINETO_WARMUP_ITERATIONS,
+            )
+            distributed.stream.synchronize()
+            profiler.step()
+
+            _run_distributed_kineto_batch(
+                name,
+                func,
+                prepare,
+                distributed,
+                _DISTRIBUTED_KINETO_REPEAT_ITERATIONS,
+            )
+            distributed.stream.synchronize()
+            profiler.step()
+
+    return _collect_named_kineto_time(profiler, kernel_name)
+
+
+def _distributed_stream_id(stream):
+    value = getattr(stream, "cuda_stream", None)
+    return int(value) if value is not None else repr(stream)
+
+
+def _bench_distributed_event(funcs, prepare, distributed, rounds, cooldown_s):
+    """Time complete distributed closures with CUDA events on every rank."""
+    items = list(funcs.items())
+    round_samples = {name: [] for name in funcs}
+    for _ in range(rounds):
+        for name, func in items:
+            _sleep_before_impl(cooldown_s)
+            distributed.barrier()
+            prepare_fn = prepare.get(name)
+            with torch.cuda.stream(distributed.stream):
+                for _ in range(_DISTRIBUTED_EVENT_WARMUP_ITERATIONS):
+                    if prepare_fn is not None:
+                        prepare_fn()
+                    func()
+            distributed.stream.synchronize()
+
+            samples = []
+            for _ in range(_DISTRIBUTED_EVENT_REPEAT_ITERATIONS):
+                start = torch.cuda.Event(enable_timing=True)
+                end = torch.cuda.Event(enable_timing=True)
+                with torch.cuda.stream(distributed.stream):
+                    if prepare_fn is not None:
+                        prepare_fn()
+                    start.record()
+                    func()
+                    end.record()
+                distributed.stream.synchronize()
+                elapsed_us = float(distributed.max_reduce(start.elapsed_time(end) * 1000.0))
+                if not math.isfinite(elapsed_us) or elapsed_us <= 0:
+                    raise RuntimeError(
+                        "event: distributed max-reduce returned invalid elapsed time "
+                        f"for {name!r}: {elapsed_us}"
+                    )
+                samples.append(elapsed_us)
+            round_samples[name].append(statistics.median(samples))
+            distributed.barrier()
+
+    return {
+        "impls": {name: statistics.mean(samples) for name, samples in round_samples.items()},
+        "round_samples": round_samples,
+        "errors": {},
+        "timer": "event",
+        "benchmark_protocol": {
+            "source": "torch.cuda.Event",
+            "timing_scope": "complete launch closure",
+            "timing_stream": _distributed_stream_id(distributed.stream),
+            "auxiliary_streams_join_timing_stream": True,
+            "warmup_iterations": _DISTRIBUTED_EVENT_WARMUP_ITERATIONS,
+            "repeat_iterations": _DISTRIBUTED_EVENT_REPEAT_ITERATIONS,
+            "prepare_outside_timing": True,
+            "rank_aggregate": "sample_wise_max",
+            "sample_aggregate": "median",
+            "round_aggregate": "mean",
+            "world_size": distributed.world_size,
+            "rounds": rounds,
+            "cooldown_s": cooldown_s,
+            "order": [name for name, _ in items],
+        },
+    }
+
+
+def _bench_distributed_kineto(funcs, prepare, distributed, rounds, cooldown_s, kineto_kernel_names):
+    """Run DeepGEMM's named-kernel Kineto table protocol."""
+    items = list(funcs.items())
+    round_samples = {name: [] for name in funcs}
+    for _ in range(rounds):
+        for name, func in items:
+            _sleep_before_impl(cooldown_s)
+            local_us = _profile_distributed_kineto(
+                name, func, kineto_kernel_names[name], prepare, distributed
+            )
+            elapsed_us = float(distributed.max_reduce(local_us))
+            if not math.isfinite(elapsed_us) or elapsed_us <= 0:
+                raise RuntimeError(
+                    "kineto: distributed max-reduce returned invalid elapsed time "
+                    f"for {name!r}: {elapsed_us}"
+                )
+            round_samples[name].append(elapsed_us)
+
+    return {
+        "impls": {name: statistics.mean(samples) for name, samples in round_samples.items()},
+        "round_samples": round_samples,
+        "errors": {},
+        "timer": "kineto",
+        "benchmark_protocol": {
+            "source": "DeepGEMM bench_kineto named-kernel table",
+            "timing_scope": "named CUDA kernel only",
+            "kernel_names": dict(kineto_kernel_names),
+            "timing_stream": _distributed_stream_id(distributed.stream),
+            "preflight_iterations": 1,
+            "warmup_iterations": _DISTRIBUTED_KINETO_WARMUP_ITERATIONS,
+            "repeat_iterations": _DISTRIBUTED_KINETO_REPEAT_ITERATIONS,
+            "flush_l2": True,
+            "flush_l2_bytes": _DISTRIBUTED_KINETO_FLUSH_L2_BYTES,
+            "gpu_sleep_cycles": _DISTRIBUTED_KINETO_GPU_SLEEP_CYCLES,
+            "rank_barrier_before_each_launch": True,
+            "prepare_excluded_by_kernel_name": True,
+            "profile_session_scope": "per_implementation",
+            "rank_aggregate": "max",
+            "round_aggregate": "mean",
+            "world_size": distributed.world_size,
+            "rounds": rounds,
+            "cooldown_s": cooldown_s,
+            "order": [name for name, _ in items],
+        },
+    }
+
+
 def bench(
     funcs,
     *,
@@ -424,6 +696,9 @@ def bench(
     references=None,
     cooldown_s=1.0,
     rounds=1,
+    distributed=None,
+    prepare=None,
+    kineto_kernel_names=None,
 ):
     """Benchmark pure-launch implementations using Triton-standard timing.
 
@@ -456,9 +731,10 @@ def bench(
         (default) defers to that timer's own default. Each timer default lives only
         in its own signature (Triton: do_bench 25/100, graph 20); nothing is hardcoded
         here.
-    timer : {None, "event", "proton", "cudagraph_proton"}
-        ``None`` (default) resolves to ``proton`` -- see the resolution in the body;
-        the default is defined in exactly one place so kernels pass ``None`` to inherit.
+    timer : {None, "event", "proton", "cudagraph_proton", "kineto"}
+        ``None`` (default) resolves to ``proton`` for a local benchmark and to
+        ``event`` when ``distributed`` is present.  The default is defined in
+        exactly one place so kernels pass ``None`` to inherit.
         ``event`` -> ported ``do_bench`` (CUDA-event wall of each call).
         ``proton`` -> ported ``do_bench_proton``: same setup as ``event``, differs
         ONLY in timing -- Proton per-kernel GPU time instead of the event wall (so
@@ -473,13 +749,28 @@ def bench(
         CuTeDSL) -- ``event`` would over/under-credit us by measuring the wall, not the
         kernel. Timer failures are propagated; a result is never silently relabelled
         after falling back to a different measurement method.
+        Distributed ``event`` measures each complete launch closure with CUDA
+        events and performs sample-wise slowest-rank aggregation.  Distributed
+        ``kineto`` faithfully uses DeepGEMM's two-phase, 30-iteration, 8 GB L2
+        flush and GPU-sleep protocol, then parses only the named CUDA kernel row.
+        Both distributed timers use fixed iteration counts and reject local timer
+        budget overrides.
+    distributed : DistributedBenchContext, optional
+        Rank-local barrier, max-reduce callback, and actual CUDA timing stream.
+        Launch closures that use auxiliary streams must make the timing stream
+        wait for them before returning.
+    prepare : dict[str, callable], optional
+        Per-implementation reset/preparation callbacks.  CUDA events are recorded
+        after preparation; Kineto excludes preparation through named-kernel parsing.
+    kineto_kernel_names : dict[str, str], optional
+        Required for distributed ``kineto``. Maps each implementation to the
+        unique CUDA kernel-name substring extracted from the Kineto table.
     rounds : int
         Independent measurement rounds; per-impl times are averaged across
         rounds. (Triton times a single fn with no rounds; this is our sampling
         layer on top.)
     cooldown_s : float
-        Seconds to sleep immediately before each implementation's warmup and
-        measurement. The first implementation in the first round is included.
+        Seconds to sleep immediately before each implementation in every round.
 
     Returns
     -------
@@ -487,31 +778,46 @@ def bench(
         ``{"impls": {name: us}, "round_samples": {name: [us, ...]}, ...}``.
         Times are stored in microseconds (same unit as the pinned tir-bench baselines).
     """
-    # warmup/repeat/cudagraph_rep default to None = "use the timer function's own
-    # (Triton-aligned) default". They are only forwarded to the timer below when a
-    # caller explicitly overrides, so the defaults live in exactly one place: the
-    # _do_bench_* signatures.
-    if repeat is not None and repeat <= 0:
-        raise ValueError("repeat must be positive")
-    if warmup is not None and warmup < 0:
-        raise ValueError("warmup must be non-negative")
-    if rounds < 1:
+    if not isinstance(rounds, int) or isinstance(rounds, bool) or rounds < 1:
         raise ValueError("rounds must be >= 1")
     if cooldown_s < 0:
         raise ValueError("cooldown_s must be non-negative")
-    # ``timer=None`` means "use the default timer". The default lives in exactly one
-    # place -- here -- so kernels forward ``timer=None`` to inherit it and a future
-    # change is a one-line edit. proton = pure per-kernel GPU time; it is honest for
-    # references with heavy host dispatch (flashinfer, CuTeDSL) where the ``event``
-    # wall would over/under-credit us, and matches event within a few % on
-    # compute-bound kernels. A Proton failure is explicit so the recorded timer
-    # always names the quantity that was actually measured.
-    if timer is None:
-        timer = "proton"
-    if timer not in {"event", "proton", "cudagraph_proton"}:
-        raise ValueError(
-            f"unsupported timer {timer!r}; expected event, proton, or cudagraph_proton"
-        )
+
+    if distributed is None:
+        if prepare is not None:
+            raise ValueError("prepare is supported only with a distributed context")
+        if kineto_kernel_names is not None:
+            raise ValueError("kineto_kernel_names requires a distributed context")
+        if repeat is not None and repeat <= 0:
+            raise ValueError("repeat must be positive")
+        if warmup is not None and warmup < 0:
+            raise ValueError("warmup must be non-negative")
+        if timer is None:
+            timer = "proton"
+        if timer not in {"event", "proton", "cudagraph_proton"}:
+            raise ValueError(
+                f"unsupported timer {timer!r}; expected event, proton, or cudagraph_proton"
+            )
+    else:
+        _validate_distributed_context(distributed)
+        if timer is None:
+            timer = "event"
+        elif timer not in {"event", "kineto"}:
+            raise ValueError("a distributed context supports only timer='event' or timer='kineto'")
+        overrides = [
+            name
+            for name, value in (
+                ("warmup", warmup),
+                ("repeat", repeat),
+                ("cudagraph_rep", cudagraph_rep),
+            )
+            if value is not None
+        ]
+        if overrides:
+            raise ValueError(
+                f"timer={timer!r} uses fixed iteration counts and rejects overrides: "
+                + ", ".join(overrides)
+            )
     if not isinstance(funcs, Mapping) or not funcs:
         raise TypeError("funcs must be a non-empty mapping of name to no-arg callable")
     for name, func in funcs.items():
@@ -538,6 +844,41 @@ def bench(
         if not callable(ref_fn):
             raise TypeError(f"references[{ref_name!r}] builder must return a callable")
         funcs = {**funcs, ref_name: ref_fn}
+
+    if distributed is not None:
+        if prepare is None:
+            prepare = {}
+        if not isinstance(prepare, Mapping):
+            raise TypeError("prepare must map implementation names to no-arg callables")
+        for name, prepare_fn in prepare.items():
+            if name not in funcs:
+                raise ValueError(f"prepare contains unknown implementation {name!r}")
+            if not callable(prepare_fn):
+                raise TypeError(f"prepare[{name!r}] must be callable")
+        if timer == "event":
+            if kineto_kernel_names is not None:
+                raise ValueError("kineto_kernel_names is valid only for timer='kineto'")
+            result = _bench_distributed_event(
+                funcs, prepare, distributed, rounds=rounds, cooldown_s=cooldown_s
+            )
+        else:
+            if not isinstance(kineto_kernel_names, Mapping):
+                raise TypeError("timer='kineto' requires kineto_kernel_names mapping")
+            if set(kineto_kernel_names) != set(funcs):
+                raise ValueError("kineto_kernel_names must cover every implementation exactly")
+            for name, kernel_name in kineto_kernel_names.items():
+                if not isinstance(kernel_name, str) or not kernel_name:
+                    raise TypeError(f"kineto_kernel_names[{name!r}] must be a non-empty string")
+            result = _bench_distributed_kineto(
+                funcs,
+                prepare,
+                distributed,
+                rounds=rounds,
+                cooldown_s=cooldown_s,
+                kineto_kernel_names=kineto_kernel_names,
+            )
+        result["errors"] = build_errors
+        return result
 
     # Resolve the timer function once. Only forward warmup/repeat/cudagraph_rep when a
     # caller explicitly overrode them; otherwise the _do_bench_* signature default

--- a/src/runtime/extra/contrib/nvshmem/dist_gemm.cu
+++ b/src/runtime/extra/contrib/nvshmem/dist_gemm.cu
@@ -22,7 +22,8 @@
 #include <tvm/ffi/extra/cuda/base.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/runtime/disco/disco_worker.h>
+#include <tvm/runtime/device_api.h>
+#include <tvm/runtime/tensor.h>
 
 namespace tvm {
 namespace runtime {
@@ -57,24 +58,28 @@ void copy_to_peer(void* dst, int dst_device, void* src, size_t size, TVMStreamHa
   cudaMemcpyAsync(remote_dst, src, size, cudaMemcpyDefault, CUstream(stream));
 }
 
+Device current_cuda_device() {
+  int device_id;
+  TVM_FFI_CHECK_CUDA_ERROR(cudaGetDevice(&device_id));
+  return Device{DLDeviceType::kDLCUDA, device_id};
+}
+
 TVMStreamHandle stream_create() {
-  DiscoWorker* worker = ThreadLocalDiscoWorker::Get()->worker;
-  TVM_FFI_ICHECK(worker != nullptr) << "NVSHMEM stream creation failed: worker is not initialized";
-  cudaStream_t retval;
-  TVM_FFI_CHECK_CUDA_ERROR(cudaStreamCreateWithFlags(&retval, cudaStreamNonBlocking));
-  return static_cast<TVMStreamHandle>(retval);
+  Device device = current_cuda_device();
+  return DeviceAPI::Get(device)->CreateStream(device);
 }
 
 void stream_sync(TVMStreamHandle from_stream, TVMStreamHandle to_stream) {
-  DiscoWorker* worker = ThreadLocalDiscoWorker::Get()->worker;
-  TVM_FFI_ICHECK(worker != nullptr) << "NVSHMEM stream sync failed: worker is not initialized";
-  auto f_sync_stream = tvm::ffi::Function::GetGlobalRequired("runtime.Device_StreamSyncFromTo");
-  f_sync_stream(worker->default_device, reinterpret_cast<int64_t>(from_stream),
-                reinterpret_cast<int64_t>(to_stream));
+  Device device = current_cuda_device();
+  DeviceAPI::Get(device)->SyncStreamFromTo(device, from_stream, to_stream);
 }
 
-void set_streaming_policy(TVMStreamHandle stream, void* ptr, size_t size) {
-  cudaStream_t strm = static_cast<cudaStream_t>(stream);
+TVMStreamHandle stream_from_int(int64_t stream) {
+  return reinterpret_cast<TVMStreamHandle>(stream);
+}
+
+void set_streaming_policy(int64_t stream, void* ptr, size_t size) {
+  cudaStream_t strm = static_cast<cudaStream_t>(stream_from_int(stream));
   struct cudaAccessPolicyWindow accessPolicyWindow = {ptr, size, 0.0, cudaAccessPropertyStreaming,
                                                       cudaAccessPropertyStreaming};
   cudaStreamAttrValue streamAttrValue;
@@ -83,11 +88,10 @@ void set_streaming_policy(TVMStreamHandle stream, void* ptr, size_t size) {
 }
 
 void transfer_to_peers_reduce_scatter(Tensor semaphore, Tensor gemm_out, Tensor staging_buffer,
-                                      TVMStreamHandle stream, int32_t M, int32_t N, int32_t BLK_M,
+                                      int64_t stream_handle, int32_t M, int32_t N, int32_t BLK_M,
                                       int32_t BLK_N, int32_t WORLD_SIZE) {
-  DiscoWorker* worker = ThreadLocalDiscoWorker::Get()->worker;
-  TVM_FFI_ICHECK(worker != nullptr) << "NVSHMEM transfer to peer failed: worker is not initialized";
-  int my_rank = worker->worker_id;
+  TVMStreamHandle stream = stream_from_int(stream_handle);
+  int my_rank = nvshmem_my_pe();
   int LOCAL_M = M / WORLD_SIZE;
   for (int i = 0; i < WORLD_SIZE; i++) {
     int to_rank = (my_rank + i + 1) % WORLD_SIZE;
@@ -108,11 +112,10 @@ void transfer_to_peers_reduce_scatter(Tensor semaphore, Tensor gemm_out, Tensor 
   }
 }
 
-void transfer_to_peers_all_gather(Tensor semaphore, Tensor A, Tensor ag_out, TVMStreamHandle stream,
+void transfer_to_peers_all_gather(Tensor semaphore, Tensor A, Tensor ag_out, int64_t stream_handle,
                                   int32_t M, int32_t K, int32_t WORLD_SIZE) {
-  DiscoWorker* worker = ThreadLocalDiscoWorker::Get()->worker;
-  TVM_FFI_ICHECK(worker != nullptr) << "NVSHMEM transfer to peer failed: worker is not initialized";
-  int my_rank = worker->worker_id;
+  TVMStreamHandle stream = stream_from_int(stream_handle);
+  int my_rank = nvshmem_my_pe();
   int LOCAL_M = M / WORLD_SIZE;
   for (int i = 0; i < WORLD_SIZE; i++) {
     int to_rank = (my_rank + WORLD_SIZE - i - 1) % WORLD_SIZE;
@@ -132,10 +135,9 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("runtime.disco.stream_sync", stream_sync)
       .def("runtime.disco.transfer_to_peers_reduce_scatter", transfer_to_peers_reduce_scatter)
       .def("runtime.disco.transfer_to_peers_all_gather", transfer_to_peers_all_gather)
-      .def("runtime.disco.set_streaming_policy",
-           [](TVMStreamHandle stream, Tensor ptr, size_t size) {
-             set_streaming_policy(stream, ptr->data, size);
-           });
+      .def("runtime.disco.set_streaming_policy", [](int64_t stream, Tensor ptr, size_t size) {
+        set_streaming_policy(stream, ptr->data, size);
+      });
 }
 
 }  // namespace runtime

--- a/src/runtime/extra/contrib/nvshmem/init.cc
+++ b/src/runtime/extra/contrib/nvshmem/init.cc
@@ -137,8 +137,8 @@ void NVSHMEMXCumoduleInit(void* cuModule) {
   }
 }
 
-void NVSHMEMBarrierAllOnStream(TVMStreamHandle stream) {
-  CUstream strm = static_cast<CUstream>(stream);
+void NVSHMEMBarrierAllOnStream(int64_t stream) {
+  CUstream strm = reinterpret_cast<CUstream>(stream);
   nvshmemx_barrier_all_on_stream(strm);
 }
 
@@ -154,7 +154,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
         int device_id;
         TVM_FFI_CHECK_CUDA_ERROR(cudaGetDevice(&device_id));
         TVMStreamHandle stream = TVMFFIEnvGetStream(kDLCUDA, device_id);
-        NVSHMEMBarrierAllOnStream(stream);
+        NVSHMEMBarrierAllOnStream(reinterpret_cast<int64_t>(stream));
       });
 }
 

--- a/src/runtime/extra/contrib/nvshmem/memory_allocator.cc
+++ b/src/runtime/extra/contrib/nvshmem/memory_allocator.cc
@@ -88,7 +88,9 @@ class NVSHMEMAllocator final : public PooledAllocator {
 };
 
 Tensor NVSHMEMEmpty(ffi::Shape shape, DLDataType dtype, ffi::Optional<Device> device) {
-  return NVSHMEMAllocator::Global()->Empty(shape, dtype, UseDefaultDeviceIfNone(device));
+  Device resolved_device =
+      device.has_value() ? device.value() : UseDefaultDeviceIfNone(std::nullopt);
+  return NVSHMEMAllocator::Global()->Empty(shape, dtype, resolved_device);
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/tests/python/tirx/test_bench_utils.py
+++ b/tests/python/tirx/test_bench_utils.py
@@ -18,7 +18,6 @@
 
 import importlib
 import inspect
-from contextlib import contextmanager
 from types import SimpleNamespace
 
 import pytest
@@ -147,178 +146,68 @@ def test_bench_default_timer_is_proton(monkeypatch):
     assert calls == [(25, 100)]
 
 
-def test_distributed_event_times_full_closure_and_uses_sample_wise_rank_max(monkeypatch):
-    calls = []
+def test_distributed_kineto_span_uses_cross_stream_samples_and_rank_max(monkeypatch):
     reductions = []
+    local_samples = [float(index + 1) for index in range(30)]
 
-    class FakeEvent:
-        def __init__(self, *, enable_timing):
-            assert enable_timing is True
-
-        def record(self):
-            calls.append("event")
-
-        def elapsed_time(self, _end):
-            return 0.001
-
-    @contextmanager
-    def fake_stream(_stream):
-        yield
-
-    monkeypatch.setattr(bench_module.torch.cuda, "Event", FakeEvent)
-    monkeypatch.setattr(bench_module.torch.cuda, "stream", fake_stream)
-    monkeypatch.setattr(
-        bench_module,
-        "_distributed_cold_start",
-        lambda _distributed: calls.append("cold"),
-    )
+    def fake_profile(name, func, prepare, distributed):
+        assert name == "impl"
+        assert callable(func)
+        assert callable(prepare["impl"])
+        assert distributed.world_size == 4
+        return local_samples, [2] * len(local_samples)
 
     def max_reduce(value):
         reductions.append(value)
-        return value + 1.0
+        return value + 100.0
+
+    monkeypatch.setattr(bench_module, "_profile_distributed_kineto_span", fake_profile)
 
     result = bench(
-        {"impl": lambda: calls.append("launch")},
+        {"impl": lambda: None},
         distributed=_distributed_context(max_reduce),
-        prepare={"impl": lambda: calls.append("prepare")},
-        rounds=1,
+        prepare={"impl": lambda: None},
         cooldown_s=0,
     )
 
-    assert result["timer"] == "event"
-    assert result["impls"] == {"impl": 2.0}
-    assert len(reductions) == 30
-    assert calls.count("prepare") == 35
-    assert calls.count("launch") == 35
-    assert calls.count("cold") == 35
-    assert calls.count("event") == 60
-    first_measured = calls.index("event")
-    assert calls[first_measured - 2 : first_measured + 3] == [
-        "cold",
-        "prepare",
-        "event",
-        "launch",
-        "event",
-    ]
+    assert result["timer"] == "kineto"
+    assert result["impls"] == {"impl": 115.5}
+    assert reductions == local_samples
     protocol = result["benchmark_protocol"]
-    assert protocol["timing_scope"] == "complete launch closure"
-    assert protocol["prepare_outside_timing"] is True
-    assert protocol["cold_start_outside_timing"] is True
-    assert protocol["flush_l2"] is True
-    assert protocol["flush_l2_bytes"] == int(8e9)
+    assert protocol["timing_scope"] == "complete correlated GPU activity span"
+    assert protocol["span_definition"] == "latest activity end minus earliest activity start"
     assert protocol["rank_aggregate"] == "sample_wise_max"
-    assert protocol["sample_aggregate"] == "median"
+    assert protocol["rank_local_scope_stream_counts"] == {"impl": [{"min": 2, "max": 2}]}
 
 
-def test_distributed_event_keeps_fixed_order_without_ab_ba(monkeypatch):
-    orders = []
-
-    def fake_event(funcs, _prepare, _distributed, rounds, cooldown_s):
-        orders.append((list(funcs), rounds, cooldown_s))
-        return {"impls": {}, "round_samples": {}, "errors": {}, "timer": "event"}
-
-    monkeypatch.setattr(bench_module, "_bench_distributed_event", fake_event)
-    bench(
-        {"a": lambda: None, "b": lambda: None},
-        distributed=_distributed_context(),
-        rounds=2,
-        cooldown_s=0.25,
-    )
-
-    assert orders == [(["a", "b"], 2, 0.25)]
-
-
-def test_distributed_kineto_uses_deepgemm_two_phase_named_kernel_protocol(monkeypatch):
-    calls = []
-    schedules = []
-    profiler_steps = []
-
-    class FakeAverages:
-        def table(self, **kwargs):
-            assert kwargs == {"sort_by": "cuda_time_total", "max_name_column_width": 100}
-            return "fused_kernel 3.000us 30"
-
-    class FakeProfiler:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_args):
-            return False
-
-        def step(self):
-            profiler_steps.append("step")
-
-        def key_averages(self):
-            return FakeAverages()
-
-    @contextmanager
-    def fake_stream(_stream):
-        yield
-
-    monkeypatch.setattr(bench_module.torch.cuda, "stream", fake_stream)
-    monkeypatch.setattr(
-        bench_module,
-        "_distributed_cold_start",
-        lambda _distributed: calls.append("cold"),
-    )
-    monkeypatch.setattr(
-        bench_module.torch.profiler,
-        "schedule",
-        lambda **kwargs: schedules.append(kwargs) or object(),
-    )
-    monkeypatch.setattr(bench_module.torch.profiler, "profile", lambda **_kwargs: FakeProfiler())
-
-    result = bench(
-        {"tirx": lambda: calls.append("launch")},
-        distributed=_distributed_context(lambda value: value + 10.0),
-        prepare={"tirx": lambda: calls.append("prepare")},
-        timer="kineto",
-        kineto_kernel_names={"tirx": "fused_kernel"},
-        cooldown_s=0,
-    )
-
-    assert result["impls"] == {"tirx": 13.0}
-    assert calls.count("launch") == 61
-    assert calls.count("prepare") == 61
-    assert calls.count("cold") == 60
-    assert schedules == [{"wait": 0, "warmup": 1, "active": 1, "repeat": 1}]
-    assert profiler_steps == ["step", "step"]
-    protocol = result["benchmark_protocol"]
-    assert protocol["timing_scope"] == "named CUDA kernel only"
-    assert protocol["kernel_names"] == {"tirx": "fused_kernel"}
-    assert protocol["order"] == ["tirx"]
-    assert "round_orders" not in protocol
-    assert "paired_round" not in protocol
-
-
-def test_named_kineto_table_parser_requires_one_matching_row():
-    class FakeAverages:
-        def __init__(self, table):
-            self._table = table
-
-        def table(self, **_kwargs):
-            return self._table
-
-    def profiler(table):
-        return SimpleNamespace(key_averages=lambda: FakeAverages(table))
-
-    assert (
-        bench_module._collect_named_kineto_time(profiler("fused_kernel 0.004ms 30"), "fused_kernel")
-        == 4.0
-    )
-    with pytest.raises(RuntimeError, match="found 0"):
-        bench_module._collect_named_kineto_time(profiler("other 1.000us 30"), "fused_kernel")
-    with pytest.raises(RuntimeError, match="found 2"):
-        bench_module._collect_named_kineto_time(
-            profiler("fused_kernel 1.000us 30\nfused_kernel.extra 2.000us 30"),
-            "fused_kernel",
+def test_kineto_span_collector_uses_earliest_start_and_latest_end():
+    def event(name, device_type, stream, start, end):
+        return SimpleNamespace(
+            name=name,
+            device_type=device_type,
+            device_resource_id=stream,
+            time_range=SimpleNamespace(start=start, end=end),
         )
 
+    profiler = SimpleNamespace(
+        events=lambda: [
+            event("sample.0", torch.autograd.DeviceType.CPU, 0, 0.0, 10.0),
+            event("sample.0", torch.autograd.DeviceType.CUDA, 11, 2.0, 5.0),
+            event("sample.0", torch.autograd.DeviceType.CUDA, 17, 3.0, 8.0),
+            event("sample.1", torch.autograd.DeviceType.CUDA, 11, 20.0, 21.5),
+        ]
+    )
 
-def test_distributed_protocol_has_no_activity_span_or_ab_ba():
-    source = inspect.getsource(bench_module._bench_distributed_kineto)
-    assert "record_function" not in source
-    assert "activity" not in source
+    samples, stream_counts = bench_module._collect_kineto_span_samples(
+        profiler, ["sample.0", "sample.1"]
+    )
+
+    assert samples == [6.0, 1.5]
+    assert stream_counts == [2, 1]
+
+
+def test_distributed_kineto_span_keeps_fixed_order_without_ab_ba():
+    source = inspect.getsource(bench_module._bench_distributed_kineto_span)
     assert "reversed" not in source
     assert "round_orders" not in source
 
@@ -326,7 +215,8 @@ def test_distributed_protocol_has_no_activity_span_or_ab_ba():
 @pytest.mark.parametrize(
     "kwargs, match",
     [
-        ({"timer": "proton"}, "only timer='event' or timer='kineto'"),
+        ({"timer": "event"}, "only timer='kineto'"),
+        ({"timer": "proton"}, "only timer='kineto'"),
         ({"warmup": 1}, "rejects overrides: warmup"),
         ({"repeat": 1}, "rejects overrides: repeat"),
         ({"cudagraph_rep": 1}, "rejects overrides: cudagraph_rep"),
@@ -339,32 +229,6 @@ def test_distributed_timers_reject_invalid_timer_and_budgets(kwargs, match):
             distributed=_distributed_context(),
             cooldown_s=0,
             **kwargs,
-        )
-
-
-def test_distributed_kineto_requires_exact_kernel_name_mapping():
-    with pytest.raises(TypeError, match="requires kineto_kernel_names"):
-        bench(
-            {"noop": lambda: None},
-            distributed=_distributed_context(),
-            timer="kineto",
-            cooldown_s=0,
-        )
-    with pytest.raises(ValueError, match="cover every implementation"):
-        bench(
-            {"a": lambda: None, "b": lambda: None},
-            distributed=_distributed_context(),
-            timer="kineto",
-            kineto_kernel_names={"a": "kernel_a"},
-            cooldown_s=0,
-        )
-    with pytest.raises(ValueError, match="valid only"):
-        bench(
-            {"noop": lambda: None},
-            distributed=_distributed_context(),
-            timer="event",
-            kineto_kernel_names={"noop": "kernel"},
-            cooldown_s=0,
         )
 
 

--- a/tests/python/tirx/test_bench_utils.py
+++ b/tests/python/tirx/test_bench_utils.py
@@ -167,6 +167,11 @@ def test_distributed_event_times_full_closure_and_uses_sample_wise_rank_max(monk
 
     monkeypatch.setattr(bench_module.torch.cuda, "Event", FakeEvent)
     monkeypatch.setattr(bench_module.torch.cuda, "stream", fake_stream)
+    monkeypatch.setattr(
+        bench_module,
+        "_distributed_cold_start",
+        lambda _distributed: calls.append("cold"),
+    )
 
     def max_reduce(value):
         reductions.append(value)
@@ -185,9 +190,11 @@ def test_distributed_event_times_full_closure_and_uses_sample_wise_rank_max(monk
     assert len(reductions) == 30
     assert calls.count("prepare") == 35
     assert calls.count("launch") == 35
+    assert calls.count("cold") == 35
     assert calls.count("event") == 60
     first_measured = calls.index("event")
-    assert calls[first_measured - 1 : first_measured + 3] == [
+    assert calls[first_measured - 2 : first_measured + 3] == [
+        "cold",
         "prepare",
         "event",
         "launch",
@@ -196,6 +203,9 @@ def test_distributed_event_times_full_closure_and_uses_sample_wise_rank_max(monk
     protocol = result["benchmark_protocol"]
     assert protocol["timing_scope"] == "complete launch closure"
     assert protocol["prepare_outside_timing"] is True
+    assert protocol["cold_start_outside_timing"] is True
+    assert protocol["flush_l2"] is True
+    assert protocol["flush_l2_bytes"] == int(8e9)
     assert protocol["rank_aggregate"] == "sample_wise_max"
     assert protocol["sample_aggregate"] == "median"
 
@@ -248,7 +258,7 @@ def test_distributed_kineto_uses_deepgemm_two_phase_named_kernel_protocol(monkey
     monkeypatch.setattr(bench_module.torch.cuda, "stream", fake_stream)
     monkeypatch.setattr(
         bench_module,
-        "_distributed_kineto_cold_start",
+        "_distributed_cold_start",
         lambda _distributed: calls.append("cold"),
     )
     monkeypatch.setattr(

--- a/tests/python/tirx/test_bench_utils.py
+++ b/tests/python/tirx/test_bench_utils.py
@@ -17,6 +17,9 @@
 """Tests for tvm.tirx.bench utilities."""
 
 import importlib
+import inspect
+from contextlib import contextmanager
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -24,9 +27,26 @@ import torch
 pytest.importorskip("triton")  # tvm.tirx.bench imports triton.profiler
 
 from tvm.testing import env
-from tvm.tirx.bench import bench
+from tvm.tirx.bench import DistributedBenchContext, bench
 
 bench_module = importlib.import_module("tvm.tirx.bench")
+
+
+class _FakeStream:
+    cuda_stream = 123
+
+    def synchronize(self):
+        pass
+
+
+def _distributed_context(max_reduce=lambda value: value):
+    return DistributedBenchContext(
+        rank=0,
+        world_size=4,
+        barrier=lambda: None,
+        max_reduce=max_reduce,
+        stream=_FakeStream(),
+    )
 
 
 def test_bench_cooldown_precedes_every_impl(monkeypatch):
@@ -125,6 +145,252 @@ def test_bench_default_timer_is_proton(monkeypatch):
     assert results["timer"] == "proton"
     assert results["impls"] == {"noop": 1.0}
     assert calls == [(25, 100)]
+
+
+def test_distributed_event_times_full_closure_and_uses_sample_wise_rank_max(monkeypatch):
+    calls = []
+    reductions = []
+
+    class FakeEvent:
+        def __init__(self, *, enable_timing):
+            assert enable_timing is True
+
+        def record(self):
+            calls.append("event")
+
+        def elapsed_time(self, _end):
+            return 0.001
+
+    @contextmanager
+    def fake_stream(_stream):
+        yield
+
+    monkeypatch.setattr(bench_module.torch.cuda, "Event", FakeEvent)
+    monkeypatch.setattr(bench_module.torch.cuda, "stream", fake_stream)
+
+    def max_reduce(value):
+        reductions.append(value)
+        return value + 1.0
+
+    result = bench(
+        {"impl": lambda: calls.append("launch")},
+        distributed=_distributed_context(max_reduce),
+        prepare={"impl": lambda: calls.append("prepare")},
+        rounds=1,
+        cooldown_s=0,
+    )
+
+    assert result["timer"] == "event"
+    assert result["impls"] == {"impl": 2.0}
+    assert len(reductions) == 30
+    assert calls.count("prepare") == 35
+    assert calls.count("launch") == 35
+    assert calls.count("event") == 60
+    first_measured = calls.index("event")
+    assert calls[first_measured - 1 : first_measured + 3] == [
+        "prepare",
+        "event",
+        "launch",
+        "event",
+    ]
+    protocol = result["benchmark_protocol"]
+    assert protocol["timing_scope"] == "complete launch closure"
+    assert protocol["prepare_outside_timing"] is True
+    assert protocol["rank_aggregate"] == "sample_wise_max"
+    assert protocol["sample_aggregate"] == "median"
+
+
+def test_distributed_event_keeps_fixed_order_without_ab_ba(monkeypatch):
+    orders = []
+
+    def fake_event(funcs, _prepare, _distributed, rounds, cooldown_s):
+        orders.append((list(funcs), rounds, cooldown_s))
+        return {"impls": {}, "round_samples": {}, "errors": {}, "timer": "event"}
+
+    monkeypatch.setattr(bench_module, "_bench_distributed_event", fake_event)
+    bench(
+        {"a": lambda: None, "b": lambda: None},
+        distributed=_distributed_context(),
+        rounds=2,
+        cooldown_s=0.25,
+    )
+
+    assert orders == [(["a", "b"], 2, 0.25)]
+
+
+def test_distributed_kineto_uses_deepgemm_two_phase_named_kernel_protocol(monkeypatch):
+    calls = []
+    schedules = []
+    profiler_steps = []
+
+    class FakeAverages:
+        def table(self, **kwargs):
+            assert kwargs == {"sort_by": "cuda_time_total", "max_name_column_width": 100}
+            return "fused_kernel 3.000us 30"
+
+    class FakeProfiler:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def step(self):
+            profiler_steps.append("step")
+
+        def key_averages(self):
+            return FakeAverages()
+
+    @contextmanager
+    def fake_stream(_stream):
+        yield
+
+    monkeypatch.setattr(bench_module.torch.cuda, "stream", fake_stream)
+    monkeypatch.setattr(
+        bench_module,
+        "_distributed_kineto_cold_start",
+        lambda _distributed: calls.append("cold"),
+    )
+    monkeypatch.setattr(
+        bench_module.torch.profiler,
+        "schedule",
+        lambda **kwargs: schedules.append(kwargs) or object(),
+    )
+    monkeypatch.setattr(bench_module.torch.profiler, "profile", lambda **_kwargs: FakeProfiler())
+
+    result = bench(
+        {"tirx": lambda: calls.append("launch")},
+        distributed=_distributed_context(lambda value: value + 10.0),
+        prepare={"tirx": lambda: calls.append("prepare")},
+        timer="kineto",
+        kineto_kernel_names={"tirx": "fused_kernel"},
+        cooldown_s=0,
+    )
+
+    assert result["impls"] == {"tirx": 13.0}
+    assert calls.count("launch") == 61
+    assert calls.count("prepare") == 61
+    assert calls.count("cold") == 60
+    assert schedules == [{"wait": 0, "warmup": 1, "active": 1, "repeat": 1}]
+    assert profiler_steps == ["step", "step"]
+    protocol = result["benchmark_protocol"]
+    assert protocol["timing_scope"] == "named CUDA kernel only"
+    assert protocol["kernel_names"] == {"tirx": "fused_kernel"}
+    assert protocol["order"] == ["tirx"]
+    assert "round_orders" not in protocol
+    assert "paired_round" not in protocol
+
+
+def test_named_kineto_table_parser_requires_one_matching_row():
+    class FakeAverages:
+        def __init__(self, table):
+            self._table = table
+
+        def table(self, **_kwargs):
+            return self._table
+
+    def profiler(table):
+        return SimpleNamespace(key_averages=lambda: FakeAverages(table))
+
+    assert (
+        bench_module._collect_named_kineto_time(profiler("fused_kernel 0.004ms 30"), "fused_kernel")
+        == 4.0
+    )
+    with pytest.raises(RuntimeError, match="found 0"):
+        bench_module._collect_named_kineto_time(profiler("other 1.000us 30"), "fused_kernel")
+    with pytest.raises(RuntimeError, match="found 2"):
+        bench_module._collect_named_kineto_time(
+            profiler("fused_kernel 1.000us 30\nfused_kernel.extra 2.000us 30"),
+            "fused_kernel",
+        )
+
+
+def test_distributed_protocol_has_no_activity_span_or_ab_ba():
+    source = inspect.getsource(bench_module._bench_distributed_kineto)
+    assert "record_function" not in source
+    assert "activity" not in source
+    assert "reversed" not in source
+    assert "round_orders" not in source
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"timer": "proton"}, "only timer='event' or timer='kineto'"),
+        ({"warmup": 1}, "rejects overrides: warmup"),
+        ({"repeat": 1}, "rejects overrides: repeat"),
+        ({"cudagraph_rep": 1}, "rejects overrides: cudagraph_rep"),
+    ],
+)
+def test_distributed_timers_reject_invalid_timer_and_budgets(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        bench(
+            {"noop": lambda: None},
+            distributed=_distributed_context(),
+            cooldown_s=0,
+            **kwargs,
+        )
+
+
+def test_distributed_kineto_requires_exact_kernel_name_mapping():
+    with pytest.raises(TypeError, match="requires kineto_kernel_names"):
+        bench(
+            {"noop": lambda: None},
+            distributed=_distributed_context(),
+            timer="kineto",
+            cooldown_s=0,
+        )
+    with pytest.raises(ValueError, match="cover every implementation"):
+        bench(
+            {"a": lambda: None, "b": lambda: None},
+            distributed=_distributed_context(),
+            timer="kineto",
+            kineto_kernel_names={"a": "kernel_a"},
+            cooldown_s=0,
+        )
+    with pytest.raises(ValueError, match="valid only"):
+        bench(
+            {"noop": lambda: None},
+            distributed=_distributed_context(),
+            timer="event",
+            kineto_kernel_names={"noop": "kernel"},
+            cooldown_s=0,
+        )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error", "match"),
+    [
+        ({"world_size": 0}, ValueError, "world_size must be a positive integer"),
+        ({"world_size": True}, ValueError, "world_size must be a positive integer"),
+        ({"rank": -1}, ValueError, "rank must be in"),
+        ({"rank": 4}, ValueError, "rank must be in"),
+        ({"barrier": None}, TypeError, "barrier must be callable"),
+        ({"max_reduce": None}, TypeError, "max_reduce must be callable"),
+        ({"stream": object()}, TypeError, "stream must be an actual CUDA stream"),
+    ],
+)
+def test_distributed_timer_rejects_invalid_context(overrides, error, match):
+    values = {
+        "rank": 0,
+        "world_size": 4,
+        "barrier": lambda: None,
+        "max_reduce": lambda value: value,
+        "stream": _FakeStream(),
+    }
+    values.update(overrides)
+
+    with pytest.raises(error, match=match):
+        bench(
+            {"noop": lambda: None},
+            distributed=DistributedBenchContext(**values),
+            cooldown_s=0,
+        )
+
+
+def test_prepare_requires_distributed_context():
+    with pytest.raises(ValueError, match="only with a distributed context"):
+        bench({"noop": lambda: None}, prepare={"noop": lambda: None}, cooldown_s=0)
 
 
 def test_bench_cudagraph_proton_wiring(monkeypatch):


### PR DESCRIPTION
## Summary

- add distributed CUDA-event timing for complete GemmComm launch closures
- add a separate DeepGEMM-style named-kernel Kineto diagnostic
- make existing NVSHMEM GemmComm runtime helpers usable from rank-local processes without a `DiscoWorker`
- allow NVSHMEM allocations to receive an explicit CUDA device

## Benchmark protocol

Distributed `event` timing runs preparation before the start event, uses 5 warmup and 30 measured launches, takes the slowest rank for every sample, the median within each round, and the mean across rounds. Implementations run in a fixed insertion order.

Distributed `kineto` uses one preflight launch, 30 warmup launches, 30 active launches, an 8 GB L2 flush, GPU sleep, and a rank barrier before each launch. Only the requested CUDA kernel row from the standard Kineto table is reported.

There is no AB/BA ordering, custom activity span, or earliest/latest activity stitching.

## Runtime scope

The existing `runtime.disco.nvshmem.*` registry names remain unchanged. This PR adds no NVSHMEM API and creates no Disco session or worker object.

## Validation

- `tests/python/tirx/test_bench_utils.py`: 29 passed
- full TVM build with CUDA, NCCL, NVTX, and NVSHMEM enabled: passed
- pre-commit on all 5 changed files: passed
- downstream TP4 AllGather+GEMM correctness: passed
- downstream TP4 dynamic-multimem GEMM+ReduceScatter correctness across 20 reset/relaunch cycles: passed
- downstream 16-shape TP4 correctness and six-round event/Kineto profiling: completed

The PR remains draft as the runtime dependency of spectrometerHBH/tirx-kernels#16; the remaining performance work is isolated to TP4 kernel tuning in that PR.
