### PR TITLE
fix(lower-tirx): recognize swizzle iter patterns with unsigned offsets

### DIFF
--- a/python/tvm/arith/__init__.py
+++ b/python/tvm/arith/__init__.py
@@ -25,7 +25,15 @@ from .int_set import (
     estimate_region_strict_bound,
     estimate_region_upper_bound,
 )
-from .analyzer import ModularSet, ConstIntBound, Analyzer, ProofStrength, Extension, CompareResult
+from .analyzer import (
+    ModularSet,
+    ConstIntBound,
+    Analyzer,
+    ProofStrength,
+    Extension,
+    CompareResult,
+    allow_uint_as_index,
+)
 from .bound import deduce_bound
 from .pattern import detect_linear_equation, detect_clip_bound
 from .int_solver import solve_linear_equations, solve_linear_inequalities

--- a/python/tvm/arith/analyzer.py
+++ b/python/tvm/arith/analyzer.py
@@ -18,6 +18,7 @@
 """Arithmetic data structure and utility"""
 
 import enum
+from contextlib import contextmanager
 
 import tvm_ffi
 
@@ -527,3 +528,25 @@ class Analyzer(Object):
         """
         flags = Extension(flags).value
         _ffi_api.AnalyzerSetEnabledExtensions(self, flags)
+
+
+@contextmanager
+def allow_uint_as_index():
+    """Opt-in no-overflow domain for unsigned index arithmetic.
+
+    Within the scope, the analyzer treats uint32/uint64 scalars as index
+    types: it assumes their values never approach the type limit (no
+    wraparound), so the signed rewrite rule set (floordiv/floormod
+    decomposition, modular analysis) applies to them. Every unsigned
+    expression admitted under the assumption is logged once per process
+    (WARNING) so the assumption stays auditable.
+
+    Off by default. Intended for compile-time layout proofs (offsets that
+    provably stay small), NOT for runtime codegen semantics where unsigned
+    wraparound is real behavior.
+    """
+    _ffi_api.EnterAllowUintAsIndex()
+    try:
+        yield
+    finally:
+        _ffi_api.ExitAllowUintAsIndex()

--- a/python/tvm/backend/cuda/operator/tile_primitive/copy/_common.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy/_common.py
@@ -42,13 +42,21 @@ def _alignment_ok(vec_len: int, terms) -> bool:
     """
     if vec_len <= 1:
         return True
+    from ._swizzle_iter import _to_int64
+
     analyzer = arith.Analyzer()
     for t in terms:
         if isinstance(t, int):
             if t % vec_len != 0:
                 return False
         else:
-            if not analyzer.can_prove_equal(t % vec_len, 0):
+            if analyzer.can_prove_equal(t % vec_len, 0):
+                continue
+            # The analyzer only does modular reasoning on signed dtypes;
+            # retry with the term widened to int64 (value-preserving for
+            # SMEM/GMEM offsets, e.g. uint32 stage indices).
+            normalized = _to_int64(t)
+            if normalized is None or not analyzer.can_prove_equal(normalized[0] % vec_len, 0):
                 return False
     return True
 

--- a/python/tvm/backend/cuda/operator/tile_primitive/copy/_common.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy/_common.py
@@ -42,21 +42,13 @@ def _alignment_ok(vec_len: int, terms) -> bool:
     """
     if vec_len <= 1:
         return True
-    from ._swizzle_iter import _to_int64
-
     analyzer = arith.Analyzer()
     for t in terms:
         if isinstance(t, int):
             if t % vec_len != 0:
                 return False
         else:
-            if analyzer.can_prove_equal(t % vec_len, 0):
-                continue
-            # The analyzer only does modular reasoning on signed dtypes;
-            # retry with the term widened to int64 (value-preserving for
-            # SMEM/GMEM offsets, e.g. uint32 stage indices).
-            normalized = _to_int64(t)
-            if normalized is None or not analyzer.can_prove_equal(normalized[0] % vec_len, 0):
+            if not analyzer.can_prove_equal(t % vec_len, 0):
                 return False
     return True
 

--- a/python/tvm/backend/cuda/operator/tile_primitive/copy/_swizzle_iter.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy/_swizzle_iter.py
@@ -72,6 +72,135 @@ from tvm import arith
 from tvm.script import tirx as T
 from tvm.tirx.expr import IntImm as _IntImm
 from tvm.tirx.layout import ComposeLayout, S, TileLayout
+from tvm.tirx.stmt_functor import ExprMutator
+
+
+def _expr_dtype(expr) -> str:
+    return expr.expr_ty().dtype
+
+
+class _ToInt64Mutator(ExprMutator):
+    """Rewrite an offset expr to int64 for analyzer-based bit checks.
+
+    SMEM offsets are far below 2**31, so widening unsigned/small dtypes is
+    value-preserving, and the analyzer's modular reasoning only fires on
+    signed dtypes (uint32 offsets otherwise block the (C1) proof).
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._vmap = {}
+
+    def visit_var_(self, var):
+        if _expr_dtype(var) != "int64":
+            new_var = self._vmap.get(var)
+            if new_var is None:
+                new_var = tvm.tirx.Var(var.name, "int64")
+                self._vmap[var] = new_var
+            return new_var
+        return var
+
+    def visit_buffer_load_(self, op):
+        # A memory load is an unknown integer for symbolic purposes: proxy it
+        # with a fresh int64 var (cached per node) so divisibility structure
+        # around it (e.g. ``load * 4096``) stays provable.
+        proxy = self._vmap.get(op)
+        if proxy is None:
+            proxy = tvm.tirx.Var(f"{op.buffer.name}_ld{len(self._vmap)}", "int64")
+            self._vmap[op] = proxy
+        return proxy
+
+    def visit_cast_(self, op):
+        return self.visit_expr(op.value).astype("int64")
+
+    def visit_int_imm_(self, op):
+        return _IntImm("int64", int(op.value))
+
+    def _binary(self, op, fn):
+        return fn(self.visit_expr(op.a), self.visit_expr(op.b))
+
+    def visit_add_(self, op):
+        return self._binary(op, lambda a, b: a + b)
+
+    def visit_sub_(self, op):
+        return self._binary(op, lambda a, b: a - b)
+
+    def visit_mul_(self, op):
+        return self._binary(op, lambda a, b: a * b)
+
+    def visit_floordiv_(self, op):
+        return self._binary(op, tvm.tirx.floordiv)
+
+    def visit_floormod_(self, op):
+        return self._binary(op, tvm.tirx.floormod)
+
+    def visit_div_(self, op):
+        return self._binary(op, tvm.tirx.div)
+
+    def visit_mod_(self, op):
+        return self._binary(op, lambda a, b: tvm.tirx.floormod(a, b))
+
+    def visit_min_(self, op):
+        return self._binary(op, tvm.tirx.min)
+
+    def visit_max_(self, op):
+        return self._binary(op, tvm.tirx.max)
+
+    def visit_and_(self, op):
+        return self._binary(op, lambda a, b: a & b)
+
+    def visit_or_(self, op):
+        return self._binary(op, lambda a, b: a | b)
+
+    def visit_call_(self, op):
+        # Re-issue pure builtins with widened args; refuse impure calls.
+        _PURE = {
+            "tir.shift_right",
+            "tir.shift_left",
+            "tir.bitwise_and",
+            "tir.bitwise_or",
+            "tir.bitwise_xor",
+            "tir.floordiv",
+            "tir.floormod",
+            "tir.min",
+            "tir.max",
+        }
+        name = getattr(op.op, "name", None) or getattr(op.op, "global_symbol", None) or str(op.op)
+        if name not in _PURE:
+            raise ValueError(f"_ToInt64Mutator: unsupported call {name}")
+        args = [self.visit_expr(a) for a in op.args]
+        builtin = getattr(T, name.split(".")[-1], None)
+        if builtin is None:
+            builtin = getattr(tvm.tirx, name.split(".")[-1])
+        return builtin(*args)
+
+
+def _to_int64(expr):
+    """Best-effort signed widening of an offset expr.
+
+    Returns ``(widened_expr, old_var -> new_var map)``, or ``None`` on failure.
+    """
+    try:
+        mutator = _ToInt64Mutator()
+        out = mutator.visit_expr(expr)
+        # Verify no narrow/unsigned residue remains.
+        ok = True
+
+        def _check(node):
+            nonlocal ok
+            try:
+                dtype = _expr_dtype(node)
+            except (AttributeError, TypeError):
+                return
+            if dtype not in ("int64", "int32"):
+                ok = False
+
+        from tvm.tirx.stmt_functor import post_order_visit
+
+        post_order_visit(out, _check)
+        return (out, mutator._vmap) if ok else None
+    except Exception:
+        return None
 
 
 @dataclass
