### PR TITLE
feat(infra): allow NVRTC frontend flag overrides via TVM_CUDA_NVRTC_EXTRA_OPTS

### DIFF
--- a/python/tvm/support/nvcc.py
+++ b/python/tvm/support/nvcc.py
@@ -550,6 +550,13 @@ namespace std {
     for flag in _ptxas_option_flags():
         compile_opts.append(f"--ptxas-options={flag}".encode())
 
+    # Extra NVRTC frontend flags (shell-tokenized), appended after all built-in
+    # defaults so they can override them (e.g. TVM_CUDA_NVRTC_EXTRA_OPTS="--ftz=false"
+    # to undo the -ftz=true implied by --use_fast_math).
+    nvrtc_extra = os.environ.get("TVM_CUDA_NVRTC_EXTRA_OPTS", "").strip()
+    if nvrtc_extra:
+        compile_opts.extend(t.encode() for t in shlex.split(nvrtc_extra))
+
     # Add user-provided options, filtering out nvcc-specific flags that nvrtc doesn't support
     if options:
         nvcc_only_prefixes = (


### PR DESCRIPTION
## What

Adds a `TVM_CUDA_NVRTC_EXTRA_OPTS` environment variable to the NVRTC path in `tvm.support.nvcc`: shell-tokenized extra NVRTC frontend flags, appended after all built-in defaults so they override them.

## Why

The NVRTC path appends `--use_fast_math` unconditionally, which implies `-ftz=true`. Some kernels need to selectively undo the FTZ bit — e.g. the SM100 MQA-logits epilogue computes `x + |x|` as the ReLU, and `abs.ftz.f32` blocks the ptxas peephole that folds abs into the packed `FADD2` operand modifier, doubling that instruction count vs the non-FTZ form. With this hook the kernel compiles with `TVM_CUDA_NVRTC_EXTRA_OPTS=--ftz=false` (appended last, so it wins) while every other kernel keeps the default flags unchanged.

## Scope / safety

- Inert unless the env var is set: no behavior change for existing compiles.
- Only the NVRTC path is extended; the nvcc subprocess path is unchanged.

Companion to the tirx-kernels PR aligning the SM100 FP8/FP4 MQA-logits kernels with DeepGEMM.