### PR TITLE
test(infra): delegate MegaKernelMoE scheduler coverage

### DIFF
--- a/tests/python/tirx/test_tirx_kernels_registry_correctness.py
+++ b/tests/python/tirx/test_tirx_kernels_registry_correctness.py
@@ -161,11 +161,4 @@ def test_manifest_tirx_kernel_correctness(kernel_name, config):
             f"requires {required_devices} CUDA devices, but only {visible_devices} are visible"
         )
     with _registry_gpu_lock(kernel_name, config):
-        schedulers = getattr(_KERNELS[kernel_name], "_SUPPORTED_SCHEDULERS", ())
-        if kernel_name == "megakernel_moe" and "scheduler" not in config:
-            for scheduler in schedulers:
-                kernel_runner.run_kernel_test(
-                    kernel_name, {**config, "scheduler": scheduler}, registry=_KERNELS
-                )
-        else:
-            kernel_runner.run_kernel_test(kernel_name, config, registry=_KERNELS)
+        kernel_runner.run_kernel_test(kernel_name, config, registry=_KERNELS)


### PR DESCRIPTION
## Summary

- remove the TVM-side MegaKernelMoE scheduler loop from registry correctness
- delegate scheduler coverage to `tirx_kernels.megakernel.moe.run_test`
- execute compilation, data preparation, and the FlashInfer correctness reference once per manifest config

## Motivation

tirx-kernels PR spectrometerHBH/tirx-kernels#41 made `run_test(scheduler=None)` the owner of all supported scheduler coverage. Keeping the TVM wrapper loop repeats the full correctness workflow once per scheduler, including compilation, data preparation, and external reference setup.

Calling the public runner once also keeps TVM's registry harness generic and leaves kernel-specific coverage with the kernel module.

Depends on spectrometerHBH/tirx-kernels#41 (merged).

## Validation

- `megakernel_moe::moe_a3b_bs1024_all` registry correctness: `1 passed`
- full `tests/python/tirx/ -n 16`: `2583 passed, 41 skipped, 3 xpassed`
- bench workload import gate: 17 kernels
- strict registry import gate: 20 categories
- `pre-commit` on the changed file