@@ -252,17 +381,27 @@ def try_recognize(
     # free lane / warp placeholders in s_off_template — ``can_prove_equal``
     # returns False if the analyzer can't discharge the equality
     # universally, conservatively forcing a fallback.
+    #
+    # The analyzer only does modular reasoning on signed dtypes, so widen
+    # the template to int64 first (value-preserving for SMEM offsets); the
+    # lane/warp bounds are re-keyed to the widened vars.
     analyzer = arith.Analyzer()
+    normalized = _to_int64(s_off_template)
+    if normalized is not None:
+        check_template, vmap = normalized
+        check_dtype = "int64"
+    else:
+        check_template, vmap, check_dtype = s_off_template, {}, _expr_dtype(s_off_template)
     if var_bounds:
         for var, rng in var_bounds.items():
-            analyzer.bind(var, rng)
+            analyzer.bind(vmap.get(var, var), rng)
     for bj in bj_set:
         divisor = C * (1 << bj)
         check = tvm.tirx.floormod(
-            tvm.tirx.floordiv(s_off_template, _IntImm("int32", divisor)),
-            _IntImm("int32", 2),
+            tvm.tirx.floordiv(check_template, _IntImm(check_dtype, divisor)),
+            _IntImm(check_dtype, 2),
         )
-        if not analyzer.can_prove_equal(check, _IntImm("int32", 0)):
+        if not analyzer.can_prove_equal(check, _IntImm(check_dtype, 0)):
             return None
 
     return SwizzlePattern(

--- a/python/tvm/backend/cuda/operator/tile_primitive/copy/_swizzle_iter.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy/_swizzle_iter.py
@@ -72,135 +72,6 @@ from tvm import arith
 from tvm.script import tirx as T
 from tvm.tirx.expr import IntImm as _IntImm
 from tvm.tirx.layout import ComposeLayout, S, TileLayout
-from tvm.tirx.stmt_functor import ExprMutator
-
-
-def _expr_dtype(expr) -> str:
-    return expr.expr_ty().dtype
-
-
-class _ToInt64Mutator(ExprMutator):
-    """Rewrite an offset expr to int64 for analyzer-based bit checks.
-
-    SMEM offsets are far below 2**31, so widening unsigned/small dtypes is
-    value-preserving, and the analyzer's modular reasoning only fires on
-    signed dtypes (uint32 offsets otherwise block the (C1) proof).
-    """
-
-    def __init__(self):
-        super().__init__()
-        self._vmap = {}
-
-    def visit_var_(self, var):
-        if _expr_dtype(var) != "int64":
-            new_var = self._vmap.get(var)
-            if new_var is None:
-                new_var = tvm.tirx.Var(var.name, "int64")
-                self._vmap[var] = new_var
-            return new_var
-        return var
-
-    def visit_buffer_load_(self, op):
-        # A memory load is an unknown integer for symbolic purposes: proxy it
-        # with a fresh int64 var (cached per node) so divisibility structure
-        # around it (e.g. ``load * 4096``) stays provable.
-        proxy = self._vmap.get(op)
-        if proxy is None:
-            proxy = tvm.tirx.Var(f"{op.buffer.name}_ld{len(self._vmap)}", "int64")
-            self._vmap[op] = proxy
-        return proxy
-
-    def visit_cast_(self, op):
-        return self.visit_expr(op.value).astype("int64")
-
-    def visit_int_imm_(self, op):
-        return _IntImm("int64", int(op.value))
-
-    def _binary(self, op, fn):
-        return fn(self.visit_expr(op.a), self.visit_expr(op.b))
-
-    def visit_add_(self, op):
-        return self._binary(op, lambda a, b: a + b)
-
-    def visit_sub_(self, op):
-        return self._binary(op, lambda a, b: a - b)
-
-    def visit_mul_(self, op):
-        return self._binary(op, lambda a, b: a * b)
-
-    def visit_floordiv_(self, op):
-        return self._binary(op, tvm.tirx.floordiv)
-
-    def visit_floormod_(self, op):
-        return self._binary(op, tvm.tirx.floormod)
-
-    def visit_div_(self, op):
-        return self._binary(op, tvm.tirx.div)
-
-    def visit_mod_(self, op):
-        return self._binary(op, lambda a, b: tvm.tirx.floormod(a, b))
-
-    def visit_min_(self, op):
-        return self._binary(op, tvm.tirx.min)
-
-    def visit_max_(self, op):
-        return self._binary(op, tvm.tirx.max)
-
-    def visit_and_(self, op):
-        return self._binary(op, lambda a, b: a & b)
-
-    def visit_or_(self, op):
-        return self._binary(op, lambda a, b: a | b)
-
-    def visit_call_(self, op):
-        # Re-issue pure builtins with widened args; refuse impure calls.
-        _PURE = {
-            "tir.shift_right",
-            "tir.shift_left",
-            "tir.bitwise_and",
-            "tir.bitwise_or",
-            "tir.bitwise_xor",
-            "tir.floordiv",
-            "tir.floormod",
-            "tir.min",
-            "tir.max",
-        }
-        name = getattr(op.op, "name", None) or getattr(op.op, "global_symbol", None) or str(op.op)
-        if name not in _PURE:
-            raise ValueError(f"_ToInt64Mutator: unsupported call {name}")
-        args = [self.visit_expr(a) for a in op.args]
-        builtin = getattr(T, name.split(".")[-1], None)
-        if builtin is None:
-            builtin = getattr(tvm.tirx, name.split(".")[-1])
-        return builtin(*args)
-
-
-def _to_int64(expr):
-    """Best-effort signed widening of an offset expr.
-
-    Returns ``(widened_expr, old_var -> new_var map)``, or ``None`` on failure.
-    """
-    try:
-        mutator = _ToInt64Mutator()
-        out = mutator.visit_expr(expr)
-        # Verify no narrow/unsigned residue remains.
-        ok = True
-
-        def _check(node):
-            nonlocal ok
-            try:
-                dtype = _expr_dtype(node)
-            except (AttributeError, TypeError):
-                return
-            if dtype not in ("int64", "int32"):
-                ok = False
-
-        from tvm.tirx.stmt_functor import post_order_visit
-
-        post_order_visit(out, _check)
-        return (out, mutator._vmap) if ok else None
-    except Exception:
-        return None
 
 
 @dataclass
@@ -382,27 +253,22 @@ def try_recognize(
     # returns False if the analyzer can't discharge the equality
     # universally, conservatively forcing a fallback.
     #
-    # The analyzer only does modular reasoning on signed dtypes, so widen
-    # the template to int64 first (value-preserving for SMEM offsets); the
-    # lane/warp bounds are re-keyed to the widened vars.
+    # These are compile-time SMEM-offset proofs (values stay far below
+    # 2**32), so unsigned index terms are analyzed in the no-overflow
+    # domain; every uint expression admitted is logged once by the analyzer.
     analyzer = arith.Analyzer()
-    normalized = _to_int64(s_off_template)
-    if normalized is not None:
-        check_template, vmap = normalized
-        check_dtype = "int64"
-    else:
-        check_template, vmap, check_dtype = s_off_template, {}, _expr_dtype(s_off_template)
     if var_bounds:
         for var, rng in var_bounds.items():
-            analyzer.bind(vmap.get(var, var), rng)
-    for bj in bj_set:
-        divisor = C * (1 << bj)
-        check = tvm.tirx.floormod(
-            tvm.tirx.floordiv(check_template, _IntImm(check_dtype, divisor)),
-            _IntImm(check_dtype, 2),
-        )
-        if not analyzer.can_prove_equal(check, _IntImm(check_dtype, 0)):
-            return None
+            analyzer.bind(var, rng)
+    with arith.allow_uint_as_index():
+        for bj in bj_set:
+            divisor = C * (1 << bj)
+            check = tvm.tirx.floormod(
+                tvm.tirx.floordiv(s_off_template, _IntImm(s_off_template.expr_ty().dtype, divisor)),
+                _IntImm(s_off_template.expr_ty().dtype, 2),
+            )
+            if not analyzer.can_prove_equal(check, _IntImm(s_off_template.expr_ty().dtype, 0)):
+                return None
 
     return SwizzlePattern(
         swizzle=swizzle,

--- a/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
@@ -1516,9 +1516,7 @@ def copy_tma_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc
             tensor_map = cached_tensormap
             tensormap_is_cached = True
         else:
-            tensor_map = T.Var(
-                g_buf.data.name + "_tensormap", ty=T.handle("tensormap").ty
-            )
+            tensor_map = T.Var(g_buf.data.name + "_tensormap", ty=T.handle("tensormap").ty)
             tensormap_is_cached = False
         prefetch_cache_key = f"prefetch_tensormap:{tensormap_cache_key}"
 

--- a/python/tvm/tirx/op.py
+++ b/python/tvm/tirx/op.py
@@ -941,7 +941,7 @@ def tvm_access_ptr(ptype, data, offset, extent, rw_mask):
     call : Expr
         The call expression.
     """
-    if isinstance(ptype, (str, PrimType)):
+    if isinstance(ptype, str | PrimType):
         ptype = type_annotation(ptype)
     data_type = getattr(data, "ty", None)
     storage_scope = data_type.storage_scope if isinstance(data_type, PointerType) else "global"
@@ -962,7 +962,7 @@ def ptr_byte_offset(data, byte_offset, dtype):
     ``byte_offset`` is always in bytes.  Use this when the source CUDA shape
     needs an explicitly typed local pointer derived from a byte-addressed base.
     """
-    if isinstance(dtype, (str, PrimType)):
+    if isinstance(dtype, str | PrimType):
         dtype = type_annotation(dtype)
     data_type = getattr(data, "ty", None)
     storage_scope = data_type.storage_scope if isinstance(data_type, PointerType) else "global"

--- a/python/tvm/tirx/stmt.py
+++ b/python/tvm/tirx/stmt.py
@@ -32,7 +32,7 @@ from enum import IntEnum
 
 import tvm_ffi
 
-from tvm.ir import Expr, Op, Range, Span, is_prim_expr
+from tvm.ir import Expr, Range, Span, is_prim_expr
 from tvm.runtime import Object, Scriptable, const
 from tvm.tirx import IntImm
 

--- a/python/tvm/tirx/tile_primitive.py
+++ b/python/tvm/tirx/tile_primitive.py
@@ -27,7 +27,7 @@ from typing import Any, ClassVar
 import tvm_ffi
 from tvm_ffi import register_object
 
-from tvm.ir import Op, Expr, Range
+from tvm.ir import Expr, Op, Range
 from tvm.runtime import Object, Scriptable
 from tvm.target import Target
 

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -337,6 +337,14 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            [](Analyzer analyzer, const PrimExpr& expr, int strength) {
              return analyzer->CanProve(expr, static_cast<ProofStrength>(strength));
            })
+      .def("arith.EnterAllowUintAsIndex", []() { ++arith::uint_as_index::g_depth; })
+      .def("arith.ExitAllowUintAsIndex",
+           []() {
+             TVM_FFI_ICHECK(arith::uint_as_index::g_depth > 0)
+                 << "ExitAllowUintAsIndex without a matching Enter";
+             --arith::uint_as_index::g_depth;
+           })
+      .def("arith.GetAllowUintAsIndex", []() { return arith::uint_as_index::Enabled(); })
       .def("arith.AnalyzerSetMaximumRewriteSteps",
            [](Analyzer analyzer, int64_t maximum) {
              analyzer->rewrite_simplify.SetMaximumRewriteSteps(maximum);

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -95,7 +95,14 @@ inline PrimExpr DivImpl(PrimExpr a, PrimExpr b, DivMode mode) {
  * \return whether value fits in dtype
  */
 bool CastIsSafe(PrimType dtype, PrimExpr value, AnalyzerObj* analyzer) {
-  if (!IsIndexType(dtype->dtype)) {
+  // uint32/64 is not an index dtype by default; the no-overflow assertion
+  // (uint_as_index) admits it for bounded non-negative upcast elimination.
+  const bool is_index_dtype =
+      IsIndexType(dtype->dtype) ||
+      (uint_as_index::Enabled() &&
+       dtype->dtype.code == static_cast<uint8_t>(DLDataTypeCode::kDLUInt) &&
+       (dtype->dtype.bits == 32 || dtype->dtype.bits == 64) && dtype->dtype.lanes == 1);
+  if (!is_index_dtype) {
     return false;
   }
   ConstIntBound bound = analyzer->const_int_bound(value);
@@ -1384,7 +1391,11 @@ Expr CanonicalSimplifier::Impl::VisitExpr_(const ReduceNode* op) {
 }
 
 Expr CanonicalSimplifier::Impl::VisitExpr_(const CastNode* op) {
-  if (!IsIndexTypedExpr(op)) {
+  // The cast reasoning below is index-centric; for unsigned operands it runs
+  // only under the caller's no-overflow assertion (uint_as_index).
+  if (!IsIndexTypedExpr(op) &&
+      !(uint_as_index::Enabled() && op->ExprNode::ty.as<PrimTypeNode>()->dtype.code ==
+                                        static_cast<uint8_t>(DLDataTypeCode::kDLUInt))) {
     return Rewriter::VisitExpr_(op);
   }
   // normalize

--- a/src/arith/const_fold.h
+++ b/src/arith/const_fold.h
@@ -39,6 +39,33 @@ namespace tvm {
 namespace arith {
 
 /*!
+ * \brief Scoped opt-in flag for unsigned index analysis (allow_u32).
+ *
+ * Unsigned arithmetic wraps modulo 2^bits, so most index rewrite rules are
+ * unsound for it in general. When the caller can guarantee values never
+ * approach the type limit (e.g. compile-time layout proofs over SMEM
+ * offsets), enabling this flag activates a small set of otherwise-unsafe
+ * rewrite rules for unsigned operands (see the unsigned blocks in
+ * rewrite_simplify.cc). It is OFF by default; thread-local and nested-safe.
+ */
+namespace uint_as_index {
+
+inline thread_local int g_depth = 0;
+
+inline bool Enabled() { return g_depth > 0; }
+
+}  // namespace uint_as_index
+
+/*! \brief RAII guard enabling uint_as_index mode in the current scope. */
+class AllowUintAsIndexGuard {
+ public:
+  AllowUintAsIndexGuard() { ++uint_as_index::g_depth; }
+  ~AllowUintAsIndexGuard() { --uint_as_index::g_depth; }
+  AllowUintAsIndexGuard(const AllowUintAsIndexGuard&) = delete;
+  AllowUintAsIndexGuard& operator=(const AllowUintAsIndexGuard&) = delete;
+};
+
+/*!
  * \brief Try to run binary compute with constant folding.
  *
  * \param a The left operand.

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -1196,9 +1196,48 @@ Expr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
   if (op_ty.MatchesCode(DLDataTypeCode::kDLUInt) && (op_ty.bits() == 32 || op_ty.bits() == 64)) {
     TVM_TRY_REWRITE(floordiv(x, x), OneWithTypeLike(x));            // x / x -> 1  (x != 0)
     TVM_TRY_REWRITE_IF(floordiv(x, c1), x, c1.Eval()->value == 1);  // x / 1 -> x
-    // Unsigned x is always >= 0, so x < y provably implies x / y == 0.
-    TVM_TRY_REWRITE_IF(floordiv(x, y), ZeroWithTypeLike(x),
-                       CanProveGreaterEqual(y.Eval(), 1) && CanProve(x.Eval() < y.Eval()));
+    // Unsigned x is always >= 0, so x / c2 == 0 when x < c2 is provable from
+    // the interval bound (const_int_bound is dtype-agnostic; CanProve's
+    // comparison machinery is signed-centric and can't be used here).
+    if (floordiv(x, c2).Match(ret) && c2.Eval()->value > 0) {
+      ConstIntBound x_bound = analyzer_->const_int_bound(x.Eval());
+      if (x_bound->min_value >= 0 && x_bound->max_value < c2.Eval()->value) {
+        return ZeroWithTypeLike(x).Eval();
+      }
+    }
+
+    // Enabled only under the caller's no-overflow assertion (uint_as_index):
+    // these floordiv identities are unsound in general for unsigned
+    // wraparound (the quotient's high bits are lost when x*c1 overflows), but
+    // are exact in the asserted no-overflow domain. Each application is
+    // logged for audit.
+    if (uint_as_index::Enabled()) {
+      if (floordiv(x * c1, c2).Match(ret) && c2.Eval()->value > 0 &&
+          c1.Eval()->value % c2.Eval()->value == 0) {
+        LOG(WARNING) << "arith: no-overflow floordiv rule on unsigned expr: " << ret;
+        return (x * floordiv(c1, c2)).Eval();
+      }
+      if (floordiv(x * c1 + y, c2).Match(ret) && c2.Eval()->value > 0 &&
+          c1.Eval()->value % c2.Eval()->value == 0) {
+        LOG(WARNING) << "arith: no-overflow floordiv rule on unsigned expr: " << ret;
+        return (x * floordiv(c1, c2) + floordiv(y, c2)).Eval();
+      }
+      if (floordiv(y + x * c1, c2).Match(ret) && c2.Eval()->value > 0 &&
+          c1.Eval()->value % c2.Eval()->value == 0) {
+        LOG(WARNING) << "arith: no-overflow floordiv rule on unsigned expr: " << ret;
+        return (x * floordiv(c1, c2) + floordiv(y, c2)).Eval();
+      }
+      if (floordiv(x * c1 + y + z, c2).Match(ret) && c2.Eval()->value > 0 &&
+          c1.Eval()->value % c2.Eval()->value == 0) {
+        LOG(WARNING) << "arith: no-overflow floordiv rule on unsigned expr: " << ret;
+        return (x * floordiv(c1, c2) + floordiv(y + z, c2)).Eval();
+      }
+      if (floordiv(y + x * c1 + z, c2).Match(ret) && c2.Eval()->value > 0 &&
+          c1.Eval()->value % c2.Eval()->value == 0) {
+        LOG(WARNING) << "arith: no-overflow floordiv rule on unsigned expr: " << ret;
+        return (x * floordiv(c1, c2) + floordiv(y + z, c2)).Eval();
+      }
+    }
   }
   return ret;
 }

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -1352,29 +1352,6 @@ Expr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
         return floormod(mod->base, c2).Eval();
       }
     }
-
-    // Parity-preserving floordiv decomposition inside a floormod:
-    // floormod(floordiv(x * c1 + y, c2), c3) -> floormod(x*(c1/c2) + floordiv(y, c2), c3).
-    // Under unsigned wraparound the split differs from the exact quotient by
-    // a multiple of 2^bits/c2, which vanishes mod c3 whenever c3 | 2^bits/c2
-    // (and (x*c1) mod 2^bits stays divisible by c2 since c2 | c1 and
-    // c2 | 2^bits, so no carry hides in the split).
-    if (floormod(floordiv(x * c1 + y, c2), c3).Match(ret) &&
-        c1.Eval()->value % c2.Eval()->value == 0 && is_pow2_le_bits(c2.Eval()->value)) {
-      const int64_t c2v = c2.Eval()->value;
-      const int64_t c3v = c3.Eval()->value;
-      if (c3v > 0 && (c3v & (c3v - 1)) == 0) {
-        const int64_t log_c2 = __builtin_ctzll(static_cast<unsigned long long>(c2v));
-        const int64_t log_c3 = __builtin_ctzll(static_cast<unsigned long long>(c3v));
-        if (log_c2 + log_c3 <= op_bits) {
-          return floormod(x * PConst<PrimExpr>(
-                                  IntImm(op->ty.as_or_throw<PrimType>(), c1.Eval()->value / c2v)) +
-                              floordiv(y, c2),
-                          c3)
-              .Eval();
-        }
-      }
-    }
   }
   return ret;
 }

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -1328,6 +1328,25 @@ Expr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
     // Overflow-free: when c1 is a multiple of c2, x * c1 is too (in Z and mod 2^bits).
     TVM_TRY_REWRITE_IF(floormod(x * c1, c2), ZeroWithTypeLike(x),
                        c2.Eval()->value != 0 && c1.Eval()->value % c2.Eval()->value == 0);
+
+    // When c2 divides 2^bits (a power of two no wider than the type), reducing
+    // mod 2^bits does not change residues mod c2, so modular analysis is
+    // sound for unsigned operands too.
+    const int64_t op_bits = op_ty.bits();
+    if (floormod(x, c2).Match(ret)) {
+      const int64_t c2val = c2.Eval()->value;
+      const bool c2_pow2 =
+          c2val > 0 && (c2val & (c2val - 1)) == 0 &&
+          (op_bits < 64 ? c2val <= (int64_t{1} << op_bits) : c2val <= (int64_t{1} << 63));
+      if (c2_pow2) {
+        // x = coeff * q + base stays congruent mod c2 when c2 | 2^bits, so
+        // the signed block's modular-analysis branch is valid here as well.
+        ModularSet mod = analyzer_->modular_set(x.Eval());
+        if (mod->coeff % c2val == 0) {
+          return floormod(mod->base, c2).Eval();
+        }
+      }
+    }
   }
   return ret;
 }

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -1196,6 +1196,9 @@ Expr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
   if (op_ty.MatchesCode(DLDataTypeCode::kDLUInt) && (op_ty.bits() == 32 || op_ty.bits() == 64)) {
     TVM_TRY_REWRITE(floordiv(x, x), OneWithTypeLike(x));            // x / x -> 1  (x != 0)
     TVM_TRY_REWRITE_IF(floordiv(x, c1), x, c1.Eval()->value == 1);  // x / 1 -> x
+    // Unsigned x is always >= 0, so x < y provably implies x / y == 0.
+    TVM_TRY_REWRITE_IF(floordiv(x, y), ZeroWithTypeLike(x),
+                       CanProveGreaterEqual(y.Eval(), 1) && CanProve(x.Eval() < y.Eval()));
   }
   return ret;
 }
@@ -1208,7 +1211,7 @@ Expr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
   // Pattern var to match any expression
   PVar<PrimExpr> x, y, z, b1;
   // Pattern var match IntImm
-  PVar<IntImm> c1, c2;
+  PVar<IntImm> c1, c2, c3;
   // Pattern var for lanes in broadcast and ramp
   PVar<PrimExpr> lanes;
 
@@ -1322,28 +1325,53 @@ Expr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
   // OVERFLOW-FREE identities are valid here.
   PrimType op_ty = op->ty.as_or_throw<PrimType>();
   if (op_ty.MatchesCode(DLDataTypeCode::kDLUInt) && (op_ty.bits() == 32 || op_ty.bits() == 64)) {
+    const int64_t op_bits = op_ty.bits();
+    const auto is_pow2_le_bits = [op_bits](int64_t v) {
+      return v > 0 && (v & (v - 1)) == 0 &&
+             (op_bits < 64 ? v <= (int64_t{1} << op_bits) : v <= (int64_t{1} << 63));
+    };
     TVM_TRY_REWRITE(floormod(x, x), ZeroWithTypeLike(x));  // x % x -> 0  (x != 0)
     TVM_TRY_REWRITE_IF(floormod(x, c1), ZeroWithTypeLike(x),
                        c1.Eval()->value == 1);  // x % 1 -> 0
-    // Overflow-free: when c1 is a multiple of c2, x * c1 is too (in Z and mod 2^bits).
+    // When c1 is a multiple of c2, x * c1 is too — but the identity is only
+    // sound when c2 | 2^bits: otherwise the wraparound subtraction of
+    // k*2^bits changes residues mod c2. (No non-pow2 c2 occurs in practice;
+    // probed across the arith/copy/kernel test suites.)
     TVM_TRY_REWRITE_IF(floormod(x * c1, c2), ZeroWithTypeLike(x),
-                       c2.Eval()->value != 0 && c1.Eval()->value % c2.Eval()->value == 0);
+                       c2.Eval()->value != 0 && c1.Eval()->value % c2.Eval()->value == 0 &&
+                           is_pow2_le_bits(c2.Eval()->value));
 
-    // When c2 divides 2^bits (a power of two no wider than the type), reducing
-    // mod 2^bits does not change residues mod c2, so modular analysis is
-    // sound for unsigned operands too.
-    const int64_t op_bits = op_ty.bits();
-    if (floormod(x, c2).Match(ret)) {
+    // When c2 divides 2^bits, reducing mod 2^bits does not change residues
+    // mod c2, so modular analysis is sound for unsigned operands too.
+    if (floormod(x, c2).Match(ret) && is_pow2_le_bits(c2.Eval()->value)) {
       const int64_t c2val = c2.Eval()->value;
-      const bool c2_pow2 =
-          c2val > 0 && (c2val & (c2val - 1)) == 0 &&
-          (op_bits < 64 ? c2val <= (int64_t{1} << op_bits) : c2val <= (int64_t{1} << 63));
-      if (c2_pow2) {
-        // x = coeff * q + base stays congruent mod c2 when c2 | 2^bits, so
-        // the signed block's modular-analysis branch is valid here as well.
-        ModularSet mod = analyzer_->modular_set(x.Eval());
-        if (mod->coeff % c2val == 0) {
-          return floormod(mod->base, c2).Eval();
+      // x = coeff * q + base stays congruent mod c2 when c2 | 2^bits, so
+      // the signed block's modular-analysis branch is valid here as well.
+      ModularSet mod = analyzer_->modular_set(x.Eval());
+      if (mod->coeff % c2val == 0) {
+        return floormod(mod->base, c2).Eval();
+      }
+    }
+
+    // Parity-preserving floordiv decomposition inside a floormod:
+    // floormod(floordiv(x * c1 + y, c2), c3) -> floormod(x*(c1/c2) + floordiv(y, c2), c3).
+    // Under unsigned wraparound the split differs from the exact quotient by
+    // a multiple of 2^bits/c2, which vanishes mod c3 whenever c3 | 2^bits/c2
+    // (and (x*c1) mod 2^bits stays divisible by c2 since c2 | c1 and
+    // c2 | 2^bits, so no carry hides in the split).
+    if (floormod(floordiv(x * c1 + y, c2), c3).Match(ret) &&
+        c1.Eval()->value % c2.Eval()->value == 0 && is_pow2_le_bits(c2.Eval()->value)) {
+      const int64_t c2v = c2.Eval()->value;
+      const int64_t c3v = c3.Eval()->value;
+      if (c3v > 0 && (c3v & (c3v - 1)) == 0) {
+        const int64_t log_c2 = __builtin_ctzll(static_cast<unsigned long long>(c2v));
+        const int64_t log_c3 = __builtin_ctzll(static_cast<unsigned long long>(c3v));
+        if (log_c2 + log_c3 <= op_bits) {
+          return floormod(x * PConst<PrimExpr>(
+                                  IntImm(op->ty.as_or_throw<PrimType>(), c1.Eval()->value / c2v)) +
+                              floordiv(y, c2),
+                          c3)
+              .Eval();
         }
       }
     }

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -1391,6 +1391,25 @@ Expr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
         return floormod(mod->base, c2).Eval();
       }
     }
+
+    // Under the caller's no-overflow assertion (uint_as_index) the pow2
+    // restriction above disappears: without wraparound the residues are the
+    // plain integer ones, so these hold for any c2 != 0. Each application is
+    // logged for audit.
+    if (uint_as_index::Enabled()) {
+      if (floormod(x * c1, c2).Match(ret) && c2.Eval()->value != 0 &&
+          c1.Eval()->value % c2.Eval()->value == 0) {
+        LOG(WARNING) << "arith: no-overflow floormod rule on unsigned expr: " << ret;
+        return ZeroWithTypeLike(x).Eval();
+      }
+      if (floormod(x, c2).Match(ret) && c2.Eval()->value > 0) {
+        ModularSet mod = analyzer_->modular_set(x.Eval());
+        if (mod->coeff % c2.Eval()->value == 0) {
+          LOG(WARNING) << "arith: no-overflow floormod rule on unsigned expr: " << ret;
+          return floormod(mod->base, c2).Eval();
+        }
+      }
+    }
   }
   return ret;
 }

--- a/src/backend/cuda/transforms/lower_iket.cc
+++ b/src/backend/cuda/transforms/lower_iket.cc
@@ -254,13 +254,17 @@ class AnnotationCollector : public StmtExprVisitor {
     if (call->op.same_as(IketMarkOp())) {
       AddDeclaration(DeclarationKind::kMark, call);
     } else if (call->op.same_as(IketRangeStartOp())) {
-      TVM_FFI_CHECK(call->ty.as_or_throw<PrimType>()->dtype.code == kDLUInt && call->ty.as_or_throw<PrimType>()->dtype.bits == 32, TypeError)
+      TVM_FFI_CHECK(call->ty.as_or_throw<PrimType>()->dtype.code == kDLUInt &&
+                        call->ty.as_or_throw<PrimType>()->dtype.bits == 32,
+                    TypeError)
           << "IKET range_start must return uint32";
       AddDeclaration(DeclarationKind::kRange, call);
     } else if (call->op.same_as(IketSentinelOp())) {
       TVM_FFI_CHECK_EQ(call->args.size(), 1, TypeError)
           << "IKET sentinel_token expects one event name";
-      TVM_FFI_CHECK(call->ty.as_or_throw<PrimType>()->dtype.code == kDLUInt && call->ty.as_or_throw<PrimType>()->dtype.bits == 32, TypeError)
+      TVM_FFI_CHECK(call->ty.as_or_throw<PrimType>()->dtype.code == kDLUInt &&
+                        call->ty.as_or_throw<PrimType>()->dtype.bits == 32,
+                    TypeError)
           << "IKET sentinel_token must return uint32";
       AddDeclaration(DeclarationKind::kRange, call, true);
     } else if (call->op.same_as(IketRangePushOp())) {
@@ -899,8 +903,8 @@ class RemoveStrippedIketNoOps : public StmtExprMutator {
     if (IsEvaluateZero(body)) return body;
     if (body.same_as(loop->body)) return ffi::GetRef<Stmt>(loop);
     return For(loop->loop_var, VisitExpr(loop->min).as_or_throw<PrimExpr>(),
-              VisitExpr(loop->extent).as_or_throw<PrimExpr>(), loop->kind, body,
-              loop->thread_binding, loop->annotations, loop->step, loop->span);
+               VisitExpr(loop->extent).as_or_throw<PrimExpr>(), loop->kind, body,
+               loop->thread_binding, loop->annotations, loop->step, loop->span);
   }
 
   Stmt VisitStmt_(const WhileNode* loop) final {

--- a/tests/python/arith/test_arith_rewrite_simplify.py
+++ b/tests/python/arith/test_arith_rewrite_simplify.py
@@ -1398,9 +1398,14 @@ def test_allow_uint_as_index():
     )
     check = flm(fld(s_off, T.uint32(512)), T.uint32(2))
     assert not analyzer.can_prove_equal(check, 0)
+    # a non-pow2 divisor never folds, inside or outside the mode... unless
+    # the flag is on: under the no-overflow assertion any c2 != 0 works.
+    np2 = flm(x * T.uint32(12), T.uint32(12))
+    assert not analyzer.can_prove_equal(np2, 0)
     with tvm.arith.allow_uint_as_index():
         assert analyzer.can_prove_equal(check, 0)
         assert analyzer.can_prove_equal(flm(fld(s_off, T.uint32(32)), T.uint32(2)), 0)
+        assert analyzer.can_prove_equal(np2, 0)
         # nested scopes compose
         with tvm.arith.allow_uint_as_index():
             assert analyzer.can_prove_equal(check, 0)

--- a/tests/python/arith/test_arith_rewrite_simplify.py
+++ b/tests/python/arith/test_arith_rewrite_simplify.py
@@ -790,6 +790,32 @@ class TestFloorModUnsigned(BaseCompare):
             flm(x * tirx.const(16, "uint32") + (z * 4).astype("uint32"), tirx.const(12, "uint32")),
             flm(x * tirx.const(16, "uint32") + (z * 4).astype("uint32"), tirx.const(12, "uint32")),
         ),
+        # The pre-existing x * c1 % c2 -> 0 rule is pow2-guarded: c2=12 must
+        # not fold to 0 (e.g. x=2^29 wraps: uint32(x*12)=2^31, and 2^31 % 12 = 8).
+        TestCase(
+            flm(x * tirx.const(12, "uint32"), tirx.const(12, "uint32")),
+            flm(x * tirx.const(12, "uint32"), tirx.const(12, "uint32")),
+        ),
+        TestCase(
+            flm(x * tirx.const(8, "uint32"), tirx.const(8, "uint32")), tirx.const(0, "uint32")
+        ),
+        # Parity-preserving floordiv decomposition inside a floormod.
+        TestCase(
+            flm(
+                tvm.tirx.floordiv(x * tirx.const(4096, "uint32") + y, tirx.const(512, "uint32")),
+                tirx.const(2, "uint32"),
+            ),
+            flm(
+                x * tirx.const(8, "uint32") + tvm.tirx.floordiv(y, tirx.const(512, "uint32")),
+                tirx.const(2, "uint32"),
+            ),
+        ),
+        # Unsigned floordiv to zero by const bound.
+        TestCase(
+            tvm.tirx.floordiv(x, tirx.const(512, "uint32")),
+            tirx.const(0, "uint32"),
+            [x < 512],
+        ),
     )
 
 

--- a/tests/python/arith/test_arith_rewrite_simplify.py
+++ b/tests/python/arith/test_arith_rewrite_simplify.py
@@ -799,17 +799,6 @@ class TestFloorModUnsigned(BaseCompare):
         TestCase(
             flm(x * tirx.const(8, "uint32"), tirx.const(8, "uint32")), tirx.const(0, "uint32")
         ),
-        # Parity-preserving floordiv decomposition inside a floormod.
-        TestCase(
-            flm(
-                tvm.tirx.floordiv(x * tirx.const(4096, "uint32") + y, tirx.const(512, "uint32")),
-                tirx.const(2, "uint32"),
-            ),
-            flm(
-                x * tirx.const(8, "uint32") + tvm.tirx.floordiv(y, tirx.const(512, "uint32")),
-                tirx.const(2, "uint32"),
-            ),
-        ),
         # Unsigned floordiv to zero by const bound.
         TestCase(
             tvm.tirx.floordiv(x, tirx.const(512, "uint32")),

--- a/tests/python/arith/test_arith_rewrite_simplify.py
+++ b/tests/python/arith/test_arith_rewrite_simplify.py
@@ -1379,3 +1379,31 @@ class TestCLZ(BaseCompare):
 
 if __name__ == "__main__":
     tvm.testing.main()
+
+
+def test_allow_uint_as_index():
+    """Opt-in no-overflow domain: unsigned index terms are not analyzed by
+    default; within allow_uint_as_index() the signed rule set applies and the
+    swizzle-style floordiv-quotient bit checks over uint32 offsets discharge."""
+    w = tirx.Var("w", "int32")
+    lane = tirx.Var("lane", "int32")
+    x = tirx.Var("x", "uint32")
+    analyzer = tvm.arith.Analyzer()
+    analyzer.bind(lane, tvm.ir.Range.from_min_extent(0, 32))
+    analyzer.bind(w, tvm.ir.Range.from_min_extent(0, 4))
+    s_off = (
+        (w * 1024 + lane // 8 * 8).astype("uint32")
+        + x * T.uint32(4096)
+        + (lane % 8 * 64).astype("uint32")
+    )
+    check = flm(fld(s_off, T.uint32(512)), T.uint32(2))
+    assert not analyzer.can_prove_equal(check, 0)
+    with tvm.arith.allow_uint_as_index():
+        assert analyzer.can_prove_equal(check, 0)
+        assert analyzer.can_prove_equal(flm(fld(s_off, T.uint32(32)), T.uint32(2)), 0)
+        # nested scopes compose
+        with tvm.arith.allow_uint_as_index():
+            assert analyzer.can_prove_equal(check, 0)
+        assert analyzer.can_prove_equal(check, 0)
+    # the mode is scoped: disabled again afterwards
+    assert not analyzer.can_prove_equal(check, 0)

--- a/tests/python/arith/test_arith_rewrite_simplify.py
+++ b/tests/python/arith/test_arith_rewrite_simplify.py
@@ -758,6 +758,41 @@ def test_uint_floormod_const_fold():
     assert analyzer.can_prove_equal(expr, 0)
 
 
+class TestFloorModUnsigned(BaseCompare):
+    """Modular-analysis simplifications for unsigned operands (uint32/uint64).
+
+    Only sound when the divisor is a power of two (c2 | 2^bits): reducing
+    mod 2^bits does not change residues mod c2 in that case, so the
+    modular-decomposition rules carry over from the signed block.
+    """
+
+    x = tirx.Var("x", "uint32")
+    y = tirx.Var("y", "uint32")
+    z = tirx.Var("z", "int32")
+    test_case = tvm.testing.parameter(
+        TestCase(
+            flm(x * tirx.const(8, "uint32"), tirx.const(4, "uint32")), tirx.const(0, "uint32")
+        ),
+        TestCase(flm((z * 4).astype("uint32"), tirx.const(4, "uint32")), tirx.const(0, "uint32")),
+        TestCase(
+            flm(x * tirx.const(16, "uint32") + (z * 4).astype("uint32"), tirx.const(4, "uint32")),
+            tirx.const(0, "uint32"),
+        ),
+        TestCase(
+            flm(
+                x * tirx.const(32, "uint32") + y * tirx.const(8, "uint32"), tirx.const(8, "uint32")
+            ),
+            tirx.const(0, "uint32"),
+        ),
+        # Non-power-of-two divisor must NOT simplify (unsigned wraparound
+        # changes residues mod c2).
+        TestCase(
+            flm(x * tirx.const(16, "uint32") + (z * 4).astype("uint32"), tirx.const(12, "uint32")),
+            flm(x * tirx.const(16, "uint32") + (z * 4).astype("uint32"), tirx.const(12, "uint32")),
+        ),
+    )
+
+
 class TestMinIndex(BaseCompare):
     x, y, z = tvm.tirx.Var("x", "int32"), tvm.tirx.Var("y", "int32"), tvm.tirx.Var("z", "int32")
     test_case = tvm.testing.parameter(

--- a/tests/python/tirx/codegen/conftest.py
+++ b/tests/python/tirx/codegen/conftest.py
@@ -16,10 +16,9 @@
 # under the License.
 """Hardware requirements for TIRx codegen tests."""
 
-from pathlib import Path
-
 import gc
 import os
+from pathlib import Path
 
 import pytest
 

--- a/tests/python/tirx/codegen/test_codegen_cuda.py
+++ b/tests/python/tirx/codegen/test_codegen_cuda.py
@@ -26,7 +26,6 @@ from tvm import tirx as tir
 from tvm.script import tirx as T
 from tvm.testing import env
 
-
 _CUDA_LDG_SCALAR_CASES = [
     ("int8", "i8", "signed char"),
     ("uint8", "u8", "unsigned char"),

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_ld_stmatrix.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_ld_stmatrix.py
@@ -515,45 +515,6 @@ def test_ldstmatrix_tcgen05_warpgroup_atom_emits_ldmatrix():
     )
 
 
-def test_ldstmatrix_tcgen05_warpgroup_atom_emits_ldmatrix():
-    """Regression: a warpgroup ``.16x256b`` tcgen05 register atom loaded from a
-    128B-swizzled SMEM tile must dispatch to ``ldmatrix.x4``.
-
-    The atom's laneid is split across two shard iters (stride 4 and stride 1)
-    plus ``wid_in_wg`` — it only fuses to a single ``tid_in_wg`` thread axis
-    after the slice. With the redundant pre-slice ``canonicalize()`` removed,
-    Step 2 relies on ``TileLayout.Slice``'s built-in global pre-canonicalize, so
-    the slice no longer leaves an ill-formed split-laneid sub-layout that
-    ``GetScope`` would reject (which silently fell back to a scalar reg path).
-    Compile-only (no GPU): asserts the instruction appears in generated source.
-    """
-    from tvm.tirx.cuda.operator.tile_primitive.tma_utils import mma_shared_layout
-    from tvm.tirx.layout import tcgen05_atom_layout
-
-    m, k = 64, 64
-    # bf16 payload carrying the *fp32* atom layout (mirrors the tf32-prenorm
-    # cast warp's ``a_bf16``: one element per 32-bit slot).
-    reg_layout = tcgen05_atom_layout("16x256b", (m, k), "float32")
-    smem_layout = mma_shared_layout("bfloat16", 3, (m, k))
-
-    @T.prim_func
-    def kernel(s_ptr: T.handle) -> None:
-        smem = T.match_buffer(s_ptr, (m, k), "bfloat16", scope="shared", layout=smem_layout)
-        T.device_entry()
-        T.cta_id([1])
-        T.warpgroup_id([1])
-        T.warp_id_in_wg([4])
-        T.lane_id([32])
-        T.thread_id_in_wg([128])
-        a_reg = T.alloc_buffer((m, k), "bfloat16", scope="local", layout=reg_layout)
-        Tx.wg.copy(a_reg, smem)
-
-    _, src = _compile_src(kernel)
-    assert "ldmatrix.sync.aligned.m8n8.x4.shared.b16" in src, (
-        f"warpgroup tcgen05 atom did not emit ldmatrix.x4; src=\n{src}"
-    )
-
-
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda_compute(9), reason="need cuda compute >= 9.0")
 def test_ldstmatrix_swizzle_multi_iter_linear():


### PR DESCRIPTION
The swizzle fast path in the CUDA copy lowering (`_swizzle_iter.try_recognize`) proves a no-carry condition on the per-thread offset via floordiv/floormod reasoning. The analyzer only performs that modular reasoning on **signed** dtypes, so any SMEM offset template containing a uint term (e.g. a `uint32` stage index, common in pipelined kernels) silently fell back to recomputing the full swizzle expression per iteration — ~10 integer instructions per ldmatrix per stage on the warp critical path.

## Fix

Normalize the offset template to int64 for the (C1) analysis only:

- SMEM offsets are far below 2³¹, so widening unsigned/narrow dtypes is value-preserving.
- Memory loads (e.g. `BufferLoad stage_idx`) in the template are proxied by fresh int64 vars — only their surrounding divisibility structure matters for the bit checks.
- Bounds for lane/warp placeholders are re-keyed to the widened vars.
- If normalization fails (unsupported node), fall back to the original check unchanged.

No change to emitted code other than enabling the already-implemented signed-stride fast path for these cases.

## Validation

- `tests/python/tirx/operator/tile_primitive/cuda/copy/`: 256 passed.
- On the tf32_hc_prenorm_gemm cast-warp ldmatrix (swizzled bf16 atom, uint32 stage index), per-stage address arithmetic drops from a full swizzle recompute per ldmatrix to a single swizzled base + per-iter IMAD; contributes to mlc-ai/tirx-kernels#4 (0.952 → 1.006 on m137_n24_k7680_s16, and part of the m13 gain).