### PR TITLE
feat(tvmscript): add PTX shl intrinsic

### DIFF
--- a/python/tvm/backend/cuda/op.py
+++ b/python/tvm/backend/cuda/op.py
@@ -4730,6 +4730,32 @@ def ptx_fns_b32(mask, base, offset):
     return call_intrin("uint32", "tirx.ptx.fns_b32", mask, base, offset)
 
 
+_PTX_SHL_RETURN_TYPE = {
+    "b16": "uint16",
+    "b32": "uint32",
+    "b64": "uint64",
+}
+
+
+def ptx_shl(a, b, ptx_type):
+    """Return the PTX ``shl.{type} a, b`` result as a raw-bit carrier.
+
+    PTX defines the shift operand as an unsigned 32-bit value.  Shift counts
+    greater than or equal to the width selected by ``ptx_type`` produce zero.
+
+    Parameters
+    ----------
+    a : Expr
+        Value to shift.
+    b : Expr
+        Unsigned 32-bit shift count.
+    ptx_type : str
+        One of ``"b16"``, ``"b32"``, or ``"b64"``.
+    """
+    _choice("ptx_type", ptx_type, _PTX_SHL_RETURN_TYPE)
+    return call_intrin(_PTX_SHL_RETURN_TYPE[ptx_type], "tirx.ptx.shl", a, b, ptx_type)
+
+
 def ptx_add_rn_f32_bf16(acc, x):
     return call_intrin("float32", "tirx.ptx.add_rn_f32_bf16", acc, x)
 

--- a/python/tvm/backend/cuda/operator/intrinsics/__init__.py
+++ b/python/tvm/backend/cuda/operator/intrinsics/__init__.py
@@ -20,6 +20,7 @@
 - ``mma`` / ``wgmma`` / ``tcgen05`` — matrix-multiply hardware (Volta+/Hopper/Blackwell).
 - ``cp_async`` — cp.async + cp.async.bulk + cp.async.bulk.tensor (TMA), incl. TMA address helpers.
 - ``sync`` — barriers, fences, mbarrier, cluster.barrier, warp vote, elect, sync helpers.
+- ``logic`` — PTX logic and shift instructions.
 - ``math`` — packed-f32x2 arithmetic, exp2/rcp/reduce3, warp/CTA reductions.
 - ``cvt`` — PTX data movement and conversion instruction forms.
 - ``memory`` — typed copies, ldg, ld.global.acquire, atomics, type conversions, address casts.
@@ -35,7 +36,7 @@ Plus the support modules:
 """
 
 # Import op modules to register their codegen functions.
-from . import cp_async, cvt, math, memory, misc, mma, nvshmem, sync, tcgen05, wgmma
+from . import cp_async, cvt, logic, math, memory, misc, mma, nvshmem, sync, tcgen05, wgmma
 from .header import TAGS, header_generator
 from .registry import CODEGEN_REGISTRY, get_codegen, register_codegen
 from .types import PTXDataType

--- a/python/tvm/backend/cuda/operator/intrinsics/logic.py
+++ b/python/tvm/backend/cuda/operator/intrinsics/logic.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""PTX logic and shift intrinsics."""
+
+from ._schema import device_intrinsic
+from .utils import parse_str
+
+_SHL_TYPE_INFO = {
+    "b16": ("unsigned short", "h", "uint16"),
+    "b32": ("unsigned int", "r", "uint32"),
+    "b64": ("unsigned long long", "l", "uint64"),
+}
+
+
+def _shl_type_info(ptx_type):
+    ptx_type = parse_str(ptx_type)
+    if ptx_type not in _SHL_TYPE_INFO:
+        raise ValueError(
+            f"Unsupported PTX shl type {ptx_type!r}; expected {sorted(_SHL_TYPE_INFO)}"
+        )
+    return ptx_type, *_SHL_TYPE_INFO[ptx_type]
+
+
+def _shl_helper_name(_a, _b, ptx_type):
+    ptx_type, _, _, _ = _shl_type_info(ptx_type)
+    return f"tvm_builtin_ptx_shl_{ptx_type}"
+
+
+def _shl_signature(_a, _b, ptx_type):
+    _, c_type, _, _ = _shl_type_info(ptx_type)
+    return f"({c_type} a, unsigned int b)"
+
+
+def _shl_body(_a, _b, ptx_type):
+    ptx_type, _, constraint, _ = _shl_type_info(ptx_type)
+    return (
+        f"    {_SHL_TYPE_INFO[ptx_type][0]} ret;\n"
+        f'    asm("shl.{ptx_type} %0, %1, %2;"'
+        f' : "={constraint}"(ret) : "{constraint}"(a), "r"(b));\n'
+        "    return ret;"
+    )
+
+
+def _shl_return_type(_a, _b, ptx_type):
+    _, c_type, _, _ = _shl_type_info(ptx_type)
+    return c_type
+
+
+def _shl_tvm_return_type(_a, _b, ptx_type):
+    _, _, _, tvm_type = _shl_type_info(ptx_type)
+    return tvm_type
+
+
+device_intrinsic(
+    "ptx_shl",
+    helper_name=_shl_helper_name,
+    c_signature=_shl_signature,
+    body=_shl_body,
+    n_attrs=1,
+    return_type=_shl_return_type,
+    tvm_return_type=_shl_tvm_return_type,
+)

--- a/python/tvm/backend/cuda/script.py
+++ b/python/tvm/backend/cuda/script.py
@@ -78,6 +78,7 @@ class PTXNamespace:
         self.st_mmio = _op_wrapper(_cuda_op.ptx_st_mmio)
         self.st_bulk = _op_wrapper(_cuda_op.ptx_st_bulk)
         self.fns_b32 = _op_wrapper(_cuda_op.ptx_fns_b32)
+        self.shl = _op_wrapper(_cuda_op.ptx_shl)
         self.add_rn_f32_bf16 = _op_wrapper(_cuda_op.ptx_add_rn_f32_bf16)
         self.mapa = _op_wrapper(_cuda_op.ptx_mapa)
         self.map_shared_rank = _op_wrapper(_cuda_op.ptx_map_shared_rank)

--- a/src/backend/cuda/op/target_builtin.cc
+++ b/src/backend/cuda/op/target_builtin.cc
@@ -310,6 +310,7 @@ const DeviceIntrinsicRegistration kDeviceIntrinsics[] = {
     TIRX_DEVICE_INTRIN_ALIAS(ptx_reduce3_max_f32, ptx, kPure),
     TIRX_DEVICE_INTRIN_ALIAS(ptx_reduce3_min_f32, ptx, kPure),
     TIRX_DEVICE_INTRIN_ALIAS(ptx_setmaxnreg, ptx, kOpaque),
+    TIRX_DEVICE_INTRIN_ALIAS(ptx_shl, ptx, kPure),
     TIRX_DEVICE_INTRIN_ALIAS(ptx_st, ptx, kOpaque),
     TIRX_DEVICE_INTRIN_ALIAS(ptx_st_bulk, ptx, kOpaque),
     TIRX_DEVICE_INTRIN_ALIAS(ptx_st_mmio, ptx, kOpaque),

--- a/tests/python/tirx/codegen/test_ptx_shl.py
+++ b/tests/python/tirx/codegen/test_ptx_shl.py
@@ -1,0 +1,142 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for the PTX ``shl`` intrinsic."""
+
+import numpy as np
+import pytest
+
+import tvm
+import tvm.testing
+from tvm.backend.cuda import op as cuda_op
+from tvm.ir import PrimType, assert_structural_equal
+from tvm.script import tirx as T
+from tvm.testing import env
+
+_SHL_CASES = [
+    ("b16", "uint16", np.uint16, 16, "unsigned short", "h"),
+    ("b32", "uint32", np.uint32, 32, "unsigned int", "r"),
+    ("b64", "uint64", np.uint64, 64, "unsigned long long", "l"),
+]
+
+
+def _get_source(func):
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_100a"})
+    with target:
+        mod = tvm.compile(
+            tvm.IRModule({"main": func}),
+            target=target,
+            tir_pipeline="tirx",
+        )
+    return mod.mod.imports[0].inspect_source(), mod
+
+
+def _make_shl_kernel(dtype, ptx_type, size):
+    @T.prim_func
+    def main(
+        values: T.Buffer((size,), dtype),
+        shifts: T.Buffer((size,), "uint32"),
+        output: T.Buffer((size,), dtype),
+    ):
+        T.device_entry()
+        tx = T.thread_id([32])
+        if tx < size:
+            output[tx] = T.ptx.shl(values[tx], shifts[tx], ptx_type=ptx_type)
+
+    return main
+
+
+@pytest.mark.parametrize(
+    ("ptx_type", "dtype", "_np_dtype", "_bits", "_c_type", "_constraint"), _SHL_CASES
+)
+def test_ptx_shl_return_dtype(ptx_type, dtype, _np_dtype, _bits, _c_type, _constraint):
+    value = tvm.tirx.Var("value", dtype)
+    shift = tvm.tirx.Var("shift", "uint32")
+    result = cuda_op.ptx_shl(value, shift, ptx_type)
+
+    assert result.op.name == "tirx.ptx.shl"
+    assert result.ty == PrimType(dtype)
+
+
+def test_ptx_shl_rejects_invalid_type():
+    with pytest.raises(ValueError, match="invalid ptx_type='u32'"):
+        cuda_op.ptx_shl(tvm.tirx.const(1, "uint32"), tvm.tirx.const(1, "uint32"), "u32")
+
+
+def test_ptx_shl_tvmscript_round_trip():
+    @T.prim_func
+    def main(
+        a16: T.Buffer((2,), "uint16"),
+        a32: T.Buffer((2,), "uint32"),
+        a64: T.Buffer((2,), "uint64"),
+        shift: T.Buffer((2,), "uint32"),
+    ):
+        a16[1] = T.ptx.shl(a16[1], shift[1], ptx_type="b16")
+        a32[1] = T.ptx.shl(a32[1], shift[1], ptx_type="b32")
+        a64[1] = T.ptx.shl(a64[1], shift[1], ptx_type="b64")
+
+    script = main.script()
+    reparsed = tvm.script.from_source(script)
+
+    assert 'T.ptx.shl(a16[1], shift[1], "b16")' in script
+    assert 'T.ptx.shl(a32[1], shift[1], "b32")' in script
+    assert 'T.ptx.shl(a64[1], shift[1], "b64")' in script
+    assert reparsed.script() == script
+    assert_structural_equal(main, reparsed)
+
+
+@pytest.mark.parametrize(
+    ("ptx_type", "dtype", "_np_dtype", "_bits", "c_type", "constraint"), _SHL_CASES
+)
+def test_ptx_shl_cuda_source(ptx_type, dtype, _np_dtype, _bits, c_type, constraint):
+    src, _ = _get_source(_make_shl_kernel(dtype, ptx_type, 1))
+    helper_name = f"tvm_builtin_ptx_shl_{ptx_type}"
+
+    assert f"__forceinline__ __device__ {c_type} {helper_name}({c_type} a, unsigned int b)" in src
+    assert (
+        f'asm("shl.{ptx_type} %0, %1, %2;"'
+        f' : "={constraint}"(ret) : "{constraint}"(a), "r"(b));' in src
+    )
+    assert "asm volatile" not in src
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+@pytest.mark.parametrize(
+    ("ptx_type", "dtype", "np_dtype", "bits", "_c_type", "_constraint"), _SHL_CASES
+)
+def test_ptx_shl_runtime_semantics(ptx_type, dtype, np_dtype, bits, _c_type, _constraint):
+    shifts = np.array([0, 1, bits - 1, bits, bits + 1, 255], dtype=np.uint32)
+    values = np.full(shifts.shape, (1 << bits) - 1, dtype=np_dtype)
+    mask = (1 << bits) - 1
+    expected = np.array(
+        [
+            (int(value) << int(shift)) & mask if shift < bits else 0
+            for value, shift in zip(values, shifts)
+        ],
+        dtype=np_dtype,
+    )
+    _, mod = _get_source(_make_shl_kernel(dtype, ptx_type, len(shifts)))
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        values_nd = tvm.runtime.tensor(values, device=dev)
+        shifts_nd = tvm.runtime.tensor(shifts, device=dev)
+        output_nd = tvm.runtime.tensor(np.zeros_like(values), device=dev)
+        mod(values_nd, shifts_nd, output_nd)
+        np.testing.assert_array_equal(output_nd.numpy(), expected)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)


### PR DESCRIPTION
## Summary

- add `T.ptx.shl(a, b, ptx_type)` for `b16`, `b32`, and `b64`
- lower the intrinsic to native PTX `shl` with width-appropriate register constraints
- add dtype validation, TVMScript round-trip, CUDA source, and runtime semantics coverage

## Motivation

This lets TIRx kernels preserve PTX clamp-to-zero semantics for out-of-range shift amounts without kernel-local inline CUDA helpers. The FA4 causal-mask migration in tirx-kernels depends on this API.

## Validation

Dedicated tests cover return dtypes, invalid PTX types, TVMScript round-tripping, generated CUDA constraints, and GPU shift semantics.