### PR TITLE
refactor(op): rename the PTX dialect namespace from ptxd to ptx

### DIFF
--- a/docs/tirx/layout.rst
+++ b/docs/tirx/layout.rst
@@ -309,7 +309,7 @@ fragment API:
 
     frag = T.alloc_tcgen05_ldst_frag("32x32b", (64, N), "float32")
     Tx.wg.copy_async(frag[:, :], paired_accumulator[:, :])
-    T.ptx.tcgen05.wait.ld()
+    T.ptx.tcgen05.wait__ld.sync.aligned()
 
 The logical ``(64, N)`` fragment is one physical ``.32x32b`` transfer over
 all 128 lanes; each thread owns ``N/2`` contiguous fp32 registers.

--- a/docs/tirx/layout.rst
+++ b/docs/tirx/layout.rst
@@ -309,7 +309,7 @@ fragment API:
 
     frag = T.alloc_tcgen05_ldst_frag("32x32b", (64, N), "float32")
     Tx.wg.copy_async(frag[:, :], paired_accumulator[:, :])
-    T.ptxd.tcgen05.wait.ld()
+    T.ptx.tcgen05.wait.ld()
 
 The logical ``(64, N)`` fragment is one physical ``.32x32b`` transfer over
 all 128 lanes; each thread owns ``N/2`` contiguous fp32 registers.

--- a/docs/tirx/native_basics.rst
+++ b/docs/tirx/native_basics.rst
@@ -21,7 +21,7 @@ TIRx Basics: CUDA C++/PTX native level
 .. note::
 
    Native-level kernel authoring for the **CUDA backend** (the ``"cuda"``
-   target): the thread hierarchy, memory scopes, the ``T.cuda.*`` / ``T.ptxd.*``
+   target): the thread hierarchy, memory scopes, the ``T.cuda.*`` / ``T.ptx.*``
    intrinsics, and the compile / run / inspect loop. The complete kernels in
    these chapters (``scale``, ``add``, ``smem_demo``, ``block_sum``, and the
    warp all-reduce) are tested end-to-end on a CUDA GPU.

--- a/docs/tirx/native_basics/cuda/buffers.rst
+++ b/docs/tirx/native_basics/cuda/buffers.rst
@@ -371,13 +371,15 @@ tensor as a view at a column offset, and one warp frees it at the end:
 
     addr = T.alloc_shared((1,), "uint32")             # slot for the allocated base
     if warp_id == alloc_warp:                         # tcgen05.alloc is warp-uniform
-        T.ptx.tcgen05.alloc(T.address_of(addr), n_cols=512, cta_group=cta_group)
+        T.ptx[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
+            T.address_of(addr), T.uint32(512))
     acc = T.decl_buffer((CTA_M, 512), "float32", scope="tmem",
                         allocated_addr=0, layout=tmem_layout)   # view at column 0
     # ... use acc as a gemm_async / copy_async operand ...
     if warp_id == alloc_warp:
-        T.ptx.tcgen05.relinquish_alloc_permit(cta_group=cta_group)
-        T.ptx.tcgen05.dealloc(addr, n_cols=512, cta_group=cta_group)
+        T.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
+        T.ptx[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
+            addr, T.uint32(512))
 
 You manage the column offsets and the ``tmem_layout`` (a datapath D/F/B layout)
 yourself. This is exactly the sequence the pool below emits.

--- a/docs/tirx/native_basics/cuda/buffers.rst
+++ b/docs/tirx/native_basics/cuda/buffers.rst
@@ -356,7 +356,7 @@ Tensor memory
 -------------
 
 Blackwell *tensor memory* is not a plain scratch scope: it must be explicitly
-reserved and freed with the warp-uniform ``T.ptxd.tcgen05.alloc`` /
+reserved and freed with the warp-uniform ``T.ptx.tcgen05.alloc`` /
 ``tcgen05.dealloc`` intrinsics, and each tensor is a view into it declared with
 ``T.decl_buffer(..., scope="tmem", allocated_addr=<column>, layout=<tmem layout>)``.
 The ``allocated_addr`` (a column offset) is mandatory — the tensor-core dispatch
@@ -371,13 +371,13 @@ tensor as a view at a column offset, and one warp frees it at the end:
 
     addr = T.alloc_shared((1,), "uint32")             # slot for the allocated base
     if warp_id == alloc_warp:                         # tcgen05.alloc is warp-uniform
-        T.ptxd.tcgen05.alloc(T.address_of(addr), n_cols=512, cta_group=cta_group)
+        T.ptx.tcgen05.alloc(T.address_of(addr), n_cols=512, cta_group=cta_group)
     acc = T.decl_buffer((CTA_M, 512), "float32", scope="tmem",
                         allocated_addr=0, layout=tmem_layout)   # view at column 0
     # ... use acc as a gemm_async / copy_async operand ...
     if warp_id == alloc_warp:
-        T.ptxd.tcgen05.relinquish_alloc_permit(cta_group=cta_group)
-        T.ptxd.tcgen05.dealloc(addr, n_cols=512, cta_group=cta_group)
+        T.ptx.tcgen05.relinquish_alloc_permit(cta_group=cta_group)
+        T.ptx.tcgen05.dealloc(addr, n_cols=512, cta_group=cta_group)
 
 You manage the column offsets and the ``tmem_layout`` (a datapath D/F/B layout)
 yourself. This is exactly the sequence the pool below emits.

--- a/docs/tirx/native_basics/cuda/compiling.rst
+++ b/docs/tirx/native_basics/cuda/compiling.rst
@@ -63,7 +63,7 @@ A natural native progression, each rung adding one capability:
 #. **Warp / block reduction** — ``T.tvm_warp_shuffle_xor`` or ``T.cuda.cta_sum``
    to combine partial results across lanes/warps (the warp all-reduce in
    :doc:`threads_sync`).
-#. **Async pipeline** — ``T.ptx.cp_async`` (or TMA ``cp_async.bulk.tensor``) with
+#. **Async pipeline** — ``T.ptx.cp.async_`` (or TMA ``cp.async.bulk.tensor``) with
    ``T.ptx.mbarrier.*`` / ``T.cuda.mbarrier_wait`` to overlap loads with compute.
 
 Rung 2 in full — a 256-element block sum via a shared-memory tree reduction

--- a/docs/tirx/native_basics/cuda/compiling.rst
+++ b/docs/tirx/native_basics/cuda/compiling.rst
@@ -63,8 +63,8 @@ A natural native progression, each rung adding one capability:
 #. **Warp / block reduction** — ``T.tvm_warp_shuffle_xor`` or ``T.cuda.cta_sum``
    to combine partial results across lanes/warps (the warp all-reduce in
    :doc:`threads_sync`).
-#. **Async pipeline** — ``T.ptxd.cp_async`` (or TMA ``cp_async.bulk.tensor``) with
-   ``T.ptxd.mbarrier.*`` / ``T.cuda.mbarrier_wait`` to overlap loads with compute.
+#. **Async pipeline** — ``T.ptx.cp_async`` (or TMA ``cp_async.bulk.tensor``) with
+   ``T.ptx.mbarrier.*`` / ``T.cuda.mbarrier_wait`` to overlap loads with compute.
 
 Rung 2 in full — a 256-element block sum via a shared-memory tree reduction
 (shared buffer, ``cta_sync``, a ``while`` loop, and a thread predicate):

--- a/docs/tirx/native_basics/cuda/data_types.rst
+++ b/docs/tirx/native_basics/cuda/data_types.rst
@@ -102,7 +102,7 @@ A buffer's ``data`` — its pointer — is a ``Var`` of pointer type, and it is
 - ``T.alloc_buffer(...)`` allocates storage **and** defines its ``data`` pointer.
 - ``T.decl_buffer(..., data=ptr)`` declares a buffer over an existing pointer
   ``Var`` ``ptr``.
-- To back a buffer with a pointer **expression** — e.g. ``T.ptxd.mapa`` giving
+- To back a buffer with a pointer **expression** — e.g. ``T.ptx.mapa`` giving
   another cluster CTA's shared address — convert the ``uint64`` address the
   instruction wrote to a pointer with the intended element type and storage
   scope.  Assigning that pointer expression to an unannotated name
@@ -114,7 +114,7 @@ A buffer's ``data`` — its pointer — is a ``Var`` of pointer type, and it is
       from tvm.ir.type import PointerType, PrimType
 
       mapped = T.alloc_local([1], "uint64")
-      T.ptxd.mapa.u64(mapped[0], mbar.ptr_to([0]), T.uint32(0))
+      T.ptx.mapa.u64(mapped[0], mbar.ptr_to([0]), T.uint32(0))
       ptr_ty = PointerType(PrimType("uint64"), "shared")
       ptr = T.reinterpret(ptr_ty, mapped[0])
       remote_mbar = T.decl_buffer([1], "uint64", data=ptr, scope="shared")

--- a/docs/tirx/native_basics/cuda/threads_sync.rst
+++ b/docs/tirx/native_basics/cuda/threads_sync.rst
@@ -62,7 +62,7 @@ The shuffle lowers straight to ``__shfl_xor_sync``:
 
     v_ptr[0] = v_ptr[0] + __shfl_xor_sync(0xFFFFFFFF, v_ptr[0], i_ptr[0], 32);
 
-Other families under ``T.ptx.*`` / ``T.cuda.*``: ``cp_async`` (LDGSTS),
+Other families under ``T.ptx.*`` / ``T.cuda.*``: ``cp.async`` (LDGSTS),
 ``cp_async.bulk.tensor`` (TMA), ``ldmatrix`` / ``stmatrix``, ``tcgen05.*``
 (Blackwell MMA), ``atomic_add``, ``fence`` … See :doc:`../../api/backend` for the
 full ``tvm.backend.cuda`` reference.

--- a/docs/tirx/native_basics/cuda/threads_sync.rst
+++ b/docs/tirx/native_basics/cuda/threads_sync.rst
@@ -19,13 +19,13 @@ CUDA C++/PTX intrinsics
 =======================
 
 When no tile primitive covers what you need, two escape hatches reach the hardware
-directly: **call a backend intrinsic** (the ``T.cuda.*`` / ``T.ptxd.*`` namespaces
+directly: **call a backend intrinsic** (the ``T.cuda.*`` / ``T.ptx.*`` namespaces
 from ``tvm.backend.cuda``), or **inline raw CUDA** source.
 
 Calling backend intrinsics
 --------------------------
 
-``T.cuda.*`` and ``T.ptxd.*`` expose the CUDA backend's device intrinsics directly —
+``T.cuda.*`` and ``T.ptx.*`` expose the CUDA backend's device intrinsics directly —
 synchronization, mbarriers, reductions, and the PTX data-movement / MMA families:
 
 .. code-block:: python
@@ -36,7 +36,7 @@ synchronization, mbarriers, reductions, and the PTX data-movement / MMA families
     T.cuda.cta_sum(val, num_warps, scratch.ptr_to([0]))   # block-level reduction
 
     bar = T.alloc_shared((1,), "uint64")
-    T.ptxd.mbarrier.init.shared.b64(bar.data, T.uint32(1))  # mbarrier for async completion
+    T.ptx.mbarrier.init.shared.b64(bar.data, T.uint32(1))  # mbarrier for async completion
     T.cuda.mbarrier_wait(bar.data, phase)
 
 A complete, runnable example — a warp all-reduce via ``T.tvm_warp_shuffle_xor``:
@@ -62,7 +62,7 @@ The shuffle lowers straight to ``__shfl_xor_sync``:
 
     v_ptr[0] = v_ptr[0] + __shfl_xor_sync(0xFFFFFFFF, v_ptr[0], i_ptr[0], 32);
 
-Other families under ``T.ptxd.*`` / ``T.cuda.*``: ``cp_async`` (LDGSTS),
+Other families under ``T.ptx.*`` / ``T.cuda.*``: ``cp_async`` (LDGSTS),
 ``cp_async.bulk.tensor`` (TMA), ``ldmatrix`` / ``stmatrix``, ``tcgen05.*``
 (Blackwell MMA), ``atomic_add``, ``fence`` … See :doc:`../../api/backend` for the
 full ``tvm.backend.cuda`` reference.

--- a/docs/tirx/tile_primitives/copy/ldstmatrix.rst
+++ b/docs/tirx/tile_primitives/copy/ldstmatrix.rst
@@ -152,10 +152,11 @@ handles:
     for mm in T.unroll(m_outer):
         smem_ptr = _ptr_off(s_buf.ptr_to(s_zero), _smem_off(mm, tile_off + (laneid % 8) * p))
         handles  = [r_local.ptr_to([...]) for i in range(num)]
+        chain = f"{direction}matrix.sync.aligned.m8n8.x{num}{trans_seg}.shared.b16"
         if direction == "ld":
-            T.ptx.ldmatrix(trans, num, ".b16", smem_ptr, *handles)
+            T.ptx[chain](*words, smem_ptr)
         else:
-            T.ptx.stmatrix(trans, num, ".b16", smem_ptr, *handles, shape="m8n8", space="shared")
+            T.ptx[chain](smem_ptr, *words)   # stmatrix takes the address first
 
 (This is the one copy variant that **does** use ``T.unroll`` — ``m_outer`` is tiny.)
 
@@ -167,21 +168,22 @@ For the demo (``num = 2``, ``M = 8`` ⇒ ``m_outer = 1``):
 .. code-block:: python
 
     for mm in T.unroll(1):
-        T.ptx.ldmatrix(T.bool(False), 2, ".b16", smem_ptr,
-                       T.address_of(r_local[0]), T.address_of(r_local[2]))
+        T.ptx["ldmatrix.sync.aligned.m8n8.x2.shared.b16"](
+            r_local[0], r_local[2], smem_ptr)
 
 Generated CUDA
 --------------
 
 .. code-block:: c++
 
-    __forceinline__ __device__ void ptx_ldmatrix_2_b16_0(void* smem_ptr, void* dst0, void* dst1) {
-      // ...
-      "ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];"
-      // ...
+    __forceinline__ __device__ void tvm_builtin_ptx_ldmatrix_sync_aligned_m8n8_x2_shared_b16(
+        uint32_t& __d0, uint32_t& __d1, uint32_t __a) {
+      asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];"
+                   : "=r"(__d0), "=r"(__d1) : "r"(__a));
     }
     // call site (per lane):
-    ptx_ldmatrix_2_b16_0(smem_ptr, &r_local_ptr[0], &r_local_ptr[2]);
+    tvm_builtin_ptx_ldmatrix_sync_aligned_m8n8_x2_shared_b16(
+        r_local_ptr[0], r_local_ptr[2], smem_addr);
 
 ``num = 2`` becomes ``.x2`` with two destination registers; the warp's 32 lanes
 cooperatively supply the 8 source rows and receive the shuffled fragment.

--- a/docs/tirx/tile_primitives/copy/ldstmatrix.rst
+++ b/docs/tirx/tile_primitives/copy/ldstmatrix.rst
@@ -153,9 +153,9 @@ handles:
         smem_ptr = _ptr_off(s_buf.ptr_to(s_zero), _smem_off(mm, tile_off + (laneid % 8) * p))
         handles  = [r_local.ptr_to([...]) for i in range(num)]
         if direction == "ld":
-            T.ptxd.ldmatrix(trans, num, ".b16", smem_ptr, *handles)
+            T.ptx.ldmatrix(trans, num, ".b16", smem_ptr, *handles)
         else:
-            T.ptxd.stmatrix(trans, num, ".b16", smem_ptr, *handles, shape="m8n8", space="shared")
+            T.ptx.stmatrix(trans, num, ".b16", smem_ptr, *handles, shape="m8n8", space="shared")
 
 (This is the one copy variant that **does** use ``T.unroll`` — ``m_outer`` is tiny.)
 
@@ -167,7 +167,7 @@ For the demo (``num = 2``, ``M = 8`` ⇒ ``m_outer = 1``):
 .. code-block:: python
 
     for mm in T.unroll(1):
-        T.ptxd.ldmatrix(T.bool(False), 2, ".b16", smem_ptr,
+        T.ptx.ldmatrix(T.bool(False), 2, ".b16", smem_ptr,
                        T.address_of(r_local[0]), T.address_of(r_local[2]))
 
 Generated CUDA

--- a/docs/tirx/tile_primitives/copy_async/dsmem.rst
+++ b/docs/tirx/tile_primitives/copy_async/dsmem.rst
@@ -91,15 +91,15 @@ mbarrier and writes the result out (from ``test_dsmem.py``):
         dst_smem = T.decl_buffer(list(shape), dtype, pool.alloc([8192], dtype, align=128).data,
                                  elem_offset=0, scope="shared.dyn", layout=dst_layout)
         mbar = MBarrier(pool, 1); pool.commit()
-        mbar.init(1); T.ptxd.fence.mbarrier_init.release.cluster(); T.cuda.cluster_sync()
+        mbar.init(1); T.ptx.fence.mbarrier_init.release.cluster(); T.cuda.cluster_sync()
         if tid == 0:
             if cbx == 0:                                      # source CTA
                 Tx.copy(src_smem[r], A[r])                    # global -> local shared
-                T.ptxd.fence.proxy.async_.shared__cta()
+                T.ptx.fence.proxy.async_.shared__cta()
                 Tx.copy_async(dst_smem[r], src_smem[r], dispatch="dsmem",
                               mbar=mbar.ptr_to([0]), remote_cta_id=T.int32(1))   # -> CTA 1
             else:                                             # destination CTA
-                T.ptxd.mbarrier.arrive.expect_tx.shared.b64(mbar.ptr_to([0]), T.uint32(copy_bytes))
+                T.ptx.mbarrier.arrive.expect_tx.shared.b64(mbar.ptr_to([0]), T.uint32(copy_bytes))
                 mbar.wait(0, 0)
                 Tx.copy(B[r], dst_smem[r])                    # remote shared -> global
         T.cuda.cluster_sync()
@@ -118,7 +118,7 @@ and a multiple of 16 (a ``cp.async.bulk`` constraint), else it declines:
     if chunk_bytes < 16 or chunk_bytes % 16 != 0:
         fail(...)
 
-**2. Map the remote address.** ``T.ptxd.mapa.u64`` translates a local shared
+**2. Map the remote address.** ``T.ptx.mapa.u64`` translates a local shared
 pointer into the destination CTA's window — applied to both the destination
 buffer pointer and the mbarrier (``mapa`` writes into a declared register, so
 the mapped addresses live in a small local scratch buffer):
@@ -126,8 +126,8 @@ the mapped addresses live in a small local scratch buffer):
 .. code-block:: python
 
     mapped = T.alloc_local([2], "uint64")
-    T.ptxd.mapa.u64(mapped[0], mbar, T.uint32(remote_cta_id))                    # remote_mbar
-    T.ptxd.mapa.u64(mapped[1], dst_buf.ptr_to(dst_st), T.uint32(remote_cta_id))  # cluster_dst
+    T.ptx.mapa.u64(mapped[0], mbar, T.uint32(remote_cta_id))                    # remote_mbar
+    T.ptx.mapa.u64(mapped[1], dst_buf.ptr_to(dst_st), T.uint32(remote_cta_id))  # cluster_dst
 
 **3. Issue one bulk copy per chunk.** Fully contiguous → a single instruction; a
 strided region loops over the outer (non-contiguous) extents, re-deriving the
@@ -136,13 +136,13 @@ chunk's offsets each step:
 .. code-block:: python
 
     if not outer_extents:                                 # one contiguous chunk
-        T.ptxd["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
+        T.ptx["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
             T.cast(mapped[1], "uint32"), src_buf.ptr_to(src_st),
             T.cast(chunk_bytes, "uint32"), T.cast(mapped[0], "uint32"))
     else:
         for loop_vars in T.grid(*outer_extents):          # one chunk per outer coord
             ...  # re-decl src/dst views at the per-chunk offset
-            T.ptxd["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
+            T.ptx["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
                 T.cast(mapped[1], "uint32"), src_ptr,
                 T.cast(chunk_bytes, "uint32"), T.cast(mapped[0], "uint32"))
 
@@ -157,7 +157,7 @@ The fully contiguous ``128×64`` fp16 tile (``16384`` bytes) is a **single chunk
 
 .. code-block:: python
 
-    T.ptxd["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
+    T.ptx["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
         T.cast(mapped[1], "uint32"), src_ptr[0], T.uint32(16384), T.cast(mapped[0], "uint32"))
 
 Generated CUDA

--- a/docs/tirx/tile_primitives/copy_async/dsmem.rst
+++ b/docs/tirx/tile_primitives/copy_async/dsmem.rst
@@ -166,8 +166,8 @@ Generated CUDA
 .. code-block:: c++
 
     // map local shared addresses into CTA 1's window (mapa)
-    remote_mbar = tvm_builtin_ptx_mapa_u64(&mbar,     /*rank=*/1);   // asm: mapa.u64
-    cluster_dst = tvm_builtin_ptx_mapa_u64(&dst_smem, /*rank=*/1);
+    tvm_builtin_ptx_mapa_shared__cluster_u64(remote_mbar, &mbar,     /*rank=*/1);
+    tvm_builtin_ptx_mapa_shared__cluster_u64(cluster_dst, &dst_smem, /*rank=*/1);
     // bulk-copy 16384 bytes local shared -> CTA 1 shared, signalling its mbarrier
     "cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes ..."
 

--- a/docs/tirx/tile_primitives/copy_async/ldgsts.rst
+++ b/docs/tirx/tile_primitives/copy_async/ldgsts.rst
@@ -86,8 +86,8 @@ shared, then commits and waits before reading it back (from ``test_ldgsts.py``):
         T.device_entry(); T.cta_id([1]); T.warp_id([4]); T.lane_id([32]); tid = T.thread_id([128])
         A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
         Tx.cta.copy_async(A_smem[full], A[full], dispatch="ldgsts")   # async global -> shared
-        T.ptxd.cp_async.commit_group()                                # caller commits ...
-        T.ptxd.cp_async.wait_group()                                  # ... and waits
+        T.ptx.cp_async.commit_group()                                # caller commits ...
+        T.ptx.cp_async.wait_group()                                  # ... and waits
         T.cuda.cta_sync()
         Tx.cta.copy(B[full], A_smem[full])
 

--- a/docs/tirx/tile_primitives/copy_async/ldgsts.rst
+++ b/docs/tirx/tile_primitives/copy_async/ldgsts.rst
@@ -86,8 +86,8 @@ shared, then commits and waits before reading it back (from ``test_ldgsts.py``):
         T.device_entry(); T.cta_id([1]); T.warp_id([4]); T.lane_id([32]); tid = T.thread_id([128])
         A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
         Tx.cta.copy_async(A_smem[full], A[full], dispatch="ldgsts")   # async global -> shared
-        T.ptx.cp_async.commit_group()                                # caller commits ...
-        T.ptx.cp_async.wait_group()                                  # ... and waits
+        T.ptx.cp.async_.commit_group()                               # caller commits ...
+        T.ptx.cp.async_.wait_group(0)                                # ... and waits
         T.cuda.cta_sync()
         Tx.cta.copy(B[full], A_smem[full])
 
@@ -131,10 +131,10 @@ Generated CUDA
 .. code-block:: c++
 
     // cp.async.cg copies 16 bytes shared <- global, asynchronously
-    tvm_builtin_ptx_cp_async_cg_16(s_ptr, g_ptr, /*cache_policy=*/0);   // x4 (outer = 4)
+    tvm_builtin_ptx_cp_async_cg_async_cg_shared_global_16(s_ptr, g_ptr);   // x4 (outer = 4)
     // ...
-    tvm_builtin_ptx_cp_async_commit_group();    // asm: cp.async.commit_group;
-    tvm_builtin_ptx_cp_async_wait_group_0();    // asm: cp.async.wait_group 0;
+    tvm_builtin_ptx_cp_async_commit_group_async_commit_group();  // asm: cp.async.commit_group;
+    tvm_builtin_ptx_cp_async_wait_group_async_wait_group_0();    // asm: cp.async.wait_group 0;
 
 where the helper is ``asm volatile("cp.async.cg.shared.global [%0], [%1], 16;")``.
 Each thread issues 4 asynchronous 16-byte copies; nothing blocks until the caller's

--- a/docs/tirx/tile_primitives/copy_async/tcgen05_cp.rst
+++ b/docs/tirx/tile_primitives/copy_async/tcgen05_cp.rst
@@ -124,13 +124,16 @@ dealloc tail elided):
     tmem_addr = T.alloc_shared([1], "uint32")
     cp_mbar   = T.alloc_shared([1], "uint64")
     if warp_id == 0:
-        T.ptx.tcgen05.alloc(T.address_of(tmem_addr), n_cols=16, cta_group=1)
+        T.ptx["tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"](
+            T.address_of(tmem_addr), T.uint32(16))
     # ... mbarrier.init, fence, cta_sync, fill A_smem from global ...
     tmem = T.decl_buffer([32, 16], "uint8", scope="tmem", allocated_addr=tmem_addr[0],
                          layout=TileLayout(S[(32, 16) : (1 @ TLane, 1 @ TCol)] + R[4 : 32 @ TLane]))
     if tid_in_wg == 0:
         Tx.copy_async(tmem[0:32, 0:16], A_smem[0:32, 0:16], cta_group=1)   # smem -> tmem
-        T.ptx.tcgen05.commit(cp_mbar.ptr_to([0]), cta_group=1)             # caller signals
+        # caller signals
+        T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
+            cp_mbar.ptr_to([0]))
     T.cuda.mbarrier_wait(cp_mbar.ptr_to([0]), 0)
     # ... readback via tcgen05.ld, then tcgen05.dealloc ...
 
@@ -162,9 +165,9 @@ bits, plus the lane half-word for lane-tiled atoms):
 
     for flat in T.unroll(total):
         t_off, s_off = T.meta_var(compute_offsets(flat))
-        T.ptx.tcgen05.cp(t_addr[0] + t_addr_off + t_off,
-                         smem_desc_add_16B_offset(desc_buf[0], init_off_16B + s_off),
-                         shape=shape, cta_group=cta_group, multicast=multicast)
+        T.ptx[f"tcgen05.cp.cta_group::{cta_group}.{shape}{multicast_seg}"](
+            T.cast(t_addr[0] + t_addr_off + t_off, "uint32"),
+            smem_desc_add_16B_offset(desc_buf[0], init_off_16B + s_off))
 
 The dispatch emits **no** ``tcgen05.commit`` / ``wait`` — the caller commits
 against an mbarrier (as in the demo).

--- a/docs/tirx/tile_primitives/copy_async/tcgen05_cp.rst
+++ b/docs/tirx/tile_primitives/copy_async/tcgen05_cp.rst
@@ -124,13 +124,13 @@ dealloc tail elided):
     tmem_addr = T.alloc_shared([1], "uint32")
     cp_mbar   = T.alloc_shared([1], "uint64")
     if warp_id == 0:
-        T.ptxd.tcgen05.alloc(T.address_of(tmem_addr), n_cols=16, cta_group=1)
+        T.ptx.tcgen05.alloc(T.address_of(tmem_addr), n_cols=16, cta_group=1)
     # ... mbarrier.init, fence, cta_sync, fill A_smem from global ...
     tmem = T.decl_buffer([32, 16], "uint8", scope="tmem", allocated_addr=tmem_addr[0],
                          layout=TileLayout(S[(32, 16) : (1 @ TLane, 1 @ TCol)] + R[4 : 32 @ TLane]))
     if tid_in_wg == 0:
         Tx.copy_async(tmem[0:32, 0:16], A_smem[0:32, 0:16], cta_group=1)   # smem -> tmem
-        T.ptxd.tcgen05.commit(cp_mbar.ptr_to([0]), cta_group=1)             # caller signals
+        T.ptx.tcgen05.commit(cp_mbar.ptr_to([0]), cta_group=1)             # caller signals
     T.cuda.mbarrier_wait(cp_mbar.ptr_to([0]), 0)
     # ... readback via tcgen05.ld, then tcgen05.dealloc ...
 
@@ -162,7 +162,7 @@ bits, plus the lane half-word for lane-tiled atoms):
 
     for flat in T.unroll(total):
         t_off, s_off = T.meta_var(compute_offsets(flat))
-        T.ptxd.tcgen05.cp(t_addr[0] + t_addr_off + t_off,
+        T.ptx.tcgen05.cp(t_addr[0] + t_addr_off + t_off,
                          smem_desc_add_16B_offset(desc_buf[0], init_off_16B + s_off),
                          shape=shape, cta_group=cta_group, multicast=multicast)
 

--- a/docs/tirx/tile_primitives/copy_async/tcgen05_ldst.rst
+++ b/docs/tirx/tile_primitives/copy_async/tcgen05_ldst.rst
@@ -88,7 +88,8 @@ fp16):
         tmem_addr = T.alloc_shared([1], "uint32")
         if wg_id == 0:
             if warp_id == 0:
-                T.ptx.tcgen05.alloc(T.address_of(tmem_addr), n_cols=32, cta_group=1)
+                T.ptx["tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"](
+                    T.address_of(tmem_addr), T.uint32(32))
             T.tvm_storage_sync("shared")
             tmem = T.decl_buffer((128, WIDTH), "float16", scope="tmem", allocated_addr=tmem_addr[0],
                                  layout=TileLayout(S[(128, WIDTH) : (1 @ TLane, 1 @ TCol)]))
@@ -96,9 +97,9 @@ fp16):
             A_local = A_reg.view(128, WIDTH, layout=local_view)
             B_local = B_reg.view(128, WIDTH, layout=local_view)
             # ... load A into A_reg, zero B_reg, cta_sync ...
-            Tx.wg.copy_async(tmem[:, :], A_local[:, :]); T.ptx.tcgen05.wait.st()   # store (local -> tmem)
+            Tx.wg.copy_async(tmem[:, :], A_local[:, :]); T.ptx.tcgen05.wait__st.sync.aligned()   # store (local -> tmem)
             T.cuda.cta_sync()
-            Tx.wg.copy_async(B_local[:, :], tmem[:, :]); T.ptx.tcgen05.wait.ld()   # load  (tmem -> local)
+            Tx.wg.copy_async(B_local[:, :], tmem[:, :]); T.ptx.tcgen05.wait__ld.sync.aligned()   # load  (tmem -> local)
             # ... write B_reg out; tcgen05.dealloc ...
 
 Algorithm
@@ -121,7 +122,7 @@ fragment spans two 16-row slabs, so the warps issue the atom twice
 
 .. code-block:: python
 
-    op = T.ptx.tcgen05.ld if load else T.ptx.tcgen05.st
+    chain = f"tcgen05.{'ld' if load else 'st'}.sync.aligned.{shape}.x{num}.b32"
     classified = _check_tmem_layout_for_atom(tmem_buf, "16x*b", frag_rows)
     datapath, sub_slab = classified if classified is not None else (None, 0)
     for slab in range(n_slabs):                 # 1 for M=64; 2 for M=128
@@ -164,9 +165,9 @@ Selecting the upper F sub-slab
     )
 
     Tx.wg.copy_async(lower_frag, lower)
-    T.ptx.tcgen05.wait.ld()
+    T.ptx.tcgen05.wait__ld.sync.aligned()
     Tx.wg.copy_async(upper_frag, upper)
-    T.ptx.tcgen05.wait.ld()
+    T.ptx.tcgen05.wait__ld.sync.aligned()
 
 The lower view emits ``row=0`` and the upper view emits ``row=16`` for
 ``.16x64b``, ``.16x128b``, and ``.16x256b`` atoms. Layout D has 128 rows and
@@ -189,11 +190,11 @@ Use the public allocation and fragment APIs together:
     frag = T.alloc_tcgen05_ldst_frag("32x32b", (64, N), "float32")
 
     Tx.wg.copy_async(frag[:, :], accumulator[:, :])
-    T.ptx.tcgen05.wait.ld()
+    T.ptx.tcgen05.wait__ld.sync.aligned()
 
     # The inverse direction emits tcgen05.st with the same physical image.
     Tx.wg.copy_async(accumulator[:, :], frag[:, :])
-    T.ptx.tcgen05.wait.st()
+    T.ptx.tcgen05.wait__st.sync.aligned()
 
 This is a single ``tcgen05.{ld,st}.32x32b.x{N/2}`` issue. ``N`` must be
 even, ``N/2`` must be a valid PTX ``num``, and the fragment is fp32-only.
@@ -210,10 +211,11 @@ For the ``128×8`` fp16 tile the layout takes the ``.32x32b`` path with ``num = 
 
 .. code-block:: python
 
-    T.ptx.tcgen05.st(tmem_addr[0], 0, 0, "32x32b", 4, False, local_32b[0], local_32b[1],
-                     local_32b[2], local_32b[3])     # local -> tmem
-    T.ptx.tcgen05.ld(tmem_addr[0], 0, 0, "32x32b", 4, False, local_32b_1[0], local_32b_1[1],
-                     local_32b_1[2], local_32b_1[3]) # tmem -> local
+    T.ptx["tcgen05.st.sync.aligned.32x32b.x4.b32"](         # local -> tmem
+        T.uint32(tmem_addr[0]), local_32b[0], local_32b[1], local_32b[2], local_32b[3])
+    T.ptx["tcgen05.ld.sync.aligned.32x32b.x4.b32"](         # tmem -> local
+        local_32b_1[0], local_32b_1[1], local_32b_1[2], local_32b_1[3],
+        T.uint32(tmem_addr[0]))
 
 Generated CUDA
 --------------

--- a/docs/tirx/tile_primitives/copy_async/tcgen05_ldst.rst
+++ b/docs/tirx/tile_primitives/copy_async/tcgen05_ldst.rst
@@ -88,7 +88,7 @@ fp16):
         tmem_addr = T.alloc_shared([1], "uint32")
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc(T.address_of(tmem_addr), n_cols=32, cta_group=1)
+                T.ptx.tcgen05.alloc(T.address_of(tmem_addr), n_cols=32, cta_group=1)
             T.tvm_storage_sync("shared")
             tmem = T.decl_buffer((128, WIDTH), "float16", scope="tmem", allocated_addr=tmem_addr[0],
                                  layout=TileLayout(S[(128, WIDTH) : (1 @ TLane, 1 @ TCol)]))
@@ -96,9 +96,9 @@ fp16):
             A_local = A_reg.view(128, WIDTH, layout=local_view)
             B_local = B_reg.view(128, WIDTH, layout=local_view)
             # ... load A into A_reg, zero B_reg, cta_sync ...
-            Tx.wg.copy_async(tmem[:, :], A_local[:, :]); T.ptxd.tcgen05.wait.st()   # store (local -> tmem)
+            Tx.wg.copy_async(tmem[:, :], A_local[:, :]); T.ptx.tcgen05.wait.st()   # store (local -> tmem)
             T.cuda.cta_sync()
-            Tx.wg.copy_async(B_local[:, :], tmem[:, :]); T.ptxd.tcgen05.wait.ld()   # load  (tmem -> local)
+            Tx.wg.copy_async(B_local[:, :], tmem[:, :]); T.ptx.tcgen05.wait.ld()   # load  (tmem -> local)
             # ... write B_reg out; tcgen05.dealloc ...
 
 Algorithm
@@ -121,7 +121,7 @@ fragment spans two 16-row slabs, so the warps issue the atom twice
 
 .. code-block:: python
 
-    op = T.ptxd.tcgen05.ld if load else T.ptxd.tcgen05.st
+    op = T.ptx.tcgen05.ld if load else T.ptx.tcgen05.st
     classified = _check_tmem_layout_for_atom(tmem_buf, "16x*b", frag_rows)
     datapath, sub_slab = classified if classified is not None else (None, 0)
     for slab in range(n_slabs):                 # 1 for M=64; 2 for M=128
@@ -164,9 +164,9 @@ Selecting the upper F sub-slab
     )
 
     Tx.wg.copy_async(lower_frag, lower)
-    T.ptxd.tcgen05.wait.ld()
+    T.ptx.tcgen05.wait.ld()
     Tx.wg.copy_async(upper_frag, upper)
-    T.ptxd.tcgen05.wait.ld()
+    T.ptx.tcgen05.wait.ld()
 
 The lower view emits ``row=0`` and the upper view emits ``row=16`` for
 ``.16x64b``, ``.16x128b``, and ``.16x256b`` atoms. Layout D has 128 rows and
@@ -189,11 +189,11 @@ Use the public allocation and fragment APIs together:
     frag = T.alloc_tcgen05_ldst_frag("32x32b", (64, N), "float32")
 
     Tx.wg.copy_async(frag[:, :], accumulator[:, :])
-    T.ptxd.tcgen05.wait.ld()
+    T.ptx.tcgen05.wait.ld()
 
     # The inverse direction emits tcgen05.st with the same physical image.
     Tx.wg.copy_async(accumulator[:, :], frag[:, :])
-    T.ptxd.tcgen05.wait.st()
+    T.ptx.tcgen05.wait.st()
 
 This is a single ``tcgen05.{ld,st}.32x32b.x{N/2}`` issue. ``N`` must be
 even, ``N/2`` must be a valid PTX ``num``, and the fragment is fp32-only.
@@ -210,9 +210,9 @@ For the ``128×8`` fp16 tile the layout takes the ``.32x32b`` path with ``num = 
 
 .. code-block:: python
 
-    T.ptxd.tcgen05.st(tmem_addr[0], 0, 0, "32x32b", 4, False, local_32b[0], local_32b[1],
+    T.ptx.tcgen05.st(tmem_addr[0], 0, 0, "32x32b", 4, False, local_32b[0], local_32b[1],
                      local_32b[2], local_32b[3])     # local -> tmem
-    T.ptxd.tcgen05.ld(tmem_addr[0], 0, 0, "32x32b", 4, False, local_32b_1[0], local_32b_1[1],
+    T.ptx.tcgen05.ld(tmem_addr[0], 0, 0, "32x32b", 4, False, local_32b_1[0], local_32b_1[1],
                      local_32b_1[2], local_32b_1[3]) # tmem -> local
 
 Generated CUDA

--- a/docs/tirx/tile_primitives/gemm.rst
+++ b/docs/tirx/tile_primitives/gemm.rst
@@ -125,8 +125,9 @@ accumulate over K in place, one ``mma`` per (m, n) tile:
                 d_ptrs = [d_local.ptr_to([m, n, rM, rN]) for rM in range(2) for rN in range(2)]  # 4 f32
                 a_ptrs = [a_local.ptr_to([m, k, rM, kHi, 0]) for kHi in range(n_kHi) for rM in range(2)]
                 b_ptrs = [b_local.ptr_to([k, n, kHi, 0]) for kHi in range(n_kHi)]
-                T.ptx.mma(shape_str, "row", "col", "float32", a_type, b_type, "float32",
-                          d_ptrs, a_ptrs, b_ptrs, d_ptrs)        # d = a·b + d
+                mma_chain = (f"mma.sync.aligned.{shape_str}.row.col"
+                             f".f32.{a_elem}.{b_elem}.f32")
+                T.ptx[mma_chain](*d_regs, *a_regs, *b_regs, *d_regs)   # d = a·b + d
 
 Generated TIRx IR
 -----------------
@@ -135,8 +136,8 @@ The single 16×8×16 tile lowers to one ``mma`` (4 D regs, 4 A regs, 2 B regs):
 
 .. code-block:: python
 
-    T.ptx.mma("m16n8k16", "row", "col", "float32", "float16", "float16", "float32",
-              4, 4, 2, 4, False, T.address_of(d_local[0]), ...)
+    T.ptx["mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32"](
+        d_local[0], d_local[1], d_local[2], d_local[3], a_local[0], ...)
 
 Generated CUDA
 --------------

--- a/docs/tirx/tile_primitives/gemm.rst
+++ b/docs/tirx/tile_primitives/gemm.rst
@@ -125,7 +125,7 @@ accumulate over K in place, one ``mma`` per (m, n) tile:
                 d_ptrs = [d_local.ptr_to([m, n, rM, rN]) for rM in range(2) for rN in range(2)]  # 4 f32
                 a_ptrs = [a_local.ptr_to([m, k, rM, kHi, 0]) for kHi in range(n_kHi) for rM in range(2)]
                 b_ptrs = [b_local.ptr_to([k, n, kHi, 0]) for kHi in range(n_kHi)]
-                T.ptxd.mma(shape_str, "row", "col", "float32", a_type, b_type, "float32",
+                T.ptx.mma(shape_str, "row", "col", "float32", a_type, b_type, "float32",
                           d_ptrs, a_ptrs, b_ptrs, d_ptrs)        # d = a·b + d
 
 Generated TIRx IR
@@ -135,7 +135,7 @@ The single 16×8×16 tile lowers to one ``mma`` (4 D regs, 4 A regs, 2 B regs):
 
 .. code-block:: python
 
-    T.ptxd.mma("m16n8k16", "row", "col", "float32", "float16", "float16", "float32",
+    T.ptx.mma("m16n8k16", "row", "col", "float32", "float16", "float16", "float32",
               4, 4, 2, 4, False, T.address_of(d_local[0]), ...)
 
 Generated CUDA

--- a/docs/tirx/tile_primitives/gemm_async.rst
+++ b/docs/tirx/tile_primitives/gemm_async.rst
@@ -87,14 +87,14 @@ into a tmem accumulator, after TMA-loading A/B into shared (from
     tmem_addr = T.alloc_shared([1], "uint32"); mma_mbar = T.alloc_shared([1], "uint64")
     # ... mbarrier.init, cta_sync ...
     if warp_id == 0:
-        T.ptxd.tcgen05.alloc(T.address_of(tmem_addr), n_cols=512, cta_group=1)
+        T.ptx.tcgen05.alloc(T.address_of(tmem_addr), n_cols=512, cta_group=1)
     T.cuda.cta_sync()
     tmem = T.decl_buffer((128, 512), "float32", scope="tmem", allocated_addr=tmem_addr[0],
                          layout=TileLayout(S[(128, 512) : (1 @ TLane, 1 @ TCol)]))
     # ... TMA-load A_smem, B_smem from global, wait ...
     if tid_in_wg == 0:
         Tx.gemm_async(tmem[0:128, 256:384], A_smem[1:2, :, :], B_smem[2:3, :, :], dispatch="tcgen05")
-        T.ptxd.tcgen05.commit(mma_mbar.ptr_to([0]), cta_group=1)   # caller signals completion
+        T.ptx.tcgen05.commit(mma_mbar.ptr_to([0]), cta_group=1)   # caller signals completion
     T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
     # ... tcgen05.fence.after_thread_sync(); read tmem back via tcgen05.ld; dealloc ...
 
@@ -128,7 +128,7 @@ the tmem accumulator (``enable_input_d`` turns accumulation on for ``ki > 0``):
 
 .. code-block:: python
 
-    T.ptxd.tcgen05.mma(
+    T.ptx.tcgen05.mma(
         "float32", A_type, B_type,
         T.cuda.get_tmem_addr(tmem_addr, mi * M_mma, tmem_col),       # C in tmem
         smem_desc_add_16B_offset(descA, a_off), descB_val, descI,    # A / B descriptors
@@ -136,7 +136,7 @@ the tmem accumulator (``enable_input_d`` turns accumulation on for ``ki > 0``):
         enable_input_d=(ki != 0),                                    # accumulate over K
     )
 
-For **block-scaled** fp8/fp4 the emit becomes ``T.ptxd.tcgen05.mma.block_scale(...)``
+For **block-scaled** fp8/fp4 the emit becomes ``T.ptx.tcgen05.mma.block_scale(...)``
 with two extra tmem addresses — ``SFA`` / ``SFB`` — and the scale-factor dtypes; the
 instruction descriptor is encoded at runtime. As with the other async ops, the
 dispatch emits **no** completion — the caller's ``tcgen05.commit`` + mbarrier wait
@@ -174,7 +174,7 @@ Allocate and read a Layout B result as follows:
 
     frag = T.alloc_tcgen05_ldst_frag("32x32b", (64, N), "float32")
     Tx.wg.copy_async(frag[:, :], accumulator[:, :])
-    T.ptxd.tcgen05.wait.ld()
+    T.ptx.tcgen05.wait.ld()
 
 The fragment is a logical ``(64, N)`` view of one physical
 ``.32x32b`` transfer over all 128 lanes. The gemm write-side layout and
@@ -190,7 +190,7 @@ For the ``128×64 × 64×128`` fp16 tile (swizzle mode 3):
 
     T.cuda.tcgen05.encode_matrix_descriptor(T.address_of(descA[0]), T.address_of(A_smem[0]), 64, 64, 3)
     T.cuda.tcgen05.encode_matrix_descriptor(T.address_of(descB[0]), T.address_of(B_smem[0]), 64, 64, 3)
-    T.ptxd.tcgen05.mma("float32", "float16", "float16",
+    T.ptx.tcgen05.mma("float32", "float16", "float16",
                       T.cuda.get_tmem_addr(tmem_addr[0], mi * 128, 256 + ni * 128), ...)
 
 Generated CUDA

--- a/docs/tirx/tile_primitives/gemm_async.rst
+++ b/docs/tirx/tile_primitives/gemm_async.rst
@@ -87,14 +87,17 @@ into a tmem accumulator, after TMA-loading A/B into shared (from
     tmem_addr = T.alloc_shared([1], "uint32"); mma_mbar = T.alloc_shared([1], "uint64")
     # ... mbarrier.init, cta_sync ...
     if warp_id == 0:
-        T.ptx.tcgen05.alloc(T.address_of(tmem_addr), n_cols=512, cta_group=1)
+        T.ptx["tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"](
+            T.address_of(tmem_addr), T.uint32(512))
     T.cuda.cta_sync()
     tmem = T.decl_buffer((128, 512), "float32", scope="tmem", allocated_addr=tmem_addr[0],
                          layout=TileLayout(S[(128, 512) : (1 @ TLane, 1 @ TCol)]))
     # ... TMA-load A_smem, B_smem from global, wait ...
     if tid_in_wg == 0:
         Tx.gemm_async(tmem[0:128, 256:384], A_smem[1:2, :, :], B_smem[2:3, :, :], dispatch="tcgen05")
-        T.ptx.tcgen05.commit(mma_mbar.ptr_to([0]), cta_group=1)   # caller signals completion
+        # caller signals completion
+        T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
+            mma_mbar.ptr_to([0]))
     T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
     # ... tcgen05.fence.after_thread_sync(); read tmem back via tcgen05.ld; dealloc ...
 
@@ -128,15 +131,15 @@ the tmem accumulator (``enable_input_d`` turns accumulation on for ``ki > 0``):
 
 .. code-block:: python
 
-    T.ptx.tcgen05.mma(
-        "float32", A_type, B_type,
-        T.cuda.get_tmem_addr(tmem_addr, mi * M_mma, tmem_col),       # C in tmem
+    mma_chain = f"tcgen05.mma.cta_group::{cta_group}.kind::{kind}"
+    T.ptx[mma_chain](
+        T.cast(T.cuda.get_tmem_addr(tmem_addr, mi * M_mma, tmem_col), "uint32"),  # C in tmem
         smem_desc_add_16B_offset(descA, a_off), descB_val, descI,    # A / B descriptors
-        use_a_tmem=a_is_tmem, cta_group=cta_group,
-        enable_input_d=(ki != 0),                                    # accumulate over K
+        *zero_masks,                                                 # disabled output lanes
+        ki != 0,                                                     # accumulate over K
     )
 
-For **block-scaled** fp8/fp4 the emit becomes ``T.ptx.tcgen05.mma.block_scale(...)``
+For **block-scaled** fp8/fp4 the chain gains ``.block_scale.scale_vec::<n>X``
 with two extra tmem addresses — ``SFA`` / ``SFB`` — and the scale-factor dtypes; the
 instruction descriptor is encoded at runtime. As with the other async ops, the
 dispatch emits **no** completion — the caller's ``tcgen05.commit`` + mbarrier wait
@@ -174,7 +177,7 @@ Allocate and read a Layout B result as follows:
 
     frag = T.alloc_tcgen05_ldst_frag("32x32b", (64, N), "float32")
     Tx.wg.copy_async(frag[:, :], accumulator[:, :])
-    T.ptx.tcgen05.wait.ld()
+    T.ptx.tcgen05.wait__ld.sync.aligned()
 
 The fragment is a logical ``(64, N)`` view of one physical
 ``.32x32b`` transfer over all 128 lanes. The gemm write-side layout and
@@ -190,8 +193,8 @@ For the ``128×64 × 64×128`` fp16 tile (swizzle mode 3):
 
     T.cuda.tcgen05.encode_matrix_descriptor(T.address_of(descA[0]), T.address_of(A_smem[0]), 64, 64, 3)
     T.cuda.tcgen05.encode_matrix_descriptor(T.address_of(descB[0]), T.address_of(B_smem[0]), 64, 64, 3)
-    T.ptx.tcgen05.mma("float32", "float16", "float16",
-                      T.cuda.get_tmem_addr(tmem_addr[0], mi * 128, 256 + ni * 128), ...)
+    T.ptx["tcgen05.mma.cta_group::1.kind::f16"](
+        T.cast(T.cuda.get_tmem_addr(tmem_addr[0], mi * 128, 256 + ni * 128), "uint32"), ...)
 
 Generated CUDA
 --------------

--- a/docs/tirx/tile_primitives/reduction/sm100_packed.rst
+++ b/docs/tirx/tile_primitives/reduction/sm100_packed.rst
@@ -88,16 +88,12 @@ the accumulator ``8 → 4 → 2 → 1`` with three more ``add.f32x2``:
 
 .. code-block:: python
 
-    # final tree (8 -> 4 -> 2 -> 1)
-    T.ptx.add_f32x2(T.address_of(local_sum[0]),
-                    T.cuda.make_float2(local_sum[0], local_sum[1]),
-                    T.cuda.make_float2(local_sum[2], local_sum[3]), ftz=True)
-    T.ptx.add_f32x2(T.address_of(local_sum[4]),
-                    T.cuda.make_float2(local_sum[4], local_sum[5]),
-                    T.cuda.make_float2(local_sum[6], local_sum[7]), ftz=True)
-    T.ptx.add_f32x2(T.address_of(local_sum[0]),
-                    T.cuda.make_float2(local_sum[0], local_sum[1]),
-                    T.cuda.make_float2(local_sum[4], local_sum[5]), ftz=True)
+    # final tree (8 -> 4 -> 2 -> 1); mov.b64 packs/unpacks the float2 lanes
+    T.ptx.mov.b64(acc, local_sum[0], local_sum[1])
+    T.ptx.mov.b64(rhs, local_sum[2], local_sum[3])
+    T.ptx.add.rn.ftz.f32x2(acc, acc, rhs)
+    T.ptx.mov.b64(local_sum[0], local_sum[1], acc)
+    # ... same for local_sum[4:8], then fold the two halves together ...
     dst[...] = local_sum[0] + local_sum[1]
 
 **max / min (3input_maxmin).** A 4-wide accumulator folded three-at-a-time with the
@@ -108,9 +104,10 @@ Generated TIRx IR
 
 .. code-block:: python
 
-    T.ptx.add_f32x2(T.address_of(local_sum[0]),
-                    T.cuda.make_float2(local_sum[0], local_sum[1]),
-                    T.cuda.make_float2(local_sum[2], local_sum[3]))   # ... the 8->4->2->1 tree
+    T.ptx.mov.b64(acc, local_sum[0], local_sum[1])
+    T.ptx.mov.b64(rhs, local_sum[2], local_sum[3])
+    T.ptx.add.rn.ftz.f32x2(acc, acc, rhs)                             # ... the 8->4->2->1 tree
+    T.ptx.mov.b64(local_sum[0], local_sum[1], acc)
 
 Generated CUDA
 --------------
@@ -119,9 +116,9 @@ Generated CUDA
 
     // packed pairwise add: two float lanes per instruction
     "add.rn.ftz.f32x2 %0, %1, %2;"
-    // call: tvm_builtin_ptx_add_f32x2_rn_ftz(&local_sum_ptr[0],
-    //          tvm_builtin_make_float2(local_sum_ptr[0], local_sum_ptr[1]),
-    //          tvm_builtin_make_float2(local_sum_ptr[2], local_sum_ptr[3]));
+    // call: tvm_builtin_ptx_add_rn_ftz_f32x2(acc, acc, rhs);
+    //   with acc / rhs packed by tvm_builtin_ptx_mov_pack_b32x2_b64_u64_f32(...)
+    //   and unpacked by  tvm_builtin_ptx_mov_unpack_b32x2_b64_f32_u64(...)
 
 (Verified on ``sm_100a`` — ``B == sum(A)`` for a 32-element vector.)
 

--- a/docs/tirx/tile_primitives/reduction/sm100_packed.rst
+++ b/docs/tirx/tile_primitives/reduction/sm100_packed.rst
@@ -89,13 +89,13 @@ the accumulator ``8 → 4 → 2 → 1`` with three more ``add.f32x2``:
 .. code-block:: python
 
     # final tree (8 -> 4 -> 2 -> 1)
-    T.ptxd.add_f32x2(T.address_of(local_sum[0]),
+    T.ptx.add_f32x2(T.address_of(local_sum[0]),
                     T.cuda.make_float2(local_sum[0], local_sum[1]),
                     T.cuda.make_float2(local_sum[2], local_sum[3]), ftz=True)
-    T.ptxd.add_f32x2(T.address_of(local_sum[4]),
+    T.ptx.add_f32x2(T.address_of(local_sum[4]),
                     T.cuda.make_float2(local_sum[4], local_sum[5]),
                     T.cuda.make_float2(local_sum[6], local_sum[7]), ftz=True)
-    T.ptxd.add_f32x2(T.address_of(local_sum[0]),
+    T.ptx.add_f32x2(T.address_of(local_sum[0]),
                     T.cuda.make_float2(local_sum[0], local_sum[1]),
                     T.cuda.make_float2(local_sum[4], local_sum[5]), ftz=True)
     dst[...] = local_sum[0] + local_sum[1]
@@ -108,7 +108,7 @@ Generated TIRx IR
 
 .. code-block:: python
 
-    T.ptxd.add_f32x2(T.address_of(local_sum[0]),
+    T.ptx.add_f32x2(T.address_of(local_sum[0]),
                     T.cuda.make_float2(local_sum[0], local_sum[1]),
                     T.cuda.make_float2(local_sum[2], local_sum[3]))   # ... the 8->4->2->1 tree
 

--- a/python/tvm/backend/cuda/__init__.py
+++ b/python/tvm/backend/cuda/__init__.py
@@ -77,7 +77,7 @@ def register_backend():
 
 def script_namespaces(**_):
     """Return CUDA-owned TVMScript namespaces."""
-    from .ptx_dialect import PTXDNamespace  # pylint: disable=import-outside-toplevel
+    from .ptx_dialect import PTXNamespace  # pylint: disable=import-outside-toplevel
     from .script import (  # pylint: disable=import-outside-toplevel
         CUDANamespace,
         NVSHMEMNamespace,
@@ -89,7 +89,7 @@ def script_namespaces(**_):
         "cuda": CUDANamespace(),
         "nvshmem": NVSHMEMNamespace(),
         "ptx_legacy": PTXLegacyNamespace(),
-        "ptxd": PTXDNamespace(),
+        "ptx": PTXNamespace(),
         "s_tir": STIRNamespace(),
     }
 

--- a/python/tvm/backend/cuda/intrinsics/cp_async.py
+++ b/python/tvm/backend/cuda/intrinsics/cp_async.py
@@ -17,7 +17,7 @@
 # pylint: disable=redefined-builtin, invalid-name, too-many-arguments, too-many-locals, too-many-positional-arguments
 """The raw cp.async op behind ``InjectPTXAsyncCopy`` (everything else is ptx).
 
-``tirx.ptx.cp_async_raw`` is constructed by the C++ pass with explicit
+``tirx.s_tir.cp_async_raw`` is constructed by the C++ pass with explicit
 offsets; its codegen emits the scaling helper inline. All user-issued
 cp.async / cp.async.bulk copies go through ``T.ptx`` instead.
 """

--- a/python/tvm/backend/cuda/intrinsics/cp_async.py
+++ b/python/tvm/backend/cuda/intrinsics/cp_async.py
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=redefined-builtin, invalid-name, too-many-arguments, too-many-locals, too-many-positional-arguments
-"""The raw cp.async op behind ``InjectPTXAsyncCopy`` (everything else is ptxd).
+"""The raw cp.async op behind ``InjectPTXAsyncCopy`` (everything else is ptx).
 
 ``tirx.ptx.cp_async_raw`` is constructed by the C++ pass with explicit
 offsets; its codegen emits the scaling helper inline. All user-issued
-cp.async / cp.async.bulk copies go through ``T.ptxd`` instead.
+cp.async / cp.async.bulk copies go through ``T.ptx`` instead.
 """
 
 from tvm.backend.cuda.op import cuda_func_call
@@ -35,7 +35,7 @@ def _safe(s):
 
 @register_codegen("s_tir_cp_async_raw")
 def codegen_s_tir_cp_async_raw(*args):
-    """The raw cp.async op InjectPTXAsyncCopy emits (new copies are ptxd).
+    """The raw cp.async op InjectPTXAsyncCopy emits (new copies are ptx).
 
     Accepts two call shapes:
 

--- a/python/tvm/backend/cuda/intrinsics/misc.py
+++ b/python/tvm/backend/cuda/intrinsics/misc.py
@@ -21,7 +21,7 @@
 Catch-all for ops that don't fit the (sync / mma / cp_async / memory / math /
 nvshmem) feature buckets:
 
-* PTX register-allocation control: ``mov`` from special reg (setmaxnreg is ptxd).
+* PTX register-allocation control: ``mov`` from special reg (setmaxnreg is ptx).
 * Per-thread queries / scheduling hints: ``thread_rank`` / ``nano_sleep``.
 * Profiler timer hooks (``timer_init/start/end/finalize``).
 * Debug helpers: ``printf`` / ``trap`` on assert failure.

--- a/python/tvm/backend/cuda/intrinsics/wgmma.py
+++ b/python/tvm/backend/cuda/intrinsics/wgmma.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=redefined-builtin, invalid-name, too-many-arguments, too-many-locals, too-many-positional-arguments
-"""PTX WGMMA companions that are not instructions (mma_async itself is ptxd).
+"""PTX WGMMA companions that are not instructions (mma_async itself is ptx).
 
 ``encode_matrix_descriptor`` is a pure-C bitfield fill and ``noop_barrier``
 is an empty asm with one inout register operand -- neither maps to a PTX
@@ -27,7 +27,7 @@ from .registry import CODEGEN_REGISTRY, register_codegen
 from .types import PTXDataType
 
 # =============================================================================
-# wgmma noop_barrier / descriptor encode helpers (wait_group is ptxd).
+# wgmma noop_barrier / descriptor encode helpers (wait_group is ptx).
 # =============================================================================
 
 

--- a/python/tvm/backend/cuda/lang/alloc_pool.py
+++ b/python/tvm/backend/cuda/lang/alloc_pool.py
@@ -358,7 +358,7 @@ class TMEMPool:
 
         def emit_alloc():
             _emit_stmt(
-                T.ptxd[f"tcgen05.alloc.cta_group::{self.cta_group}.sync.aligned.shared::cta.b32"](
+                T.ptx[f"tcgen05.alloc.cta_group::{self.cta_group}.sync.aligned.shared::cta.b32"](
                     T.address_of(self.addr), T.uint32(self.total_cols)
                 )
             )
@@ -376,12 +376,10 @@ class TMEMPool:
 
         def emit_dealloc():
             _emit_stmt(
-                T.ptxd[
-                    f"tcgen05.relinquish_alloc_permit.cta_group::{self.cta_group}.sync.aligned"
-                ]()
+                T.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{self.cta_group}.sync.aligned"]()
             )
             _emit_stmt(
-                T.ptxd[f"tcgen05.dealloc.cta_group::{self.cta_group}.sync.aligned.b32"](
+                T.ptx[f"tcgen05.dealloc.cta_group::{self.cta_group}.sync.aligned.b32"](
                     self.addr, T.uint32(self.total_cols)
                 )
             )

--- a/python/tvm/backend/cuda/lang/clc.py
+++ b/python/tvm/backend/cuda/lang/clc.py
@@ -39,12 +39,12 @@ def query_cancel_first_ctaid_x(first_ctaid_x, handle, *, use_ld_acquire=True):
     response = T.local_scalar("uint128")
     canceled = T.local_scalar("uint32")
 
-    T.ptxd[f"ld{'.acquire.cta' if use_ld_acquire else ''}.shared.b128"](response, handle)
-    T.ptxd.clusterlaunchcontrol.query_cancel.is_canceled.pred.b128(canceled, response)
+    T.ptx[f"ld{'.acquire.cta' if use_ld_acquire else ''}.shared.b128"](response, handle)
+    T.ptx.clusterlaunchcontrol.query_cancel.is_canceled.pred.b128(canceled, response)
     first_ctaid_x = T.uint32(0xFFFFFFFF)
-    T.ptxd.clusterlaunchcontrol.query_cancel.get_first_ctaid__x.b32.b128(
+    T.ptx.clusterlaunchcontrol.query_cancel.get_first_ctaid__x.b32.b128(
         first_ctaid_x, response, pred=canceled
     )
     # Release the generic-proxy read of the handle before the next iteration's
     # async-proxy write to it (ISA 9.7.14.15's own example does the same).
-    T.ptxd.fence.proxy.async_.shared__cta()
+    T.ptx.fence.proxy.async_.shared__cta()

--- a/python/tvm/backend/cuda/lang/pipeline.py
+++ b/python/tvm/backend/cuda/lang/pipeline.py
@@ -95,7 +95,7 @@ def _map_addr_into_cta(ptr, rank):
     """
     mapped = T.alloc_local([1], "uint32")
     T.evaluate(
-        T.ptxd.mapa.shared__cluster.u32(
+        T.ptx.mapa.shared__cluster.u32(
             mapped[0], T.cuda.cvta_generic_to_shared(ptr), T.uint32(rank)
         )
     )
@@ -114,7 +114,7 @@ def _map_buffer_into_cta(ptr, rank, depth):
 
     ptr_ty = PointerType(PrimType("uint64"), "shared")
     mapped = T.alloc_local([1], "uint64")
-    T.evaluate(T.ptxd.mapa.u64(mapped[0], ptr, T.uint32(rank)))
+    T.evaluate(T.ptx.mapa.u64(mapped[0], ptr, T.uint32(rank)))
     remote_ptr = TIRVar("remote_mbar_ptr", ptr_ty)
     T.Bind(T.reinterpret(ptr_ty, mapped[0]), var=remote_ptr)
     return T.decl_buffer([depth], "uint64", data=remote_ptr, scope="shared")
@@ -127,14 +127,14 @@ def _mbarrier_arrive_remote(bar, pred=None, count=None):
     implicit count-of-1 line, which is a distinct ISA syntax line rather than
     a default operand.
     """
-    chain = T.ptxd.mbarrier.arrive.shared__cluster.b64
+    chain = T.ptx.mbarrier.arrive.shared__cluster.b64
     args = (bar,) if count is None else (bar, T.uint32(count))
     T.evaluate(chain(*args, pred=pred) if pred is not None else chain(*args))
 
 
 def _mbarrier_arrive_expect_tx_remote(bar, tx_count, pred=None):
     """``mbarrier.arrive.expect_tx.shared::cluster.b64 _, [bar], txCount``."""
-    chain = T.ptxd.mbarrier.arrive.expect_tx.shared__cluster.b64
+    chain = T.ptx.mbarrier.arrive.expect_tx.shared__cluster.b64
     args = (bar, T.uint32(tx_count))
     T.evaluate(chain(*args, pred=pred) if pred is not None else chain(*args))
 
@@ -184,7 +184,7 @@ class MBarrier:
     def _init(self, count):
         if self.leader:
             for i in T.unroll(self.depth):
-                T.ptxd.mbarrier.init.shared.b64(self.buf.ptr_to([i]), T.uint32(count))
+                T.ptx.mbarrier.init.shared.b64(self.buf.ptr_to([i]), T.uint32(count))
 
     def wait(self, stage, phase):
         if self._remote_cta_id is not None:
@@ -224,7 +224,7 @@ class MBarrier:
         # cross-CTA path was both surprising (``bar.arrive(stage)`` silently
         # ``mapa``ed across the cluster) and a per-call cost of ~3 PTX ops on
         # every single-CTA kernel.
-        T.ptxd.mbarrier.arrive.shared.b64(bar, T.uint32(1))
+        T.ptx.mbarrier.arrive.shared.b64(bar, T.uint32(1))
 
     def ptr_to(self, idx):
         return self.buf.ptr_to(idx)
@@ -281,9 +281,9 @@ class TMABar(MBarrier):
     @T.inline
     def _arrive_tma_local(self, bar, tx_count=None):
         if tx_count is None:
-            T.ptxd.mbarrier.arrive.shared.b64(bar, T.uint32(1))
+            T.ptx.mbarrier.arrive.shared.b64(bar, T.uint32(1))
         else:
-            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(bar, T.uint32(tx_count))
+            T.ptx.mbarrier.arrive.expect_tx.shared.b64(bar, T.uint32(tx_count))
 
 
 class TCGen05Bar(MBarrier):
@@ -305,18 +305,18 @@ class TCGen05Bar(MBarrier):
         # mbar address already names the target, so no mask operand. A runtime
         # mask is fine -- ctaMask is a register operand -- but the *choice* of
         # form cannot depend on it, so a runtime mask always multicasts.
-        # ``pred`` rides the ptxd keyword: the instruction is emitted
+        # ``pred`` rides the ptx keyword: the instruction is emitted
         # predicated (@p) rather than branched around.
         if _tcgen05_commit_is_unicast(cta_mask):
             T.evaluate(
-                T.ptxd[
+                T.ptx[
                     f"tcgen05.commit.cta_group::{cta_group}"
                     ".mbarrier::arrive::one.shared::cluster.b64"
                 ](self.buf.ptr_to([stage]), pred=pred)
             )
         else:
             T.evaluate(
-                T.ptxd[
+                T.ptx[
                     f"tcgen05.commit.cta_group::{cta_group}"
                     ".mbarrier::arrive::one.shared::cluster.multicast::cluster.b64"
                 ](self.buf.ptr_to([stage]), T.Cast("uint16", cta_mask), pred=pred)

--- a/python/tvm/backend/cuda/lang/tile_scheduler.py
+++ b/python/tvm/backend/cuda/lang/tile_scheduler.py
@@ -933,7 +933,7 @@ class ClusterLaunchControlScheduler:
                 if cbx == 0:
                     self.sched_fin.empty.wait(0, sf.phase)
                     sf.advance()
-                    T.ptxd[
+                    T.ptx[
                         "clusterlaunchcontrol.try_cancel.async.shared::cta"
                         ".mbarrier::complete_tx::bytes.multicast::cluster::all.b128"
                     ](T.address_of(self.clc_handle[0]), T.address_of(self.sched_arr.full.buf[0]))

--- a/python/tvm/backend/cuda/lang/warp_role.py
+++ b/python/tvm/backend/cuda/lang/warp_role.py
@@ -46,7 +46,7 @@ class WarpRole:
 
         if <warp_id_var> == <warp_id_val>:
             # if regs specified:
-            T.ptxd[f"setmaxnreg.{'inc' if <increase> else 'dec'}.sync.aligned.u32"](<regs>)
+            T.ptx[f"setmaxnreg.{'inc' if <increase> else 'dec'}.sync.aligned.u32"](<regs>)
             <user code>
 
     The ``if`` guard narrows the active set to the single warp; individual
@@ -60,7 +60,7 @@ class WarpRole:
     warp_id_val : int
         Which warp index this role corresponds to.
     regs : int, optional
-        Register budget (passed to ``T.ptxd.setmaxnreg``).
+        Register budget (passed to ``T.ptx.setmaxnreg``).
         If None, no setmaxnreg is emitted.
     increase : bool
         Direction for ``setmaxnreg`` (default False = decrease).
@@ -79,9 +79,7 @@ class WarpRole:
         self._then_frame.__enter__()
         if self.regs is not None:
             T.evaluate(
-                T.ptxd[f"setmaxnreg.{'inc' if self.increase else 'dec'}.sync.aligned.u32"](
-                    self.regs
-                )
+                T.ptx[f"setmaxnreg.{'inc' if self.increase else 'dec'}.sync.aligned.u32"](self.regs)
             )
         return self
 
@@ -99,13 +97,13 @@ class WarpgroupRole:
 
         if <wg_id_var> == <wg_id_val>:
             # if regs specified:
-            T.ptxd[f"setmaxnreg.{'inc' if <increase> else 'dec'}.sync.aligned.u32"](<regs>)
+            T.ptx[f"setmaxnreg.{'inc' if <increase> else 'dec'}.sync.aligned.u32"](<regs>)
             <user code>
 
     Generates (range of wg_ids, e.g. ``wg_id_val=(0, 2)``)::
 
         if 0 <= <wg_id_var> and <wg_id_var> < 2:
-            T.ptxd[f"setmaxnreg.{'inc' if <increase> else 'dec'}.sync.aligned.u32"](<regs>)
+            T.ptx[f"setmaxnreg.{'inc' if <increase> else 'dec'}.sync.aligned.u32"](<regs>)
             <user code>
 
     The ``if`` guard narrows the active set to the target warpgroup(s);
@@ -142,9 +140,7 @@ class WarpgroupRole:
         self._then_frame.__enter__()
         if self.regs is not None:
             T.evaluate(
-                T.ptxd[f"setmaxnreg.{'inc' if self.increase else 'dec'}.sync.aligned.u32"](
-                    self.regs
-                )
+                T.ptx[f"setmaxnreg.{'inc' if self.increase else 'dec'}.sync.aligned.u32"](self.regs)
             )
         return self
 

--- a/python/tvm/backend/cuda/op.py
+++ b/python/tvm/backend/cuda/op.py
@@ -424,7 +424,7 @@ def ptx_cp_async_legacy(*all_args):
 
     Signature: ``(dst_ptr, dst_offset, src_ptr, src_offset, cp_size)``.
     Offsets are folded into the pointers via ``tvm_access_ptr`` and the call
-    lowers through the raw ``tirx.ptx.cp_async_raw`` op.
+    lowers through the raw ``tirx.s_tir.cp_async_raw`` op.
 
     ``T.s_tir.cp_async_raw.legacy`` runs through ``_dtype_forward`` which
     prepends a ``dtype=`` kwarg as a leading positional. The dtype names

--- a/python/tvm/backend/cuda/ptx_dialect/__init__.py
+++ b/python/tvm/backend/cuda/ptx_dialect/__init__.py
@@ -14,18 +14,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Table-driven PTX dialect prototype (``T.ptxd``).
+"""Table-driven PTX dialect prototype (``T.ptx``).
 
 One table (:mod:`.table`), one generic engine (:mod:`.engine`), thin
 generators (:mod:`.gen_helpers``/``gen_stubs`, :mod:`.gen_coverage`). Importing this package
 registers every table entry as a TVM Op with a generic codegen; the
-``T.ptxd`` namespace itself is installed by the CUDA backend's
+``T.ptx`` namespace itself is installed by the CUDA backend's
 ``register_backend()`` via ``script_namespaces()``.
 """
 
-from .engine import PTXDNamespace, register_table
+from .engine import PTXNamespace, register_table
 from .table import TABLE
 
 register_table(TABLE)
 
-__all__ = ["TABLE", "PTXDNamespace", "register_table"]
+__all__ = ["TABLE", "PTXNamespace", "register_table"]

--- a/python/tvm/backend/cuda/ptx_dialect/__init__.py
+++ b/python/tvm/backend/cuda/ptx_dialect/__init__.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Table-driven PTX dialect prototype (``T.ptx``).
+"""Table-driven PTX dialect (``T.ptx``).
 
 One table (:mod:`.table`), one generic engine (:mod:`.engine`), thin
 generators (:mod:`.gen_helpers``/``gen_stubs`, :mod:`.gen_coverage`). Importing this package

--- a/python/tvm/backend/cuda/ptx_dialect/engine.py
+++ b/python/tvm/backend/cuda/ptx_dialect/engine.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Generic engine for the ``T.ptx`` table-driven PTX dialect prototype.
+"""Generic engine for the ``T.ptx`` table-driven PTX dialect.
 
 One engine interprets every :class:`~.table.InstructionEntry` — there is no
 per-instruction generated or hand-written code:
@@ -510,7 +510,7 @@ def _narrow(cands, token):
 
 
 class PTXNamespace:
-    """``T.ptx`` — table-driven PTX instruction namespace (prototype)."""
+    """``T.ptx`` — table-driven PTX instruction namespace."""
 
     def __init__(self, table=None):
         if table is None:

--- a/python/tvm/backend/cuda/ptx_dialect/engine.py
+++ b/python/tvm/backend/cuda/ptx_dialect/engine.py
@@ -14,27 +14,27 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Generic engine for the ``T.ptxd`` table-driven PTX dialect prototype.
+"""Generic engine for the ``T.ptx`` table-driven PTX dialect prototype.
 
 One engine interprets every :class:`~.table.InstructionEntry` — there is no
 per-instruction generated or hand-written code:
 
 - :func:`register_table` registers each family as a TVM Op
-  (``tirx.ptxd.<name>``) with effect/printer attrs, plus one generic codegen
+  (``tirx.ptx.<name>``) with effect/printer attrs, plus one generic codegen
   closure that renders the ``asm volatile`` helper from the table.
-- :class:`PTXDNamespace` (surfaced as ``T.ptxd``) resolves attribute chains
-  such as ``T.ptxd.ld.global_.acquire.gpu.b32(addr)`` against the table:
+- :class:`PTXNamespace` (surfaced as ``T.ptx``) resolves attribute chains
+  such as ``T.ptx.ld.global_.acquire.gpu.b32(addr)`` against the table:
   the first token names the family, every further token fills a modifier
   slot (order-free). Python keywords are escaped with a trailing underscore
   (``global_``); ``::`` is written as a double underscore (``shared__cta``).
-  The string form ``T.ptxd["st.weak.shared::cta.b32"]`` preserves exact PTX
+  The string form ``T.ptx["st.weak.shared::cta.b32"]`` preserves exact PTX
   text.
 - Modifiers travel as trailing positional string args of the traced Call
   (never ``Call.attrs`` — that would break TVMScript pretty-printing). Call
   arg layout: ``[operands..., pred?] [slot tokens ("" = omitted)]``; the
   codegen derives predication from the arg count. Destinations are ordinary
   leading operands, so a call is always a statement:
-  ``T.ptxd.ld.acquire.gpu.global_.b32(val, ptr)``.
+  ``T.ptx.ld.acquire.gpu.global_.b32(val, ptr)``.
 """
 
 from tvm.backend.cuda.intrinsics.registry import register_codegen
@@ -58,7 +58,7 @@ from .table import (
     unescape_token,
 )
 
-# Every ptxd call is a void statement, and RemoveNoOp deletes any Evaluate()
+# Every ptx call is a void statement, and RemoveNoOp deletes any Evaluate()
 # whose value is <= kReadState, so kOpaque is what keeps the instruction alive.
 # It is also the honest answer: "do not touch my instruction" is exactly the
 # contract a hand-written PTX call wants.
@@ -76,13 +76,13 @@ def register_table(table: dict[str, InstructionEntry]) -> None:
         # kind must exist before any side-effect analysis sees the op.
         register_op_attr(entry.op_name, "TCallEffectKind", _EFFECT_OPAQUE)
         # The printer name is the *surface* path a user can type, which is the
-        # mnemonic (several `mov_*` entries all answer to `T.ptxd.mov`), not the
+        # mnemonic (several `mov_*` entries all answer to `T.ptx.mov`), not the
         # table key. Reparsing re-dispatches on the operand shape.
         family = entry.family
-        register_op_attr(entry.op_name, "TScriptPrinterName", f"ptxd.{family}", level=20)
+        register_op_attr(entry.op_name, "TScriptPrinterName", f"ptx.{family}", level=20)
         register_op_attr(entry.op_name, "TIRxOpCategory", "device_intrin")
-        register_op_attr(entry.op_name, "TDeviceIntrinsicNamespace", "ptxd")
-        register_codegen(f"ptxd.{entry.name}")(_make_codegen(entry))
+        register_op_attr(entry.op_name, "TDeviceIntrinsicNamespace", "ptx")
+        register_codegen(f"ptx.{entry.name}")(_make_codegen(entry))
 
 
 # ---------------------------------------------------------------------------
@@ -373,7 +373,7 @@ def _emit(entry, filled, operands, pred=None):
     # one optional operand, a predicated short form is indistinguishable from an
     # unpredicated long one. The marker makes the round trip exact.
     return call_intrin(
-        "",  # every ptxd call is a void statement; destinations are operands
+        "",  # every ptx call is a void statement; destinations are operands
         entry.op_name,
         *coerced,
         *((pred,) if pred is not None else ()),
@@ -383,7 +383,7 @@ def _emit(entry, filled, operands, pred=None):
 
 
 # ---------------------------------------------------------------------------
-# Namespace surface: T.ptxd attribute chains + string form
+# Namespace surface: T.ptx attribute chains + string form
 # ---------------------------------------------------------------------------
 
 
@@ -466,11 +466,11 @@ class _InstrChain:
             if len(errors) == 1:
                 raise errors[0][1]
             raise ValueError(
-                "no ptxd instruction matches these operands; candidates rejected it as:\n  "
+                "no ptx instruction matches these operands; candidates rejected it as:\n  "
                 + "\n  ".join(f"{e.name}: {err}" for e, err in errors)
             )
         raise AssertionError(  # a table bug, not a user error
-            f"ambiguous ptxd table: {len(hits)} entries accept the same call "
+            f"ambiguous ptx table: {len(hits)} entries accept the same call "
             f"({', '.join(e.name for e, _ in cands)})"
         )
 
@@ -489,7 +489,7 @@ class _InstrChain:
     def __repr__(self):
         entry, filled = self._cands[0]
         mods_str = [tok for tok in filled if tok]
-        return f"<T.ptxd.{'.'.join([entry.ptx_name, *mods_str])}>"
+        return f"<T.ptx.{'.'.join([entry.ptx_name, *mods_str])}>"
 
 
 def _narrow(cands, token):
@@ -509,8 +509,8 @@ def _narrow(cands, token):
     return out
 
 
-class PTXDNamespace:
-    """``T.ptxd`` — table-driven PTX instruction namespace (prototype)."""
+class PTXNamespace:
+    """``T.ptx`` — table-driven PTX instruction namespace (prototype)."""
 
     def __init__(self, table=None):
         if table is None:
@@ -535,18 +535,18 @@ class PTXDNamespace:
         chain = self._family(unescape_token(name))
         if chain is None:
             raise AttributeError(
-                f"'{name}' is not a ptxd instruction; known families: "
+                f"'{name}' is not a ptx instruction; known families: "
                 f"{', '.join(sorted(self._family_names()))}"
             )
         return chain
 
     def __getitem__(self, text):
-        """Exact-PTX-text form, e.g. ``T.ptxd["st.weak.shared::cta.b32"]``."""
+        """Exact-PTX-text form, e.g. ``T.ptx["st.weak.shared::cta.b32"]``."""
         first, _, rest = text.partition(".")
         chain = self._family(first)
         if chain is None:
             raise KeyError(
-                f"'{text}' does not start with a ptxd instruction family; "
+                f"'{text}' does not start with a ptx instruction family; "
                 f"known: {', '.join(sorted(self._family_names()))}"
             )
         for token in rest.split(".") if rest else []:
@@ -564,4 +564,4 @@ class PTXDNamespace:
         return sorted(self._family_names() | set(super().__dir__()))
 
     def __repr__(self):
-        return f"<T.ptxd: {len(self._family_names())} instruction families>"
+        return f"<T.ptx: {len(self._family_names())} instruction families>"

--- a/python/tvm/backend/cuda/ptx_dialect/gen_coverage.py
+++ b/python/tvm/backend/cuda/ptx_dialect/gen_coverage.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Thin generator 2: emit a markdown coverage table for the ptxd dialect.
+"""Thin generator 2: emit a markdown coverage table for the ptx dialect.
 
 Run manually::
 
@@ -30,7 +30,7 @@ from .table import TABLE
 
 def generate() -> str:
     lines = [
-        "# ptxd dialect coverage",
+        "# ptx dialect coverage",
         "",
         "| instruction | modifiers | constraints | operands |",
         "|---|---|---|---|",

--- a/python/tvm/backend/cuda/ptx_dialect/gen_helpers.py
+++ b/python/tvm/backend/cuda/ptx_dialect/gen_helpers.py
@@ -16,14 +16,14 @@
 # under the License.
 """Thin generator 3: dump the generated inline-CUDA helper of every instruction.
 
-The engine renders each ``T.ptxd`` call's ``__device__`` helper on the fly at
+The engine renders each ``T.ptx`` call's ``__device__`` helper on the fly at
 codegen time — this tool renders the exact same helpers ahead of time so a
 human can inspect what each registered instruction variant compiles to,
 without building a kernel::
 
     python -m tvm.backend.cuda.ptx_dialect.gen_helpers            # everything
     python -m tvm.backend.cuda.ptx_dialect.gen_helpers ld st      # some families
-    python -m tvm.backend.cuda.ptx_dialect.gen_helpers -o ptxd_helpers.cu
+    python -m tvm.backend.cuda.ptx_dialect.gen_helpers -o ptx_helpers.cu
 
 Only imports :mod:`.table` / :mod:`.render` (tvm-free).
 """
@@ -61,7 +61,7 @@ def generate(families=None) -> str:
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="python -m tvm.backend.cuda.ptx_dialect.gen_helpers",
-        description="Dump the generated inline-CUDA helper of every ptxd instruction variant.",
+        description="Dump the generated inline-CUDA helper of every ptx instruction variant.",
     )
     parser.add_argument("families", nargs="*", help="restrict to these families (default: all)")
     parser.add_argument("-o", "--output", default=None, help="output path (default: stdout)")

--- a/python/tvm/backend/cuda/ptx_dialect/gen_stubs.py
+++ b/python/tvm/backend/cuda/ptx_dialect/gen_stubs.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Thin generator 1: emit a ``.pyi`` stub for the ``T.ptxd`` namespace.
+"""Thin generator 1: emit a ``.pyi`` stub for the ``T.ptx`` namespace.
 
 Run manually (never at import time)::
 
@@ -23,7 +23,7 @@ Run manually (never at import time)::
 The output is a *module stub for* ``tvm.script.tirx``: that module is
 virtual at runtime (dialect-registry ``__getattr__``), but a ``.pyi`` file
 at ``python/tvm/script/tirx.pyi`` makes Pyright/Pylance resolve it — giving
-VS Code completion for ``T.ptxd.`` chains. All other members fall back to
+VS Code completion for ``T.ptx.`` chains. All other members fall back to
 ``Any`` via the stub's module ``__getattr__``, matching today's behavior.
 
 Each family's chain class lists every slot token flatly, so the stub also
@@ -102,7 +102,7 @@ def _chain_class(family: str, entries: list[InstructionEntry]) -> str:
         if not attr.isidentifier():
             # A token like `16x64b` cannot be an attribute name, so the chain
             # form cannot reach it; those variants are written as strings,
-            # `T.ptxd["tcgen05.ld.sync.aligned.16x64b.x4.b32"](...)`.
+            # `T.ptx["tcgen05.ld.sync.aligned.16x64b.x4.b32"](...)`.
             continue
         lines.append(f"    {attr}: {cls}")
     if len(signature) > 92:  # keep the generated stub within the repo line limit
@@ -136,7 +136,7 @@ _ASF_HEADER = """\
 def generate() -> str:
     out = [
         _ASF_HEADER,
-        '"""Generated stub for T.ptxd — do not edit.',
+        '"""Generated stub for T.ptx — do not edit.',
         "",
         "Regenerate:",
         "  python -m tvm.backend.cuda.ptx_dialect.gen_stubs -o python/tvm/script/tirx.pyi",
@@ -151,12 +151,12 @@ def generate() -> str:
     for family in sorted(families):
         out.append(_chain_class(family, families[family]))
         out.append("")
-    out.append("class _PTXD:")
+    out.append("class _PTX:")
     for family in sorted(families):
         out.append(f"    {escape_token(family)}: _Chain_{family}")
     out.append("    def __getitem__(self, text: str) -> Any: ...")
     out.append("")
-    out.append("ptxd: _PTXD")
+    out.append("ptx: _PTX")
     out.append("")
     out.append("# Every other tvm.script.tirx member stays dynamically typed, as before.")
     out.append("def __getattr__(name: str) -> Any: ...")

--- a/python/tvm/backend/cuda/ptx_dialect/render.py
+++ b/python/tvm/backend/cuda/ptx_dialect/render.py
@@ -109,7 +109,7 @@ def _helper_name(entry: InstructionEntry, written, imms, dtypes, canonical) -> s
     discriminator = (
         [] if tuple(dtypes) == tuple(canonical) else [C_BINDING[d].suffix for d in dtypes]
     )
-    return "tvm_builtin_ptxd_" + "_".join([*isa_name, *discriminator]).replace("::", "__").replace(
+    return "tvm_builtin_ptx_" + "_".join([*isa_name, *discriminator]).replace("::", "__").replace(
         ".", "_"
     ).replace("-", "m")
 

--- a/python/tvm/backend/cuda/ptx_dialect/render.py
+++ b/python/tvm/backend/cuda/ptx_dialect/render.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Pure CUDA-helper rendering for the ptxd dialect.
+"""Pure CUDA-helper rendering for the ptx dialect.
 
 tvm-free (imports only :mod:`.table`), so it is shared by the codegen engine
 and by :mod:`.gen_helpers`, which dumps the generated helpers for humans to

--- a/python/tvm/backend/cuda/ptx_dialect/table.py
+++ b/python/tvm/backend/cuda/ptx_dialect/table.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Instruction table for the ``T.ptxd`` table-driven PTX dialect prototype.
+"""Instruction table for the ``T.ptx`` table-driven PTX dialect prototype.
 
 Pure data + pure functions: this module deliberately imports nothing from
 ``tvm`` so the thin generators (``gen_stubs``, ``gen_coverage``,
@@ -42,12 +42,12 @@ The converged :class:`InstructionEntry` design:
   destination accepts ``pred=`` at the call site; entries never mention it.
 
 Calling convention: PTX has no defining form — a register is declared first
-and instructions then write into it — so a ptxd call mirrors the PTX text
+and instructions then write into it — so a ptx call mirrors the PTX text
 exactly. Destinations are ordinary operands (``role="dst"``, in PTX operand
 order), every helper is ``void``, and every call is a statement::
 
     acc: T.float32                        # .reg .f32 acc;
-    T.ptxd.add.rn.f32(acc, x, acc)        # add.rn.f32 acc, x, acc;
+    T.ptx.add.rn.f32(acc, x, acc)        # add.rn.f32 acc, x, acc;
 """
 
 import functools
@@ -292,7 +292,7 @@ class InstructionEntry:
 
     @property
     def op_name(self) -> str:
-        return f"tirx.ptxd.{self.name}"
+        return f"tirx.ptx.{self.name}"
 
     @property
     def ptx_name(self) -> str:
@@ -300,7 +300,7 @@ class InstructionEntry:
 
     @property
     def family(self) -> str:
-        """The attribute users type: ``T.ptxd.<family>``.
+        """The attribute users type: ``T.ptx.<family>``.
 
         The mnemonic with dots folded to underscores. Equal to ``name`` for
         every single-shape family (``st.bulk`` -> ``st_bulk``); the shared
@@ -1824,7 +1824,7 @@ _ENTRIES = [
     # - .unified (variable-attribute addressing)
     # - .param/.const spaces (require kernel-parameter / const addresses,
     #   which cannot flow through the helper-function ABI)
-    # The ISA permits @p on this instruction; ptxd does not, because it writes a
+    # The ISA permits @p on this instruction; ptx does not, because it writes a
     # destination -- see InstructionEntry.has_dst for why that needs a "+"
     # constraint first.
     InstructionEntry(
@@ -2019,7 +2019,7 @@ _ENTRIES = [
             OperandSlot("value", role="value"),
         ),
     ),
-    # The ISA permits @p on this instruction; ptxd does not, because it writes a
+    # The ISA permits @p on this instruction; ptx does not, because it writes a
     # destination -- see InstructionEntry.has_dst for why that needs a "+"
     # constraint first.
     InstructionEntry(
@@ -2264,7 +2264,7 @@ _ENTRIES = [
     # `mov.b64 {lo,hi}, %x;  // %x is a double; lo,hi are .u32`), so both are
     # part of the operand shape, and each (direction, lanes, lane type) is its
     # own entry. They all share mnemonic "mov", so the emitted opcode is right
-    # and the call spelling stays `T.ptxd.mov.b64(...)`.
+    # and the call spelling stays `T.ptx.mov.b64(...)`.
     #
     # NOT REGISTERED -- legal PTX that CUDA C inline asm cannot express:
     #   mov.b16 d, {a,b}      2 x 8-bit lanes
@@ -3224,7 +3224,7 @@ _ENTRIES = [
     # set `orders_memory=True` -- see InstructionEntry for why `asm volatile`
     # alone is not enough. Each syntax line whose token sequence differs is its
     # own entry, all sharing the `fence` mnemonic, so the surface stays
-    # `T.ptxd.fence...` and the chain narrows on the tokens themselves.
+    # `T.ptx.fence...` and the chain narrows on the tokens themselves.
     # NOT REGISTERED: the `.sync_restrict` lines and the fabric-proxy line
     # (fixed token sequences with no users yet), and the deprecated `membar`
     # spellings, which the ISA itself marks as the old style for `fence`.
@@ -3408,7 +3408,7 @@ _ENTRIES = [
         InstructionEntry(  # barrier.cluster.arrive{.sem}{.aligned} / .wait{.acquire}{.aligned}
             name=f"barrier_cluster_{act}",
             # Shares the `barrier` mnemonic with 9.7.14.1 so the surface reads
-            # `T.ptxd.barrier.cluster.arrive(...)`; `cluster` is the token that
+            # `T.ptx.barrier.cluster.arrive(...)`; `cluster` is the token that
             # tells the two ISA sections apart.
             mnemonic="barrier",
             slots=(
@@ -5026,7 +5026,7 @@ _ENTRIES = [
     #     so it is a choices immediate, not a runtime operand. (The legacy
     #     helper burned a setp + predicate register on it per call.)
     #   - imm-scale-a/b: "the valid values ... are -1 and 1". The legacy
-    #     helper emitted 0 for "no negate", outside the ISA's domain; ptxd
+    #     helper emitted 0 for "no negate", outside the ISA's domain; ptx
     #     transcribes the documented set.
     #   - imm-trans-a/b: {0, 1}, f16/bf16 lines only (k-major inputs cannot
     #     be transposed); the rs line has no imm-trans-a.

--- a/python/tvm/backend/cuda/ptx_dialect/table.py
+++ b/python/tvm/backend/cuda/ptx_dialect/table.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Instruction table for the ``T.ptx`` table-driven PTX dialect prototype.
+"""Instruction table for the ``T.ptx`` table-driven PTX dialect.
 
 Pure data + pure functions: this module deliberately imports nothing from
 ``tvm`` so the thin generators (``gen_stubs``, ``gen_coverage``,

--- a/python/tvm/backend/cuda/script.py
+++ b/python/tvm/backend/cuda/script.py
@@ -64,7 +64,7 @@ class _CpAsyncRaw:
             )
         raise TypeError(
             "T.s_tir.cp_async_raw only accepts the printed 6-arg raw form; "
-            'issue new copies through T.ptxd["cp.async..."]'
+            'issue new copies through T.ptx["cp.async..."]'
         )
 
 
@@ -91,7 +91,7 @@ class PTXLegacyNamespace:
     """
 
     def __init__(self):
-        # Same lowered asm as T.ptxd.mma, but the accumulator doubles as the
+        # Same lowered asm as T.ptx.mma, but the accumulator doubles as the
         # destination and the offsets are explicit.
         self.mma = _dtype_forward(_cuda_op.ptx_legacy_mma)
         # (trans, num, dtype, local_ptr, local_offset, smem_ptr, smem_offset)
@@ -139,15 +139,15 @@ class CUDANamespace:
         self.tcgen05 = CudaTcgen05Namespace()
         self.any_sync = _op_wrapper(_cuda_op.cuda_any_sync)
         # elect.sync plus the two movs that materialize its d|p pair: a
-        # multi-statement asm block, so it belongs here rather than T.ptxd.
+        # multi-statement asm block, so it belongs here rather than T.ptx.
         # The warp-specialization passes match this op to build predicates.
         self.elect_sync: Callable[..., Any] = _op_wrapper(_cuda_op.cuda_elect_sync)
         # `mov.u32 d, %sreg` -- one PTX instruction, but the special-register
         # name is baked into the asm text, so it is a helper per register
-        # rather than a ptxd entry with a register operand.
+        # rather than a ptx entry with a register operand.
         self.mov_sreg: Callable[..., Any] = _op_wrapper(_cuda_op.cuda_mov_sreg)
         # Spin-until-ready mbarrier waits: label-loop asm blocks, not single
-        # PTX instructions -- which is why they live here and not in T.ptxd.
+        # PTX instructions -- which is why they live here and not in T.ptx.
         self.mbarrier_wait = _op_wrapper(_cuda_op.cuda_mbarrier_wait)
         self.mbarrier_wait_acquire_cluster = _op_wrapper(
             _cuda_op.cuda_mbarrier_wait_acquire_cluster

--- a/python/tvm/backend/cuda/tile_primitive/common.py
+++ b/python/tvm/backend/cuda/tile_primitive/common.py
@@ -220,7 +220,7 @@ def copy_vec_load_impl(
                         fused = T.meta_var((s * tx + tid_x) * vec_len)
                         dst_indices = T.meta_var(get_indices(fused, dst_st, dst_extent))
                         src_indices = T.meta_var(get_indices(fused, src_st, src_extent))
-                        T.evaluate(T.ptxd[f"cp.async.{'cg' if cp_size == 16 else 'ca'}.shared.global"](dst.ptr_to(dst_indices), src.ptr_to(src_indices), cp_size))  # noqa: E501
+                        T.evaluate(T.ptx[f"cp.async.{'cg' if cp_size == 16 else 'ca'}.shared.global"](dst.ptr_to(dst_indices), src.ptr_to(src_indices), cp_size))  # noqa: E501
             if dst.scope().startswith("shared") and inst_type == CopyInstType.NORMAL:
                 T.tvm_storage_sync("shared")
         # fmt: on
@@ -239,7 +239,7 @@ def copy_vec_load_impl(
                     fused = T.meta_var(s * vec_len)
                     dst_indices = T.meta_var(get_indices(fused, dst_st, dst_extent))
                     src_indices = T.meta_var(get_indices(fused, src_st, src_extent))
-                    T.evaluate(T.ptxd[f"cp.async.{'cg' if cp_size == 16 else 'ca'}.shared.global"](dst.ptr_to(dst_indices), src.ptr_to(src_indices), cp_size))  # noqa: E501
+                    T.evaluate(T.ptx[f"cp.async.{'cg' if cp_size == 16 else 'ca'}.shared.global"](dst.ptr_to(dst_indices), src.ptr_to(src_indices), cp_size))  # noqa: E501
         # fmt: on
     else:
         fail(f"unsupported exec_scope {sctx.scope_kind}")

--- a/python/tvm/backend/cuda/tile_primitive/copy/_common.py
+++ b/python/tvm/backend/cuda/tile_primitive/copy/_common.py
@@ -541,8 +541,8 @@ def _outer_offsets(outer_iters_s, outer_iters_g, flat_idx):
     return ds, dg
 
 
-def copy_ptxd_form(num_bytes: int) -> tuple[str, int, str]:
-    """Map copy width (bytes) to ``(ptxd chain tail, lanes, register dtype)``.
+def copy_ptx_form(num_bytes: int) -> tuple[str, int, str]:
+    """Map copy width (bytes) to ``(ptx chain tail, lanes, register dtype)``.
 
     The chain tail is the ``{vec.}type`` suffix; ``lanes`` is how many operands
     the group takes; the register dtype is the container the lanes are read and
@@ -559,7 +559,7 @@ def copy_ptxd_form(num_bytes: int) -> tuple[str, int, str]:
     }[num_bytes]
 
 
-def copy_ptxd_ld_chain(
+def copy_ptx_ld_chain(
     space: str,
     tail: str,
     *,

--- a/python/tvm/backend/cuda/tile_primitive/copy/ld_stmatrix.py
+++ b/python/tvm/backend/cuda/tile_primitive/copy/ld_stmatrix.py
@@ -377,10 +377,10 @@ def _emit(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
                 for i in range(num)
             ]
             if direction == "ld":
-                T.ptxd[ld_chain](*words, smem_ptr)
+                T.ptx[ld_chain](*words, smem_ptr)
             else:
                 # stmatrix reverses ldmatrix's operand order: address first.
-                T.ptxd[st_chain](smem_ptr, *words)
+                T.ptx[st_chain](smem_ptr, *words)
     # fmt: on
     return impl
 

--- a/python/tvm/backend/cuda/tile_primitive/copy/vec_auto_gmem_smem.py
+++ b/python/tvm/backend/cuda/tile_primitive/copy/vec_auto_gmem_smem.py
@@ -37,7 +37,7 @@ from ._common import (
     _TID_AXIS_FOR_SCOPE,
     _thread_cnt,
     align_layouts_gs,
-    copy_ptxd_form,
+    copy_ptx_form,
 )
 from .utils import _is_valid_copy, _scope_allowed
 from .vec_auto_reg import _all_threads_active, _axis_decl, _ptr_off
@@ -128,7 +128,7 @@ def _emit_gmem_smem(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFu
 
     vec_bits = vec_len * elem_bits
     num_bytes = vec_bits // 8
-    tail, lanes, reg_dtype = copy_ptxd_form(num_bytes)
+    tail, lanes, reg_dtype = copy_ptx_form(num_bytes)
     # Chains are built here: a Python string bound inside the traced body is
     # not something the parser can carry.
     ld_g, st_s = f"ld.global.{tail}", f"st.shared.{tail}"
@@ -177,10 +177,10 @@ def _emit_gmem_smem(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFu
             s_ptr = _ptr_off(s_buf.ptr_to(s_zero), s_off)
             g_ptr = _ptr_off(g_buf.ptr_to(g_zero), g_lin)
             if g_is_src:
-                T.ptxd[ld_g](*[tmp[i] for i in range(lanes)], g_ptr)
-                T.ptxd[st_s](s_ptr, *[tmp[i] for i in range(lanes)])
+                T.ptx[ld_g](*[tmp[i] for i in range(lanes)], g_ptr)
+                T.ptx[st_s](s_ptr, *[tmp[i] for i in range(lanes)])
             else:
-                T.ptxd[ld_s](*[tmp[i] for i in range(lanes)], s_ptr)
-                T.ptxd[st_g](g_ptr, *[tmp[i] for i in range(lanes)])
+                T.ptx[ld_s](*[tmp[i] for i in range(lanes)], s_ptr)
+                T.ptx[st_g](g_ptr, *[tmp[i] for i in range(lanes)])
     # fmt: on
     return impl

--- a/python/tvm/backend/cuda/tile_primitive/copy/vec_auto_reg.py
+++ b/python/tvm/backend/cuda/tile_primitive/copy/vec_auto_reg.py
@@ -39,7 +39,7 @@ from tvm.tirx.operator.tile_primitive.registry import DispatchContext
 from tvm.tirx.tile_primitive import TilePrimitiveCall
 
 from ..layout_utils import recompose_swizzle, strip_swizzle_to_tile
-from ._common import _alignment_ok, copy_ptxd_form, copy_ptxd_ld_chain
+from ._common import _alignment_ok, copy_ptx_form, copy_ptx_ld_chain
 from .utils import _is_valid_copy, _scope_allowed
 from .vec_forced import _ld_cache_config
 
@@ -558,7 +558,7 @@ def _emit_reg(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
 
     s_is_shared = s_buf.scope().startswith("shared")
     num_bytes = vec_bits // 8
-    tail, lanes, reg_dtype = copy_ptxd_form(num_bytes)
+    tail, lanes, reg_dtype = copy_ptx_form(num_bytes)
     space = "shared" if s_is_shared else "global"
 
     # Honor the load cache hint (cache="nc") only on global -> register loads;
@@ -578,7 +578,7 @@ def _emit_reg(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
     # not something the parser can carry. `nc` folds into the chain, so the
     # three-way branch at the call site collapses to load-or-store.
     st_chain = f"st.{space}.{tail}"
-    ld_chain = copy_ptxd_ld_chain(
+    ld_chain = copy_ptx_ld_chain(
         space,
         tail,
         nc=_use_nc,
@@ -619,9 +619,9 @@ def _emit_reg(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
             # between element and word granularity.
             r_w = (r_off_base + dr) * words_per_elem // elems_per_word
             if r_is_src:
-                T.ptxd[st_chain](s_ptr, *[r_words[r_w + i] for i in range(lanes)])
+                T.ptx[st_chain](s_ptr, *[r_words[r_w + i] for i in range(lanes)])
             else:
-                T.ptxd[ld_chain](*[r_words[r_w + i] for i in range(lanes)], s_ptr)
+                T.ptx[ld_chain](*[r_words[r_w + i] for i in range(lanes)], s_ptr)
     # fmt: on
     import os
 

--- a/python/tvm/backend/cuda/tile_primitive/copy/vec_forced.py
+++ b/python/tvm/backend/cuda/tile_primitive/copy/vec_forced.py
@@ -19,11 +19,11 @@
 
 Cache-semantics config (all variants, read from ``op_call.config``):
 
-- ``cache``: ``None`` (default, plain ``T.ptxd.ld``) or ``"nc"`` (load via
-  ``T.ptxd.ld.global_.nc``, i.e. PTX ``ld.global.nc``). Requires a global src.
+- ``cache``: ``None`` (default, plain ``T.ptx.ld``) or ``"nc"`` (load via
+  ``T.ptx.ld.global_.nc``, i.e. PTX ``ld.global.nc``). Requires a global src.
 - ``l1_evict`` / ``l2_evict`` / ``prefetch_size``: L1/L2 cache hint kwargs
-  forwarded verbatim to the emitted load (same values ``T.ptxd.ld`` /
-  ``T.ptxd.ld.global_.nc`` accept, e.g. ``"L1::no_allocate"``,
+  forwarded verbatim to the emitted load (same values ``T.ptx.ld`` /
+  ``T.ptx.ld.global_.nc`` accept, e.g. ``"L1::no_allocate"``,
   ``"L2::evict_first"``, ``"L2::256B"``). Requires a global src.
 
 Example::
@@ -41,7 +41,7 @@ from tvm.tirx.operator.tile_primitive.registry import DispatchContext
 from tvm.tirx.stmt import BufferRegion
 from tvm.tirx.tile_primitive import TilePrimitiveCall
 
-from ._common import copy_ptxd_form, copy_ptxd_ld_chain
+from ._common import copy_ptx_form, copy_ptx_ld_chain
 from .utils import _scope_allowed
 
 
@@ -75,7 +75,7 @@ def _ld_cache_config(op_call: TilePrimitiveCall) -> tuple[str | None, dict[str, 
     """Read the cache-semantics config from ``op_call.config``.
 
     Returns ``(cache, hints)``: ``cache`` is ``None`` or ``"nc"``, and
-    ``hints`` maps the ``T.ptxd.ld``/``T.ptxd.ld.global_.nc`` L1/L2 hint kwargs
+    ``hints`` maps the ``T.ptx.ld``/``T.ptx.ld.global_.nc`` L1/L2 hint kwargs
     (``l1_evict``, ``l2_evict``, ``prefetch_size``) to their string values.
     """
     cache = op_call.config.get("cache", None)
@@ -148,7 +148,7 @@ def _emit_forced_vec_copy(op_call: TilePrimitiveCall, _sctx: DispatchContext, nu
     src_ptr = src.ptr_to(_region_start(op_call.src))
     dst_ptr = dst.ptr_to(_region_start(op_call.dst))
     elem_bits = DataType(src.dtype).bits
-    tail, lanes, reg_dtype = copy_ptxd_form(num_bytes)
+    tail, lanes, reg_dtype = copy_ptx_form(num_bytes)
     container_bits = num_bytes * 8 // lanes
 
     def _words(buf, region):
@@ -179,7 +179,7 @@ def _emit_forced_vec_copy(op_call: TilePrimitiveCall, _sctx: DispatchContext, nu
     l1_evict = hints.get("l1_evict", "")
     l2_evict = hints.get("l2_evict", "")
     prefetch_size = hints.get("prefetch_size", "")
-    ld_chain = copy_ptxd_ld_chain(
+    ld_chain = copy_ptx_ld_chain(
         src_space,
         tail,
         nc=use_nc,
@@ -192,13 +192,13 @@ def _emit_forced_vec_copy(op_call: TilePrimitiveCall, _sctx: DispatchContext, nu
     @T.prim_func(check_well_formed=False)
     def impl():
         if src_is_local:
-            T.ptxd[st_chain](dst_ptr, *_words(src, op_call.src))
+            T.ptx[st_chain](dst_ptr, *_words(src, op_call.src))
         elif dst_is_local:
-            T.ptxd[ld_chain](*_words(dst, op_call.dst), src_ptr)
+            T.ptx[ld_chain](*_words(dst, op_call.dst), src_ptr)
         else:
             tmp = T.alloc_local((lanes,), reg_dtype)
-            T.ptxd[ld_chain](*[tmp[i] for i in range(lanes)], src_ptr)
-            T.ptxd[st_chain](dst_ptr, *[tmp[i] for i in range(lanes)])
+            T.ptx[ld_chain](*[tmp[i] for i in range(lanes)], src_ptr)
+            T.ptx[st_chain](dst_ptr, *[tmp[i] for i in range(lanes)])
     # fmt: on
     return impl
 

--- a/python/tvm/backend/cuda/tile_primitive/copy_async/dsmem.py
+++ b/python/tvm/backend/cuda/tile_primitive/copy_async/dsmem.py
@@ -155,15 +155,15 @@ def copy_dsmem_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFu
         # mapa writes its result into a declared register, so the mapped
         # addresses live in a small local scratch buffer.
         mapped = T.alloc_local([2], "uint64")
-        T.ptxd.mapa.u64(mapped[0], mbar, T.uint32(remote_cta_id))
+        T.ptx.mapa.u64(mapped[0], mbar, T.uint32(remote_cta_id))
         remote_mbar = mapped[0]
 
         if not outer_extents:
             # Single contiguous chunk — no iteration needed
             src_ptr = src_buf.ptr_to(src_st)
-            T.ptxd.mapa.u64(mapped[1], dst_buf.ptr_to(dst_st), T.uint32(remote_cta_id))
+            T.ptx.mapa.u64(mapped[1], dst_buf.ptr_to(dst_st), T.uint32(remote_cta_id))
             cluster_dst = mapped[1]
-            T.ptxd["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
+            T.ptx["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
                     T.cast(cluster_dst, "uint32"), src_ptr, T.cast(chunk_bytes, "uint32"),
                     T.cast(remote_mbar, "uint32"),
                 )
@@ -185,9 +185,9 @@ def copy_dsmem_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFu
                 )
 
                 src_ptr = src_buf_w.ptr_to(src_st)
-                T.ptxd.mapa.u64(mapped[1], dst_buf_w.ptr_to(dst_st), T.uint32(remote_cta_id))
+                T.ptx.mapa.u64(mapped[1], dst_buf_w.ptr_to(dst_st), T.uint32(remote_cta_id))
                 cluster_dst = mapped[1]
-                T.ptxd["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
+                T.ptx["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
                     T.cast(cluster_dst, "uint32"), src_ptr, T.cast(chunk_bytes, "uint32"),
                     T.cast(remote_mbar, "uint32"),
                 )

--- a/python/tvm/backend/cuda/tile_primitive/copy_async/ldgsts.py
+++ b/python/tvm/backend/cuda/tile_primitive/copy_async/ldgsts.py
@@ -25,7 +25,7 @@ emit time only:
 * direction: ``cp.async`` is global → shared only (hardware restriction).
 * cp_size: PTX ``cp.async`` only accepts 4 / 8 / 16 bytes, so the vec-width
   candidate set is restricted to ``{32, 64, 128}`` bits.
-* emit: one ``T.ptxd["cp.async..."]`` per slice instead of the synchronous
+* emit: one ``T.ptx["cp.async..."]`` per slice instead of the synchronous
   ``T.cuda.copy_{vec_bits}b(dst, src)``.
 * config: ``prefetch_size`` lands in the instruction spelling, ``predicate``
   rides ``pred=`` (@p), and ``fill_mode="zero"`` selects the src-size arity
@@ -68,7 +68,7 @@ _LDGSTS_VEC_BITS = (128, 64, 32)
 
 
 def _emit_cp_async(dst_ptr, src_ptr, cp_size, prefetch_size, predicate_expr, fill_mode):
-    """Emit one ptxd cp.async for the ldgsts configuration.
+    """Emit one ptx cp.async for the ldgsts configuration.
 
     fill_mode="zero" is the src-size arity (src-size = pred ? cp-size : 0,
     zero-filling the tail); a bare predicate rides pred= (@p); otherwise the
@@ -85,11 +85,11 @@ def _emit_cp_async(dst_ptr, src_ptr, cp_size, prefetch_size, predicate_expr, fil
     has_pred = not is_default
     if fill_mode == "zero":
         src_size = T.cast(if_then_else(predicate_expr != 0, int(cp_size), 0), "uint32")
-        T.evaluate(T.ptxd[chain](dst_ptr, src_ptr, int(cp_size), src_size))
+        T.evaluate(T.ptx[chain](dst_ptr, src_ptr, int(cp_size), src_size))
     elif has_pred:
-        T.evaluate(T.ptxd[chain](dst_ptr, src_ptr, int(cp_size), pred=predicate_expr))
+        T.evaluate(T.ptx[chain](dst_ptr, src_ptr, int(cp_size), pred=predicate_expr))
     else:
-        T.evaluate(T.ptxd[chain](dst_ptr, src_ptr, int(cp_size)))
+        T.evaluate(T.ptx[chain](dst_ptr, src_ptr, int(cp_size)))
 
 
 def _config_bool(value) -> bool:

--- a/python/tvm/backend/cuda/tile_primitive/copy_async/tcgen05_cp.py
+++ b/python/tvm/backend/cuda/tile_primitive/copy_async/tcgen05_cp.py
@@ -768,7 +768,7 @@ def copy_smem_tmem_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> Pr
     if total == 1:
         @T.prim_func(check_well_formed=False)
         def impl():
-            T.ptxd[cp_chain](T.cast(t_addr[0] + t_addr_off, "uint32"), _cp_desc(init_off_16B))
+            T.ptx[cp_chain](T.cast(t_addr[0] + t_addr_off, "uint32"), _cp_desc(init_off_16B))
     else:
         def compute_offsets(flat):
             t_off = 0
@@ -785,7 +785,7 @@ def copy_smem_tmem_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> Pr
         def impl():
             for flat in T.unroll(total):
                 t_off, s_off = T.meta_var(compute_offsets(flat))
-                T.ptxd[cp_chain](
+                T.ptx[cp_chain](
                     T.cast(t_addr[0] + t_addr_off + t_off, "uint32"),
                     _cp_desc(init_off_16B + s_off),
                 )

--- a/python/tvm/backend/cuda/tile_primitive/copy_async/tcgen05_ldst.py
+++ b/python/tvm/backend/cuda/tile_primitive/copy_async/tcgen05_ldst.py
@@ -483,7 +483,7 @@ def _tcgen05_ldst_emitter(is_load, shape, num):
 
     Returns the Call so a traced call site evaluates it; the two instructions
     mirror each other's operand order, which is why this is not just a chain
-    string. The tmem address is composed at the call site now -- ptxd is one
+    string. The tmem address is composed at the call site now -- ptx is one
     instruction per call, so the row/col packing the legacy helper did
     internally moves out to `T.cuda.get_tmem_addr`.
     """
@@ -496,7 +496,7 @@ def _tcgen05_ldst_emitter(is_load, shape, num):
             # Only compose when there is something to add: the packing is
             # (row << 16 | col), so a zero row and column leave the base alone.
             addr = T.cuda.get_tmem_addr(addr, row, col)
-        return T.ptxd[chain](*regs, addr) if is_load else T.ptxd[chain](addr, *regs)
+        return T.ptx[chain](*regs, addr) if is_load else T.ptx[chain](addr, *regs)
 
     return emit
 
@@ -574,9 +574,9 @@ def _emit_datapath_b_path(
 # When: one buffer is in tmem (tensor memory, Blackwell SM100+) and the other
 # is in local scope, at warpgroup exec scope.
 #
-# Emits: T.ptxd.tcgen05.ld / T.ptxd.tcgen05.st (async). The caller is
-# responsible for issuing the matching ``T.ptxd.tcgen05.wait__ld`` /
-# ``T.ptxd.tcgen05.wait__st`` when synchronization is required.
+# Emits: T.ptx.tcgen05.ld / T.ptx.tcgen05.st (async). The caller is
+# responsible for issuing the matching ``T.ptx.tcgen05.wait__ld`` /
+# ``T.ptx.tcgen05.wait__st`` when synchronization is required.
 @register_dispatch(
     "copy_async",
     "cuda",

--- a/python/tvm/backend/cuda/tile_primitive/copy_async/tma.py
+++ b/python/tvm/backend/cuda/tile_primitive/copy_async/tma.py
@@ -2085,7 +2085,7 @@ def _prefetch_main_descriptor(tensor_map, key: str, sctx: DispatchContext) -> No
     def prefetch_tensor_map():
         if warp_id == 0:
             if T.cuda.elect_sync() != T.uint32(0):
-                T.ptxd.prefetch.tensormap(T.address_of(tensor_map))
+                T.ptx.prefetch.tensormap(T.address_of(tensor_map))
         T.tvm_kernel_replace_point()
     # fmt: on
 
@@ -2150,7 +2150,7 @@ def _emit_plan(
                 args.append(T.cast(spec.cta_mask, "uint16"))
             if has_cache:
                 args.append(cache_policy)
-            T.evaluate(T.ptxd[chain](*args))
+            T.evaluate(T.ptx[chain](*args))
         else:
             if spec.use_tma_reduce is None:
                 chain = (
@@ -2165,7 +2165,7 @@ def _emit_plan(
             args = [tensor_map_address, *coords, shared_ptr]
             if has_cache:
                 args.append(cache_policy)
-            T.evaluate(T.ptxd[chain](*args))
+            T.evaluate(T.ptx[chain](*args))
 
     def shared_ptr(element_offset=0):
         # Keep the sliced offset in the pointer index instead of the Buffer's

--- a/python/tvm/backend/cuda/tile_primitive/elementwise/vec_emit/binary_f32x2.py
+++ b/python/tvm/backend/cuda/tile_primitive/elementwise/vec_emit/binary_f32x2.py
@@ -80,11 +80,11 @@ def _emit_binary_f32x2_for(op_name):
         rm = extras.get("rounding_mode", "rz")
         lhs = T.local_scalar("uint64")
         rhs = T.local_scalar("uint64")
-        T.evaluate(T.ptxd.mov.b64(lhs, _lane(a_arg, 0), _lane(a_arg, 1)))
-        T.evaluate(T.ptxd.mov.b64(rhs, _lane(b_arg, 0), _lane(b_arg, 1)))
-        T.evaluate(T.ptxd[f"{op_name}.{rm}.ftz.f32x2"](lhs, lhs, rhs))
+        T.evaluate(T.ptx.mov.b64(lhs, _lane(a_arg, 0), _lane(a_arg, 1)))
+        T.evaluate(T.ptx.mov.b64(rhs, _lane(b_arg, 0), _lane(b_arg, 1)))
+        T.evaluate(T.ptx[f"{op_name}.{rm}.ftz.f32x2"](lhs, lhs, rhs))
         T.evaluate(
-            T.ptxd.mov.b64(
+            T.ptx.mov.b64(
                 dst_buf[tuple(dst_lane_indices[0])],
                 dst_buf[tuple(dst_lane_indices[1])],
                 lhs,

--- a/python/tvm/backend/cuda/tile_primitive/elementwise/vec_emit/fma_f32x2.py
+++ b/python/tvm/backend/cuda/tile_primitive/elementwise/vec_emit/fma_f32x2.py
@@ -65,12 +65,12 @@ def _emit_fma_f32x2(dst_buf, dst_lane_indices, src_args, extras) -> None:
     pa = T.local_scalar("uint64")
     pb = T.local_scalar("uint64")
     pc = T.local_scalar("uint64")
-    T.evaluate(T.ptxd.mov.b64(pa, _lane(a_arg, 0), _lane(a_arg, 1)))
-    T.evaluate(T.ptxd.mov.b64(pb, _lane(b_arg, 0), _lane(b_arg, 1)))
-    T.evaluate(T.ptxd.mov.b64(pc, _lane(c_arg, 0), _lane(c_arg, 1)))
-    T.evaluate(T.ptxd[f"fma.{rm}.ftz.f32x2"](pa, pa, pb, pc))
+    T.evaluate(T.ptx.mov.b64(pa, _lane(a_arg, 0), _lane(a_arg, 1)))
+    T.evaluate(T.ptx.mov.b64(pb, _lane(b_arg, 0), _lane(b_arg, 1)))
+    T.evaluate(T.ptx.mov.b64(pc, _lane(c_arg, 0), _lane(c_arg, 1)))
+    T.evaluate(T.ptx[f"fma.{rm}.ftz.f32x2"](pa, pa, pb, pc))
     T.evaluate(
-        T.ptxd.mov.b64(
+        T.ptx.mov.b64(
             dst_buf[tuple(dst_lane_indices[0])],
             dst_buf[tuple(dst_lane_indices[1])],
             pa,

--- a/python/tvm/backend/cuda/tile_primitive/gemm/mma_m16n8k_.py
+++ b/python/tvm/backend/cuda/tile_primitive/gemm/mma_m16n8k_.py
@@ -534,7 +534,7 @@ def gemm_cuda_mma_dispatch(op: TilePrimitiveCall, sctx: DispatchContext) -> Prim
     M_tiles, N_tiles, K_tiles = d_shape[0], d_shape[1], a_shape[1]
     shape_str = f"m{inst.m}n{inst.n}k{inst.k}"
     a_type, b_type, c_type, d_type = inst.dtype
-    # The ptxd chain is built here: a Python string bound inside the traced
+    # The ptx chain is built here: a Python string bound inside the traced
     # body is not something the parser can carry. PTX names the element format
     # of each matrix, which is not the TVM dtype of the register buffer.
     _PTX_ELEM = {"float16": "f16", "bfloat16": "bf16", "float32": "f32"}
@@ -587,6 +587,6 @@ def gemm_cuda_mma_dispatch(op: TilePrimitiveCall, sctx: DispatchContext) -> Prim
                     # B: b32 regs in PTX order b32 = kHi.
                     b_regs = [b_words[k, n, kHi, 0] for kHi in range(n_kHi)]
                     # Accumulate in place into D's own regs: c = d.
-                    T.ptxd[mma_chain](*d_regs, *a_regs, *b_regs, *d_regs)
+                    T.ptx[mma_chain](*d_regs, *a_regs, *b_regs, *d_regs)
 
     return impl

--- a/python/tvm/backend/cuda/tile_primitive/gemm_async/tcgen05.py
+++ b/python/tvm/backend/cuda/tile_primitive/gemm_async/tcgen05.py
@@ -111,7 +111,7 @@ def _encode_instr_descriptor_dense_uint32(
 
     See ``python/tvm/tirx/operator/intrinsics/cuda/header.py:InstrDescriptor``
     for the bit layout. Lets the dispatcher pass a literal ``uint32`` to
-    ``T.ptxd["tcgen05.mma..."]`` instead of allocating + encoding a per-dispatch
+    ``T.ptx["tcgen05.mma..."]`` instead of allocating + encoding a per-dispatch
     local descriptor on every gemm_async call (which forces an inline ``asm``
     block that ptxas cannot hoist out of the i_kv loop body).
 
@@ -1340,7 +1340,7 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
     # and uses rows 64-127 for the other half.
     N_mma_phys_cols = N_mma // 2 if is_2x2 or packed_n2 else N_mma
 
-    # The ptxd instruction spelling, resolved once from the trace-time dtypes.
+    # The ptx instruction spelling, resolved once from the trace-time dtypes.
     if is_block_scaled:
         _bs_kind = _get_tcgen05_mma_kind(C_type, A_type, B_type, SFA_type, SFB_type)
         _bs_vec = _get_tcgen05_mma_scale_vec_size(_bs_kind, SFA_type)
@@ -1364,9 +1364,9 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
         if a_is_tmem:
             a_val = T.cast(a_val, "uint32")
         if weight_stationary:
-            T.evaluate(T.ptxd[mma_chain](d_addr, a_val, b_val, i_val, accum, 0))
+            T.evaluate(T.ptx[mma_chain](d_addr, a_val, b_val, i_val, accum, 0))
         else:
-            T.evaluate(T.ptxd[mma_chain](d_addr, a_val, b_val, i_val, *_mma_zero_masks, accum))
+            T.evaluate(T.ptx[mma_chain](d_addr, a_val, b_val, i_val, *_mma_zero_masks, accum))
 
     # Build main_impl: descA_in is None when A is in TMEM (ignored by _a_operand).
     # fmt: off
@@ -1413,7 +1413,7 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
                         tmem_lane_offset + (0 if M_tiles == 1 else mi * M_mma)
                     )
                     if elect_pred:
-                        T.evaluate(T.ptxd[mma_chain](
+                        T.evaluate(T.ptx[mma_chain](
                             T.cast(_get_tmem_addr_fast(tmem_addr, tmem_row, tmem_col), "uint32"),
                             T.cast(a_val, "uint32") if a_is_tmem else a_val,
                             descB_val, descI_in,
@@ -1580,7 +1580,7 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
 #     T.cuda.tcgen05.encode_instr_descriptor(
 #         &descI_local, C_type="f32", A_type="f16", B_type="f16",
 #         M=64, N=256, MMA_K=64, transA=False, transB=True, cta_group=1)
-#     T.ptxd[mma_chain](..., descA_buf[0], descB_buf[0], descI_local, ...)
+#     T.ptx[mma_chain](..., descA_buf[0], descB_buf[0], descI_local, ...)
 #
 # Before (TilePrimitiveCall — block-scaled fp8 MMA):
 #     Tx.gemm_async(C_tmem, A_smem, B_smem,
@@ -1588,7 +1588,7 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
 #     # A/B: shared float8_e4m3, SFA/SFB: tmem float8_e8m0fnu
 #
 # After (adds scale factor descriptors):
-#     T.ptxd[mma_chain](..., descA, descB, descI,
+#     T.ptx[mma_chain](..., descA, descB, descI,
 #                        scale_A=sfA_desc, scale_B=sfB_desc)
 #
 # Scale factor layout (sf_tmem_layout) must match tcgen05 hardware requirements:

--- a/python/tvm/backend/cuda/tile_primitive/permute_layout/warp_xor_swizzle.py
+++ b/python/tvm/backend/cuda/tile_primitive/permute_layout/warp_xor_swizzle.py
@@ -339,7 +339,7 @@ def _impl(op_call, sctx):
                 iter_idx = T.meta_var(get_indices(flat, [0] * len(extent), extent))
                 off = T.meta_var(_iter_off(iter_idx, src_str_))
                 ptr = T.meta_var(T.ptr_byte_offset(base_src, off * dtype_bytes, dtype))
-                T.ptxd[ld_chain](regs[r], ptr)
+                T.ptx[ld_chain](regs[r], ptr)
             T.cuda.warp_sync()
             # Phase 2: write via L_dst
             for r in T.unroll(0, P):
@@ -348,7 +348,7 @@ def _impl(op_call, sctx):
                 iter_idx = T.meta_var(get_indices(flat, [0] * len(extent), extent))
                 off = T.meta_var(_iter_off(iter_idx, dst_str_))
                 ptr = T.meta_var(T.ptr_byte_offset(base_dst, off * dtype_bytes, dtype))
-                T.ptxd[st_chain](ptr, regs[r])
+                T.ptx[st_chain](ptr, regs[r])
             T.cuda.warp_sync()
     else:
         @T.prim_func

--- a/python/tvm/backend/cuda/tile_primitive/reduction/sm100_packed.py
+++ b/python/tvm/backend/cuda/tile_primitive/reduction/sm100_packed.py
@@ -107,34 +107,34 @@ def _emit_reduction_local_thread_packed_add_sum(
         # Process remaining full chunks of 8
         for outer in T.serial(num_full_chunks - 1):
             for j in T.unroll(4):
-                T.ptxd.mov.b64(acc, local_sum[2 * j], local_sum[2 * j + 1])
-                T.ptxd.mov.b64(
+                T.ptx.mov.b64(acc, local_sum[2 * j], local_sum[2 * j + 1])
+                T.ptx.mov.b64(
                     rhs,
                     src[src_base + 8 * (outer + 1) + 2 * j],
                     src[src_base + 8 * (outer + 1) + 2 * j + 1],
                 )
-                T.ptxd.add.rn.ftz.f32x2(acc, acc, rhs)
-                T.ptxd.mov.b64(local_sum[2 * j], local_sum[2 * j + 1], acc)
+                T.ptx.add.rn.ftz.f32x2(acc, acc, rhs)
+                T.ptx.mov.b64(local_sum[2 * j], local_sum[2 * j + 1], acc)
 
         # Handle remainder elements (0 to 7)
         for i in T.serial(remainder):
             local_sum[0] = local_sum[0] + src[src_base + remainder_base + i]
 
         # Final packed add sum: 8 -> 4 -> 2 -> 1
-        T.ptxd.mov.b64(acc, local_sum[0], local_sum[1])
-        T.ptxd.mov.b64(rhs, local_sum[2], local_sum[3])
-        T.ptxd.add.rn.ftz.f32x2(acc, acc, rhs)
-        T.ptxd.mov.b64(local_sum[0], local_sum[1], acc)
+        T.ptx.mov.b64(acc, local_sum[0], local_sum[1])
+        T.ptx.mov.b64(rhs, local_sum[2], local_sum[3])
+        T.ptx.add.rn.ftz.f32x2(acc, acc, rhs)
+        T.ptx.mov.b64(local_sum[0], local_sum[1], acc)
 
-        T.ptxd.mov.b64(acc, local_sum[4], local_sum[5])
-        T.ptxd.mov.b64(rhs, local_sum[6], local_sum[7])
-        T.ptxd.add.rn.ftz.f32x2(acc, acc, rhs)
-        T.ptxd.mov.b64(local_sum[4], local_sum[5], acc)
+        T.ptx.mov.b64(acc, local_sum[4], local_sum[5])
+        T.ptx.mov.b64(rhs, local_sum[6], local_sum[7])
+        T.ptx.add.rn.ftz.f32x2(acc, acc, rhs)
+        T.ptx.mov.b64(local_sum[4], local_sum[5], acc)
 
-        T.ptxd.mov.b64(acc, local_sum[0], local_sum[1])
-        T.ptxd.mov.b64(rhs, local_sum[4], local_sum[5])
-        T.ptxd.add.rn.ftz.f32x2(acc, acc, rhs)
-        T.ptxd.mov.b64(local_sum[0], local_sum[1], acc)
+        T.ptx.mov.b64(acc, local_sum[0], local_sum[1])
+        T.ptx.mov.b64(rhs, local_sum[4], local_sum[5])
+        T.ptx.add.rn.ftz.f32x2(acc, acc, rhs)
+        T.ptx.mov.b64(local_sum[0], local_sum[1], acc)
 
         dst[tuple(dst_st)] = local_sum[0] + local_sum[1]
     # fmt: on
@@ -176,14 +176,14 @@ def _emit_reduction_local_thread_3input_maxmin(
         # First pass: process first 8 elements into 4 temps
         for i in T.unroll(4):
             if accum and i == 0:
-                T.ptxd[f"{reduce3_name}.f32"](temp[i], src[src_base + 2 * i], src[src_base + 2 * i + 1], dst[tuple(dst_st)])  # noqa: E501
+                T.ptx[f"{reduce3_name}.f32"](temp[i], src[src_base + 2 * i], src[src_base + 2 * i + 1], dst[tuple(dst_st)])  # noqa: E501
             else:
                 temp[i] = op_func(src[src_base + 2 * i], src[src_base + 2 * i + 1])
 
         # Process remaining full chunks of 8
         for outer in T.serial(num_full_chunks - 1):
             for i in T.unroll(4):
-                T.ptxd[f"{reduce3_name}.f32"](
+                T.ptx[f"{reduce3_name}.f32"](
                     temp[i],
                     temp[i],
                     src[src_base + 8 * (outer + 1) + 2 * i],
@@ -196,7 +196,7 @@ def _emit_reduction_local_thread_3input_maxmin(
 
         # Final merge: combine 4 temps into result
         dst[tuple(dst_st)] = op_func(temp[0], temp[1])
-        T.ptxd[f"{reduce3_name}.f32"](dst[tuple(dst_st)], dst[tuple(dst_st)], temp[2], temp[3])
+        T.ptx[f"{reduce3_name}.f32"](dst[tuple(dst_st)], dst[tuple(dst_st)], temp[2], temp[3])
     # fmt: on
 
     return impl

--- a/python/tvm/script/tirx.pyi
+++ b/python/tvm/script/tirx.pyi
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Generated stub for T.ptxd — do not edit.
+"""Generated stub for T.ptx — do not edit.
 
 Regenerate:
   python -m tvm.backend.cuda.ptx_dialect.gen_stubs -o python/tvm/script/tirx.pyi
@@ -945,7 +945,7 @@ class _Chain_wgmma:
     wait_group: _Chain_wgmma
     def __call__(self, *args: Any, pred: Any = None) -> None: ...
 
-class _PTXD:
+class _PTX:
     add: _Chain_add
     atom: _Chain_atom
     bar: _Chain_bar
@@ -981,7 +981,7 @@ class _PTXD:
     wgmma: _Chain_wgmma
     def __getitem__(self, text: str) -> Any: ...
 
-ptxd: _PTXD
+ptx: _PTX
 
 # Every other tvm.script.tirx member stays dynamically typed, as before.
 def __getattr__(name: str) -> Any: ...

--- a/src/backend/cuda/codegen/codegen_cuda.cc
+++ b/src/backend/cuda/codegen/codegen_cuda.cc
@@ -1569,9 +1569,9 @@ void CodeGenCUDA::VisitStmt_(const AttrStmtNode* op) {
     TVM_FFI_ICHECK(queue_id && queue_id->value == 0)
         << "For CUDA, the index of an async queue must be 0.";
     this->VisitStmt(op->body);
-    static const Op& ptxd_cp_async_commit_group_op = Op::Get("tirx.ptxd.cp_async_commit_group");
-    // ptxd Call layout: [operands...] [slot tokens] [pred marker ""].
-    auto commit_group = Call(PrimType::Void(), ptxd_cp_async_commit_group_op,
+    static const Op& ptx_cp_async_commit_group_op = Op::Get("tirx.ptx.cp_async_commit_group");
+    // ptx Call layout: [operands...] [slot tokens] [pred marker ""].
+    auto commit_group = Call(PrimType::Void(), ptx_cp_async_commit_group_op,
                              {StringImm("async"), StringImm("commit_group"), StringImm("")})
                             .as_or_throw<PrimExpr>();
     this->PrintIndent();
@@ -1584,11 +1584,11 @@ void CodeGenCUDA::VisitStmt_(const AttrStmtNode* op) {
     TVM_FFI_ICHECK(queue_id && queue_id->value == 0)
         << "For CUDA, the index of an async queue must be 0.";
     auto wait_cnt = wait_attrs.second;
-    static const Op& ptxd_cp_async_wait_group_op = Op::Get("tirx.ptxd.cp_async_wait_group");
-    // ptxd Call layout: [operands...] [slot tokens] [pred marker ""]. The group
+    static const Op& ptx_cp_async_wait_group_op = Op::Get("tirx.ptx.cp_async_wait_group");
+    // ptx Call layout: [operands...] [slot tokens] [pred marker ""]. The group
     // count is a role="imm" operand baked into the instruction text, so it must
     // already be a compile-time constant here (the pipeline pass guarantees it).
-    auto wait_group = Call(PrimType::Void(), ptxd_cp_async_wait_group_op,
+    auto wait_group = Call(PrimType::Void(), ptx_cp_async_wait_group_op,
                            {wait_cnt, StringImm("async"), StringImm("wait_group"), StringImm("")})
                           .as_or_throw<PrimExpr>();
     this->PrintIndent();

--- a/src/backend/cuda/op/target_builtin.cc
+++ b/src/backend/cuda/op/target_builtin.cc
@@ -86,7 +86,7 @@ OpRegEntry::RegisterOrGet("tirx.s_tir.ldg32")
     .set_attr<TDeviceIntrinsicNamespace>("TDeviceIntrinsicNamespace", ffi::String("s_tir"), 10);
 
 // Raw legacy cp.async form emitted by InjectPTXAsyncCopy (and round-tripped by
-// the T.ptx.cp_async 6-arg surface). It carries the element dtype in Call.dtype
+// the T.s_tir.cp_async_raw.legacy 6-arg surface). It carries the element dtype in Call.dtype
 // and prints it dtype-first; user-issued copies go through T.ptx instead.
 OpRegEntry::RegisterOrGet("tirx.s_tir.cp_async_raw")
     .set_name()

--- a/src/backend/cuda/op/target_builtin.cc
+++ b/src/backend/cuda/op/target_builtin.cc
@@ -87,7 +87,7 @@ OpRegEntry::RegisterOrGet("tirx.s_tir.ldg32")
 
 // Raw legacy cp.async form emitted by InjectPTXAsyncCopy (and round-tripped by
 // the T.ptx.cp_async 6-arg surface). It carries the element dtype in Call.dtype
-// and prints it dtype-first; user-issued copies go through T.ptxd instead.
+// and prints it dtype-first; user-issued copies go through T.ptx instead.
 OpRegEntry::RegisterOrGet("tirx.s_tir.cp_async_raw")
     .set_name()
     .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))

--- a/src/s_tir/transform/inject_permuted_layout.cc
+++ b/src/s_tir/transform/inject_permuted_layout.cc
@@ -284,7 +284,7 @@ class PermutedLayoutInjector : private IRMutatorWithAnalyzer {
     }
 
     if (call->op.same_as(ptx_ldmatrix_op)) {
-      // form: T.ptx.ldmatrix_legacy(..., smem_ptr, smem_offset)
+      // form: T.ptx_legacy.ldmatrix(..., smem_ptr, smem_offset)
       // smem_ptr: T.tvm_access_ptr(ptype, data, offset, extent, rw_mask)
       Expr access_ptr = call->args[5];
       PrimExpr smem_offset = call->args[6].as_or_throw<PrimExpr>();

--- a/tests/python/s_tir/transform/test_s_tir_transform_inject_ptx_async_copy.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_inject_ptx_async_copy.py
@@ -241,17 +241,17 @@ expected_cuda_script = r"""#include <cuda.h>
   #define uchar unsigned char
   #define ushort unsigned short
 #endif
-__forceinline__ __device__ void tvm_builtin_ptxd_cp_async_wait_group_async_wait_group_0() {
+__forceinline__ __device__ void tvm_builtin_ptx_cp_async_wait_group_async_wait_group_0() {
   asm volatile("cp.async.wait_group 0;" :  :  : "memory");
 }
-__forceinline__ __device__ void tvm_builtin_ptxd_cp_async_wait_group_async_wait_group_1() {
+__forceinline__ __device__ void tvm_builtin_ptx_cp_async_wait_group_async_wait_group_1() {
   asm volatile("cp.async.wait_group 1;" :  :  : "memory");
 }
-__forceinline__ __device__ void tvm_builtin_ptxd_cp_async_wait_group_async_wait_group_5() {
-  asm volatile("cp.async.wait_group 5;" :  :  : "memory");
-}
-__forceinline__ __device__ void tvm_builtin_ptxd_cp_async_wait_group_async_wait_group_2() {
+__forceinline__ __device__ void tvm_builtin_ptx_cp_async_wait_group_async_wait_group_2() {
   asm volatile("cp.async.wait_group 2;" :  :  : "memory");
+}
+__forceinline__ __device__ void tvm_builtin_ptx_cp_async_wait_group_async_wait_group_5() {
+  asm volatile("cp.async.wait_group 5;" :  :  : "memory");
 }
 
 __forceinline__ __device__ void ptx_cp_async_legacy_pred_ca_4_4_4(void* dst, int dst_off, void* src, int src_off, int predicate) {
@@ -276,7 +276,7 @@ __forceinline__ __device__ void ptx_cp_async_legacy_ca_4_4_4(void* dst, int dst_
   asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
     :: "r"(dst_addr), "l"(src_p), "n"(4));
 }
-__forceinline__ __device__ void tvm_builtin_ptxd_cp_async_commit_group_async_commit_group() {
+__forceinline__ __device__ void tvm_builtin_ptx_cp_async_commit_group_async_commit_group() {
   asm volatile("cp.async.commit_group;" :  : );
 }
 extern "C" __global__ void __launch_bounds__(16) main_kernel(float* __restrict__ A_ptr, float* __restrict__ B_ptr, float* __restrict__ C_ptr);
@@ -285,38 +285,38 @@ extern "C" __global__ void __launch_bounds__(16) main_kernel(float* __restrict__
   __shared__ alignas(64) float B_shared_ptr[64];
   A_shared_ptr[((int)threadIdx.x)] = 0x0p+0f/*0.000000e+00*/;
   B_shared_ptr[((int)threadIdx.x)] = 0x0p+0f/*0.000000e+00*/;
-  tvm_builtin_ptxd_cp_async_commit_group_async_commit_group();
+  tvm_builtin_ptx_cp_async_commit_group_async_commit_group();
   int cse_v1 = (((int)threadIdx.x) * 14);
   int cse_v2 = (((int)threadIdx.x) + 16);
   ptx_cp_async_legacy_ca_4_4_4(A_shared_ptr, (((int)threadIdx.x) + 16), A_ptr, (((int)threadIdx.x) * 14));
   ptx_cp_async_legacy_ca_4_4_4(B_shared_ptr, (((int)threadIdx.x) + 16), B_ptr, (((int)threadIdx.x) * 14));
-  tvm_builtin_ptxd_cp_async_commit_group_async_commit_group();
+  tvm_builtin_ptx_cp_async_commit_group_async_commit_group();
   int cse_v3 = (((int)threadIdx.x) + 32);
   int cse_v6 = ((((int)threadIdx.x) * 14) + 1);
   ptx_cp_async_legacy_ca_4_4_4(A_shared_ptr, (((int)threadIdx.x) + 32), A_ptr, ((((int)threadIdx.x) * 14) + 1));
   ptx_cp_async_legacy_ca_4_4_4(B_shared_ptr, (((int)threadIdx.x) + 32), B_ptr, ((((int)threadIdx.x) * 14) + 1));
-  tvm_builtin_ptxd_cp_async_commit_group_async_commit_group();
+  tvm_builtin_ptx_cp_async_commit_group_async_commit_group();
   int cse_v4 = (((int)threadIdx.x) * 16);
   for (int i = 0; i < 13; ++i) {
     int cse_v7 = (((((int)threadIdx.x) * 14) + i) + 2);
     int cse_v9 = ((((i + 3) & 3) * 16) + ((int)threadIdx.x));
     ptx_cp_async_legacy_pred_ca_4_4_4(A_shared_ptr, ((((i + 3) & 3) * 16) + ((int)threadIdx.x)), A_ptr, (((((int)threadIdx.x) * 14) + i) + 2), (i < 12));
-    tvm_builtin_ptxd_cp_async_commit_group_async_commit_group();
-    tvm_builtin_ptxd_cp_async_wait_group_async_wait_group_5();
+    tvm_builtin_ptx_cp_async_commit_group_async_commit_group();
+    tvm_builtin_ptx_cp_async_wait_group_async_wait_group_5();
     __syncthreads();
     int cse_v8 = (((i & 3) * 16) + ((int)threadIdx.x));
     C_ptr[((((int)threadIdx.x) * 16) + i)] = (A_shared_ptr[(((i & 3) * 16) + ((int)threadIdx.x))] + B_shared_ptr[(((i & 3) * 16) + ((int)threadIdx.x))]);
     __syncthreads();
     ptx_cp_async_legacy_pred_ca_4_4_4(B_shared_ptr, ((((i + 3) & 3) * 16) + ((int)threadIdx.x)), B_ptr, (((((int)threadIdx.x) * 14) + i) + 2), (i < 12));
-    tvm_builtin_ptxd_cp_async_commit_group_async_commit_group();
+    tvm_builtin_ptx_cp_async_commit_group_async_commit_group();
   }
-  tvm_builtin_ptxd_cp_async_wait_group_async_wait_group_2();
+  tvm_builtin_ptx_cp_async_wait_group_async_wait_group_2();
   __syncthreads();
   C_ptr[((((int)threadIdx.x) * 16) + 13)] = (A_shared_ptr[(((int)threadIdx.x) + 16)] + B_shared_ptr[(((int)threadIdx.x) + 16)]);
-  tvm_builtin_ptxd_cp_async_wait_group_async_wait_group_1();
+  tvm_builtin_ptx_cp_async_wait_group_async_wait_group_1();
   __syncthreads();
   C_ptr[((((int)threadIdx.x) * 16) + 14)] = (A_shared_ptr[(((int)threadIdx.x) + 32)] + B_shared_ptr[(((int)threadIdx.x) + 32)]);
-  tvm_builtin_ptxd_cp_async_wait_group_async_wait_group_0();
+  tvm_builtin_ptx_cp_async_wait_group_async_wait_group_0();
   __syncthreads();
   int cse_v5 = (((int)threadIdx.x) + 48);
   C_ptr[((((int)threadIdx.x) * 16) + 15)] = (A_shared_ptr[(((int)threadIdx.x) + 48)] + B_shared_ptr[(((int)threadIdx.x) + 48)]);

--- a/tests/python/s_tir/transform/test_s_tir_transform_inject_ptx_async_copy.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_inject_ptx_async_copy.py
@@ -77,8 +77,8 @@ def generate_global_to_shared_vectorized_copy(dtype, vector_size):
                 for j in T.vectorized(vector_size):
                     A_shared[tx, i * vector_size_expr + j] = A[tx, i * vector_size_expr + j]
 
-            T.evaluate(T.ptxd.cp.async_.commit_group())
-            T.evaluate(T.ptxd.cp.async_.wait_group(0))
+            T.evaluate(T.ptx.cp.async_.commit_group())
+            T.evaluate(T.ptx.cp.async_.wait_group(0))
 
             for i in range(128):
                 B[tx, i] = A_shared[tx, i]
@@ -104,8 +104,8 @@ def ptx_global_to_shared_copy_fp32x1(
         for i in T.serial(128):
             A_shared[tx, i] = A[tx, i]
 
-        T.evaluate(T.ptxd.cp.async_.commit_group())
-        T.evaluate(T.ptxd.cp.async_.wait_group(0))
+        T.evaluate(T.ptx.cp.async_.commit_group())
+        T.evaluate(T.ptx.cp.async_.wait_group(0))
 
         for i in range(128):
             B[tx, i] = A_shared[tx, i]
@@ -134,8 +134,8 @@ def ptx_global_to_shared_dyn_copy_fp16x8(
                 A_shared[tx, i * 8 + j] = A[tx, i * 8 + j]
                 B_shared[tx, i * 8 + j] = B[tx, i * 8 + j]
 
-        T.evaluate(T.ptxd.cp.async_.commit_group())
-        T.evaluate(T.ptxd.cp.async_.wait_group(0))
+        T.evaluate(T.ptx.cp.async_.commit_group())
+        T.evaluate(T.ptx.cp.async_.wait_group(0))
 
         for i in range(128):
             C[tx, i] = A_shared[tx, i] + B_shared[tx, i]
@@ -907,8 +907,8 @@ def test_multiplication_nodes_are_inlined():
                 A_shared[T.Ramp(tx * T.int64(128) + cse_v1 * T.int64(8), T.int64(1), 8)] = (
                     A_flattened[T.Ramp(tx * T.int64(128) + cse_v1 * T.int64(8), T.int64(1), 8)]
                 )
-            T.ptxd.cp.async_.commit_group()
-            T.ptxd.cp.async_.wait_group(0)
+            T.ptx.cp.async_.commit_group()
+            T.ptx.cp.async_.wait_group(0)
 
     @I.ir_module(s_tir=True)
     class Expected:
@@ -927,8 +927,8 @@ def test_multiplication_nodes_are_inlined():
                     tx * T.int64(128) + cse_v1 * T.int64(8),
                     16,
                 )
-            T.ptxd.cp.async_.commit_group()
-            T.ptxd.cp.async_.wait_group(0)
+            T.ptx.cp.async_.commit_group()
+            T.ptx.cp.async_.wait_group(0)
 
     After = tvm.s_tir.transform.InjectPTXAsyncCopy()(Before)
     tvm.ir.assert_structural_equal(After, Expected)

--- a/tests/python/tirx-base/test_tir_ptx_cp_async.py
+++ b/tests/python/tirx-base/test_tir_ptx_cp_async.py
@@ -44,8 +44,8 @@ def ptx_cp_async(A: T.Buffer((32, 128), "float16"), B: T.Buffer((32, 128), "floa
             )
 
         # TODO(masahi): Remove dtype requirement from TVMScript parser
-        T.evaluate(T.ptxd.cp.async_.commit_group())
-        T.evaluate(T.ptxd.cp.async_.wait_group(0))
+        T.evaluate(T.ptx.cp.async_.commit_group())
+        T.evaluate(T.ptx.cp.async_.wait_group(0))
 
         for i in range(128):
             B[tx, i] = A_shared[tx, i]

--- a/tests/python/tirx-base/test_tir_ptx_griddepcontrol.py
+++ b/tests/python/tirx-base/test_tir_ptx_griddepcontrol.py
@@ -34,9 +34,9 @@ def ptx_griddepcontrol(A: T.Buffer((32,), "float32"), B: T.Buffer((32,), "float3
     with T.sblock():
         T.reads(A[0:32])
         T.writes(B[0:32])
-        T.ptxd.griddepcontrol.wait()
+        T.ptx.griddepcontrol.wait()
         B[tx] = A[tx]
-        T.ptxd.griddepcontrol.launch_dependents()
+        T.ptx.griddepcontrol.launch_dependents()
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx-base/test_tir_ptx_mma_sp.py
+++ b/tests/python/tirx-base/test_tir_ptx_mma_sp.py
@@ -73,7 +73,7 @@ def mma_sp_m16n8k16_f16f16f16(a: T.handle, b: T.handle, c: T.handle, _metadata: 
     a_words = T.decl_buffer([2], "uint32", data=multi_a.data, scope="local")
     b_words = T.decl_buffer([2], "uint32", data=multi_b.data, scope="local")
     acc_words = T.decl_buffer([2], "uint32", data=accum.data, scope="local")
-    T.ptxd.mma.sp.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16(
+    T.ptx.mma.sp.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16(
         acc_words[0],
         acc_words[1],
         a_words[0],
@@ -120,7 +120,7 @@ def mma_sp_m16n8k16_f16f16f32(a: T.handle, b: T.handle, c: T.handle, _metadata: 
 
     a_words = T.decl_buffer([2], "uint32", data=multi_a.data, scope="local")
     b_words = T.decl_buffer([2], "uint32", data=multi_b.data, scope="local")
-    T.ptxd.mma.sp.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32(
+    T.ptx.mma.sp.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32(
         accum[0],
         accum[1],
         accum[2],
@@ -172,7 +172,7 @@ def mma_sp_m16n8k32_f16f16f16(a: T.handle, b: T.handle, c: T.handle, _metadata: 
     a_words = T.decl_buffer([4], "uint32", data=multi_a.data, scope="local")
     b_words = T.decl_buffer([4], "uint32", data=multi_b.data, scope="local")
     acc_words = T.decl_buffer([2], "uint32", data=accum.data, scope="local")
-    T.ptxd.mma.sp.sync.aligned.m16n8k32.row.col.f16.f16.f16.f16(
+    T.ptx.mma.sp.sync.aligned.m16n8k32.row.col.f16.f16.f16.f16(
         acc_words[0],
         acc_words[1],
         a_words[0],
@@ -223,7 +223,7 @@ def mma_sp_m16n8k32_f16f16f32(a: T.handle, b: T.handle, c: T.handle, _metadata: 
 
     a_words = T.decl_buffer([4], "uint32", data=multi_a.data, scope="local")
     b_words = T.decl_buffer([4], "uint32", data=multi_b.data, scope="local")
-    T.ptxd.mma.sp.sync.aligned.m16n8k32.row.col.f32.f16.f16.f32(
+    T.ptx.mma.sp.sync.aligned.m16n8k32.row.col.f32.f16.f16.f32(
         accum[0],
         accum[1],
         accum[2],

--- a/tests/python/tirx-base/test_tir_ptx_scalar_f32_math.py
+++ b/tests/python/tirx-base/test_tir_ptx_scalar_f32_math.py
@@ -40,9 +40,9 @@ def ptx_scalar_f32_math(
     with T.sblock():
         T.reads(A[0:32], B[0:32])
         T.writes(C_add[0:32], C_mul[0:32], C_max[0:32])
-        T.ptxd.add.rn.f32(C_add[tx], A[tx], B[tx])
-        T.ptxd.mul.rn.f32(C_mul[tx], A[tx], B[tx])
-        T.ptxd.max.f32(C_max[tx], A[tx], B[tx])
+        T.ptx.add.rn.f32(C_add[tx], A[tx], B[tx])
+        T.ptx.mul.rn.f32(C_mul[tx], A[tx], B[tx])
+        T.ptx.max.f32(C_max[tx], A[tx], B[tx])
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/codegen/test_codegen_ampere.py
+++ b/tests/python/tirx/codegen/test_codegen_ampere.py
@@ -17,7 +17,7 @@
 # pylint: disable=missing-function-docstring
 """Codegen tests for Ampere (sm_80) warp-level ``mma.sync`` tensor cores.
 
-These exercise the ``T.ptxd.mma`` chain directly (not via the gemm
+These exercise the ``T.ptx.mma`` chain directly (not via the gemm
 dispatch). ``ptx.mma`` takes one pointer per 32-bit register for each operand
 (``d_ptrs`` / ``a_ptrs`` / ``b_ptrs`` / ``c_ptrs``), enumerated in the fixed
 PTX register order, so the b32 registers may be scattered in the register file
@@ -127,12 +127,12 @@ def test_ptx_mma_m16n8k16(a_type, no_c_ptr):
         # multiplicands are packed two per b32, so they ride a uint32 view.
         A_words = A_local.view("uint32")
         B_words = B_local.view("uint32")
-        # ptxd takes the accumulator as an operand; the legacy "omit c" form
+        # ptx takes the accumulator as an operand; the legacy "omit c" form
         # fed literal zeros, which is now spelled at the call site.
         if no_c_ptr:
             for i in range(4):
                 C_local[i] = T.float32(0)
-        T.ptxd[f"mma.sync.aligned.m16n8k16.row.col.f32.{_elem}.{_elem}.f32"](
+        T.ptx[f"mma.sync.aligned.m16n8k16.row.col.f32.{_elem}.{_elem}.f32"](
             *[D_local[i] for i in range(4)],
             *[A_words[i] for i in range(4)],
             *[B_words[i] for i in range(2)],
@@ -203,12 +203,12 @@ def test_ptx_mma_m16n8k8(a_type, no_c_ptr):
         # One register per b32, in PTX order: A=2, B=1, D/C=4.
         A_words = A_local.view("uint32")
         B_words = B_local.view("uint32")
-        # ptxd takes the accumulator as an operand; the legacy "omit c" form
+        # ptx takes the accumulator as an operand; the legacy "omit c" form
         # fed literal zeros, which is now spelled at the call site.
         if no_c_ptr:
             for i in range(4):
                 C_local[i] = T.float32(0)
-        T.ptxd[f"mma.sync.aligned.m16n8k8.row.col.f32.{_elem}.{_elem}.f32"](
+        T.ptx[f"mma.sync.aligned.m16n8k8.row.col.f32.{_elem}.{_elem}.f32"](
             *[D_local[i] for i in range(4)],
             *[A_words[i] for i in range(2)],
             *[B_words[i] for i in range(1)],

--- a/tests/python/tirx/codegen/test_codegen_blackwell.py
+++ b/tests/python/tirx/codegen/test_codegen_blackwell.py
@@ -48,7 +48,7 @@ def _assert_remote_mbarrier_ir(func, arrive_op_name, n_arrives=1):
             and getattr(node.data, "name", None) == "remote_mbar_ptr"
         ):
             buffers.append(node)
-        if isinstance(node, tvm.ir.Call) and node.op.name == "tirx.ptxd.mapa":
+        if isinstance(node, tvm.ir.Call) and node.op.name == "tirx.ptx.mapa":
             mapa_calls.append(node)
         if isinstance(node, tvm.ir.Call) and node.op.name == arrive_op_name:
             arrive_calls.append(node)
@@ -64,7 +64,7 @@ def _assert_remote_mbarrier_ir(func, arrive_op_name, n_arrives=1):
     assert buffers[0].data.same_as(bindings[0].var)
     assert buffers[0].data.ty.storage_scope == "shared"
     assert buffers[0].buffer.scope() == "shared"
-    # ptxd operand order is the PTX operand order: mapa writes its result into
+    # ptx operand order is the PTX operand order: mapa writes its result into
     # a destination the caller declared, so args are (d, a, b) and the arrive
     # reads the mapped address back out of that destination rather than
     # re-deriving it. One mapa serves every arrive on the view -- the arrive
@@ -95,15 +95,15 @@ def test_tmem_alloc_dealloc_relinquish():
 
         # alloc TMEM
         if warp_id == 0:
-            T.ptxd[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
+            T.ptx[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
                 T.address_of(tmem_addr), T.uint32(N_COLS)
             )
         T.cuda.cta_sync()
 
         # dealloc TMEM
         if warp_id == 0:
-            T.ptxd[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
-            T.ptxd[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
+            T.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
+            T.ptx[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
                 tmem_addr, T.uint32(N_COLS)
             )
     # fmt: on
@@ -127,7 +127,7 @@ def test_mbarrier_try_wait_once_codegen():
         T.thread_id([128])
         bar = T.shared_scalar("uint64")
         ok = T.local_scalar("uint32")
-        T.ptxd.mbarrier.try_wait.parity.shared__cta.b64(
+        T.ptx.mbarrier.try_wait.parity.shared__cta.b64(
             ok, T.address_of(bar), T.uint32(0), T.uint32(0)
         )
     # fmt: on
@@ -163,8 +163,8 @@ def test_mbarrier_remote_view_codegen():
     # the mapped address rather than re-deriving it the way the fused wrapper
     # did. The two arrives are different ISA lines (implicit count vs explicit),
     # hence different entries.
-    _assert_remote_mbarrier_ir(test_remote_view, "tirx.ptxd.mbarrier_arrive_nocount")
-    _assert_remote_mbarrier_ir(test_remote_view, "tirx.ptxd.mbarrier_arrive")
+    _assert_remote_mbarrier_ir(test_remote_view, "tirx.ptx.mbarrier_arrive_nocount")
+    _assert_remote_mbarrier_ir(test_remote_view, "tirx.ptx.mbarrier_arrive")
     with tvm.target.Target("cuda"):
         src, _ = _get_source(test_remote_view)
         assert "tvm_builtin_ptxd_mapa_u64" in src
@@ -193,7 +193,7 @@ def test_tma_mbarrier_remote_view_codegen():
         remote_bar.arrive(0, tx_count=128)
     # fmt: on
 
-    _assert_remote_mbarrier_ir(test_remote_view, "tirx.ptxd.mbarrier_arrive_expect_tx")
+    _assert_remote_mbarrier_ir(test_remote_view, "tirx.ptx.mbarrier_arrive_expect_tx")
     with tvm.target.Target("cuda"):
         src, _ = _get_source(test_remote_view)
         assert (
@@ -281,9 +281,9 @@ def test_fence_before_after_thread_sync():
         warp_id = T.warp_id([4])
         lane_id = T.lane_id([32])
         tid = T.thread_id([128])
-        T.ptxd.tcgen05.fence__before_thread_sync()
-        T.ptxd.bar.sync(0, 32)
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__before_thread_sync()
+        T.ptx.bar.sync(0, 32)
+        T.ptx.tcgen05.fence__after_thread_sync()
     # fmt: on
 
     target = tvm.target.Target("cuda")
@@ -316,7 +316,7 @@ def test_tcgen05_ld_st_roundtrip():
 
         # alloc TMEM
         if warp_id == 0:
-            T.ptxd[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
+            T.ptx[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
                 T.address_of(tmem_addr), T.uint32(N_COLS)
             )
         T.cuda.cta_sync()
@@ -325,26 +325,26 @@ def test_tcgen05_ld_st_roundtrip():
             reg[i] = A[tx, i]
         # RF -> TMEM
         for i in range(WIDTH):
-            T.ptxd[f"tcgen05.st.sync.aligned.32x32b.x{REPEAT_NUM}.b32"](T.cuda.get_tmem_addr(tmem_addr, warp_id * 32, i), reg[i])  # noqa: E501
-        T.ptxd.tcgen05.wait__st.sync.aligned()
+            T.ptx[f"tcgen05.st.sync.aligned.32x32b.x{REPEAT_NUM}.b32"](T.cuda.get_tmem_addr(tmem_addr, warp_id * 32, i), reg[i])  # noqa: E501
+        T.ptx.tcgen05.wait__st.sync.aligned()
         T.cuda.cta_sync()
         # reset RF
         for i in range(WIDTH):
             reg[i] = 0.0
         T.cuda.cta_sync()
         # TMEM -> RF
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         for i in range(WIDTH):
-            T.ptxd[f"tcgen05.ld.sync.aligned.32x32b.x{REPEAT_NUM}.b32"](reg[i], T.cuda.get_tmem_addr(tmem_addr, warp_id * 32, i))  # noqa: E501
-        T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx[f"tcgen05.ld.sync.aligned.32x32b.x{REPEAT_NUM}.b32"](reg[i], T.cuda.get_tmem_addr(tmem_addr, warp_id * 32, i))  # noqa: E501
+        T.ptx.tcgen05.wait__ld.sync.aligned()
         # RF -> GMEM
         for i in range(WIDTH):
             B[tx, i] = reg[i]
 
         # dealloc TMEM
         if warp_id == 0:
-            T.ptxd[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
-            T.ptxd[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
+            T.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
+            T.ptx[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
                 tmem_addr, T.uint32(N_COLS)
             )
     # fmt: on
@@ -400,12 +400,12 @@ def test_tcgen05_cp_ld_roundtrip():
 
         # alloc TMEM
         if warp_id == 0:
-            T.ptxd[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
+            T.ptx[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
                 T.address_of(tmem_addr), T.uint32(N_COLS)
             )
         T.cuda.cta_sync()
         Tx.cta.copy(A_smem[:, :], A[:, :])
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         # reset RF
         for i in range(WIDTH):
@@ -413,27 +413,27 @@ def test_tcgen05_cp_ld_roundtrip():
         # SMEM -> TMEM (cp)
         phase[0] = 0
         if tx == 0:
-            T.ptxd.mbarrier.init.shared.b64(bar.data, T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(bar.data, T.uint32(1))
             for k in range(dtype_bits * WIDTH // 256):
                 T.cuda.tcgen05.encode_matrix_descriptor(descA.data, A_smem.access_ptr("r", offset=A_smem.elem_offset_of([0, k * 8])), ldo=ldo, sdo=sdo, swizzle=SWIZZLE)  # noqa: E501
-                T.ptxd[f"tcgen05.cp.cta_group::{cta_group}.128x256b"](T.cuda.get_tmem_addr(tmem_addr, 0, k * 256 // 32), descA[0])  # noqa: E501
-            T.ptxd[f"tcgen05.commit.cta_group::{cta_group}.mbarrier::arrive::one.shared::cluster.b64"](bar.data)
+                T.ptx[f"tcgen05.cp.cta_group::{cta_group}.128x256b"](T.cuda.get_tmem_addr(tmem_addr, 0, k * 256 // 32), descA[0])  # noqa: E501
+            T.ptx[f"tcgen05.commit.cta_group::{cta_group}.mbarrier::arrive::one.shared::cluster.b64"](bar.data)
         T.cuda.mbarrier_wait(bar.data, phase[0])
         phase[0] = phase[0] ^ 1
         T.cuda.cta_sync()
         # TMEM -> RF (ld)
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         for i in range(WIDTH):
-            T.ptxd[f"tcgen05.ld.sync.aligned.32x32b.x{REPEAT_NUM}.b32"](reg[i], T.cuda.get_tmem_addr(tmem_addr, warp_id * 32, i))  # noqa: E501
-        T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx[f"tcgen05.ld.sync.aligned.32x32b.x{REPEAT_NUM}.b32"](reg[i], T.cuda.get_tmem_addr(tmem_addr, warp_id * 32, i))  # noqa: E501
+        T.ptx.tcgen05.wait__ld.sync.aligned()
         # RF -> GMEM
         for i in range(WIDTH):
             B[tx, i] = reg[i]
 
         # dealloc TMEM
         if warp_id == 0:
-            T.ptxd[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
-            T.ptxd[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
+            T.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
+            T.ptx[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
                 tmem_addr, T.uint32(N_COLS)
             )
     # fmt: on
@@ -517,7 +517,7 @@ def test_tcgen05_mma_ss_no_tma(swizzle):
 
         # alloc TMEM
         if warp_id == 0:
-            T.ptxd[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
+            T.ptx[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
                 T.address_of(tmem_addr), T.uint32(N_COLS)
             )
         T.cuda.cta_sync()
@@ -525,38 +525,38 @@ def test_tcgen05_mma_ss_no_tma(swizzle):
             reg[i] = 0.0
         Tx.cta.copy(A_smem[:, :], A[:, :])
         Tx.cta.copy(B_smem[:, :], B[:, :])
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         # MMA
         phase[0] = 0
         if tx == 0:
-            T.ptxd.mbarrier.init.shared.b64(bar.data, T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(bar.data, T.uint32(1))
             T.cuda.tcgen05.encode_instr_descriptor(descI.data, d_dtype=d_type, a_dtype=a_type, b_dtype=b_type, M=M, N=N, K=MMA_K, trans_a=False, trans_b=False, n_cta_groups=cta_group)  # noqa: E501
             for k in range(K // MMA_K):
                 T.cuda.tcgen05.encode_matrix_descriptor(descA.data, A_smem.ptr_to([0, k * MMA_K]), ldo=ldo, sdo=sdo, swizzle=SWIZZLE)  # noqa: E501
                 T.cuda.tcgen05.encode_matrix_descriptor(descB.data, B_smem.ptr_to([0, k * MMA_K]), ldo=ldo, sdo=sdo, swizzle=SWIZZLE)  # noqa: E501
                 if k == 0:
-                    T.ptxd[mma_chain](tmem_addr, descA[0], descB[0], descI[0], *mma_masks, 0)
+                    T.ptx[mma_chain](tmem_addr, descA[0], descB[0], descI[0], *mma_masks, 0)
                 else:
-                    T.ptxd[mma_chain](tmem_addr, descA[0], descB[0], descI[0], *mma_masks, 1)
-            T.ptxd[f"tcgen05.commit.cta_group::{cta_group}.mbarrier::arrive::one.shared::cluster.b64"](bar.data)
+                    T.ptx[mma_chain](tmem_addr, descA[0], descB[0], descI[0], *mma_masks, 1)
+            T.ptx[f"tcgen05.commit.cta_group::{cta_group}.mbarrier::arrive::one.shared::cluster.b64"](bar.data)
         T.cuda.mbarrier_wait(bar.data, phase[0])
         phase[0] = phase[0] ^ 1
         T.cuda.cta_sync()
 
         # TMEM -> RF
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         for i in range(N):
-            T.ptxd[f"tcgen05.ld.sync.aligned.32x32b.x{REPEAT_NUM}.b32"](reg[i], T.cuda.get_tmem_addr(tmem_addr, warp_id * 32, i))  # noqa: E501
-        T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx[f"tcgen05.ld.sync.aligned.32x32b.x{REPEAT_NUM}.b32"](reg[i], T.cuda.get_tmem_addr(tmem_addr, warp_id * 32, i))  # noqa: E501
+        T.ptx.tcgen05.wait__ld.sync.aligned()
         # RF -> GMEM
         for i in range(N):
             C[tx, i] = reg[i]
 
         # dealloc TMEM
         if warp_id == 0:
-            T.ptxd[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
-            T.ptxd[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
+            T.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
+            T.ptx[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
                 tmem_addr, T.uint32(N_COLS)
             )
     # fmt: on
@@ -607,7 +607,7 @@ def test_tcgen05_mma_pred_codegen():
         desc_b[0] = T.uint64(0)
         desc_i[0] = T.uint32(0)
         pred[0] = T.uint32(1)
-        T.ptxd["tcgen05.mma.cta_group::1.kind::f16"](
+        T.ptx["tcgen05.mma.cta_group::1.kind::f16"](
             tmem_addr[0],
             desc_a[0],
             desc_b[0],

--- a/tests/python/tirx/codegen/test_codegen_blackwell.py
+++ b/tests/python/tirx/codegen/test_codegen_blackwell.py
@@ -167,9 +167,9 @@ def test_mbarrier_remote_view_codegen():
     _assert_remote_mbarrier_ir(test_remote_view, "tirx.ptx.mbarrier_arrive")
     with tvm.target.Target("cuda"):
         src, _ = _get_source(test_remote_view)
-        assert "tvm_builtin_ptxd_mapa_u64" in src
-        assert "tvm_builtin_ptxd_mbarrier_arrive_nocount_arrive_shared__cluster_b64" in src
-        assert "tvm_builtin_ptxd_mbarrier_arrive_arrive_shared__cluster_b64" in src
+        assert "tvm_builtin_ptx_mapa_u64" in src
+        assert "tvm_builtin_ptx_mbarrier_arrive_nocount_arrive_shared__cluster_b64" in src
+        assert "tvm_builtin_ptx_mbarrier_arrive_arrive_shared__cluster_b64" in src
         assert "mbarrier.arrive.shared::cluster.b64" in src
         assert 'asm volatile("mbarrier.arrive.shared.b64' not in src
 
@@ -197,7 +197,7 @@ def test_tma_mbarrier_remote_view_codegen():
     with tvm.target.Target("cuda"):
         src, _ = _get_source(test_remote_view)
         assert (
-            "tvm_builtin_ptxd_mbarrier_arrive_expect_tx_arrive_expect_tx_shared__cluster_b64" in src
+            "tvm_builtin_ptx_mbarrier_arrive_expect_tx_arrive_expect_tx_shared__cluster_b64" in src
         )
         assert "mbarrier.arrive.expect_tx.shared::cluster.b64" in src
         assert 'asm volatile("mbarrier.arrive.expect_tx.shared.b64' not in src
@@ -624,7 +624,7 @@ def test_tcgen05_mma_pred_codegen():
     target = tvm.target.Target("cuda")
     with target:
         src, _ = _get_source(test_mma_pred)
-        assert "tvm_builtin_ptxd_tcgen05_mma_ss_mma_cta_group__1_kind__f16_pred" in src
+        assert "tvm_builtin_ptx_tcgen05_mma_ss_mma_cta_group__1_kind__f16_pred" in src
         # enable-input-d converts in via ps0, the @p guard via p -- two
         # independent setp conversions inside one block.
         assert "setp.ne.b32 ps0" in src

--- a/tests/python/tirx/codegen/test_codegen_cuda.py
+++ b/tests/python/tirx/codegen/test_codegen_cuda.py
@@ -602,7 +602,6 @@ def test_ptx_sync_and_clc_codegen():
     assert "tvm_builtin_cuda_mbarrier_wait" in src
     # (No assertion on the timeout local: T.cuda.mbarrier_wait keeps the
     # `ticks = 0x989680` hint the TIRx spin-wait convention specifies.)
-    assert "tirx.ptx.cp_async_mbarrier_arrive_noinc" not in src
     assert "mbarrier.complete_tx.relaxed.cluster.shared::cluster.b64" in src
     assert "mbarrier.complete_tx.relaxed.cta.shared::cta.b64" in src
     assert "@p mbarrier.complete_tx.relaxed.cta.shared::cta.b64" in src

--- a/tests/python/tirx/codegen/test_codegen_cuda.py
+++ b/tests/python/tirx/codegen/test_codegen_cuda.py
@@ -330,7 +330,7 @@ def test_ptx_ld_acquire_and_volatile_codegen():
     assert "ld.acquire.gpu.global.u64" in src
     assert "ld.acquire.sys.global.s32" in src
     assert "ld.acquire.gpu.global.b32" in src
-    assert "tvm_builtin_ptxd_ld_acquire_gpu_global_b32_s32" in src
+    assert "tvm_builtin_ptx_ld_acquire_gpu_global_b32_s32" in src
     assert "ld.volatile.global.u64" in src
 
 
@@ -350,10 +350,10 @@ def test_ptx_f32x2_value_codegen():
             T.ptx.sub.rn.f32x2(A[1], sum_pair, rhs)
 
     src, _ = _get_source(main)
-    assert "tvm_builtin_ptxd_mul_f32x2" in src
-    assert "tvm_builtin_ptxd_fma_rn_f32x2" in src
-    assert "tvm_builtin_ptxd_add_rn_f32x2" in src
-    assert "tvm_builtin_ptxd_sub_rn_f32x2" in src
+    assert "tvm_builtin_ptx_mul_f32x2" in src
+    assert "tvm_builtin_ptx_fma_rn_f32x2" in src
+    assert "tvm_builtin_ptx_add_rn_f32x2" in src
+    assert "tvm_builtin_ptx_sub_rn_f32x2" in src
     # `.rnd` is optional on add/mul and mandatory on fma; the tokens written at
     # the call site are exactly the tokens emitted.
     assert "mul.f32x2 %0, %1, %2;" in src
@@ -611,8 +611,8 @@ def test_ptx_sync_and_clc_codegen():
     # own rather than something folded into the complete_tx helper.
     assert "mapa.shared::cluster.u32" in src
     for helper in (
-        "tvm_builtin_ptxd_mbarrier_complete_tx_complete_tx_relaxed_cta_shared__cta_b64",
-        "tvm_builtin_ptxd_mbarrier_complete_tx_complete_tx_relaxed_cluster_shared__cluster_b64",
+        "tvm_builtin_ptx_mbarrier_complete_tx_complete_tx_relaxed_cta_shared__cta_b64",
+        "tvm_builtin_ptx_mbarrier_complete_tx_complete_tx_relaxed_cluster_shared__cluster_b64",
     ):
         assert "mapa" not in _helper_source(src, helper)
     assert "mbarrier.complete_tx.shared::cluster.relaxed.cluster.b64" not in src

--- a/tests/python/tirx/codegen/test_codegen_cuda.py
+++ b/tests/python/tirx/codegen/test_codegen_cuda.py
@@ -320,11 +320,11 @@ def test_ptx_ld_acquire_and_volatile_codegen():
         T.device_entry()
         tx = T.thread_id([32])
         if tx == 0:
-            T.ptxd.ld.acquire.gpu.global_.u64(A[0], A.data)
-            T.ptxd.ld.acquire.sys.global_.s32(B[0], B.data)
-            T.ptxd.ld.acquire.gpu.global_.b32(C[0], C.data)
-            T.ptxd.ld.acquire.gpu.global_.b32(B[0], B.data)
-            T.ptxd.ld.volatile.global_.u64(A[0], A.data)
+            T.ptx.ld.acquire.gpu.global_.u64(A[0], A.data)
+            T.ptx.ld.acquire.sys.global_.s32(B[0], B.data)
+            T.ptx.ld.acquire.gpu.global_.b32(C[0], C.data)
+            T.ptx.ld.acquire.gpu.global_.b32(B[0], B.data)
+            T.ptx.ld.volatile.global_.u64(A[0], A.data)
 
     src, _ = _get_source(main)
     assert "ld.acquire.gpu.global.u64" in src
@@ -344,10 +344,10 @@ def test_ptx_f32x2_value_codegen():
             rhs: T.let = T.cuda.make_float2(B[1], B[0])
             prod = T.local_scalar("uint64")
             sum_pair = T.local_scalar("uint64")
-            T.ptxd.mul.f32x2(prod, lhs, rhs)
-            T.ptxd.fma.rn.f32x2(A[0], lhs, rhs, prod)
-            T.ptxd.add.rn.f32x2(sum_pair, lhs, rhs)
-            T.ptxd.sub.rn.f32x2(A[1], sum_pair, rhs)
+            T.ptx.mul.f32x2(prod, lhs, rhs)
+            T.ptx.fma.rn.f32x2(A[0], lhs, rhs, prod)
+            T.ptx.add.rn.f32x2(sum_pair, lhs, rhs)
+            T.ptx.sub.rn.f32x2(A[1], sum_pair, rhs)
 
     src, _ = _get_source(main)
     assert "tvm_builtin_ptxd_mul_f32x2" in src
@@ -362,7 +362,7 @@ def test_ptx_f32x2_value_codegen():
     assert "add.rn.f32x2 %0, %1, %2;" in src
 
 
-def test_ptxd_neg_f32_codegen():
+def test_ptx_neg_f32_codegen():
     """`neg{.ftz}.f32` (ISA 9.7.3.10) -- the exact form, without fast-math .ftz."""
 
     @T.prim_func
@@ -370,14 +370,14 @@ def test_ptxd_neg_f32_codegen():
         T.device_entry()
         tx = T.thread_id([32])
         if tx == 0:
-            T.ptxd.neg.f32(A[1], A[0])
+            T.ptx.neg.f32(A[1], A[0])
 
     src, _ = _get_source(main)
     assert "neg.f32 %0, %1;" in src
     assert "neg.ftz.f32" not in src
 
 
-def test_ptxd_sub_f16x2_codegen():
+def test_ptx_sub_f16x2_codegen():
     """The packed half line `sub{.rnd}{.ftz}{.sat}.f16x2` (ISA 9.7.4.2)."""
 
     @T.prim_func
@@ -385,7 +385,7 @@ def test_ptxd_sub_f16x2_codegen():
         T.device_entry()
         tx = T.thread_id([32])
         if tx == 0:
-            T.ptxd.sub.f16x2(A[2], A[0], A[1])
+            T.ptx.sub.f16x2(A[2], A[0], A[1])
 
     src, _ = _get_source(main)
     assert "sub.f16x2 %0, %1, %2;" in src
@@ -409,10 +409,10 @@ def test_sparse_decode_conversion_intrinsics_codegen(monkeypatch):
         tx = T.thread_id([32])
         if tx == 0:
             pair: T.let = T.cuda.make_float2(F32[0], F32[1])
-            T.ptxd.cvt.rz.ue8m0x2.f32(U16[0], F32[1], F32[0])
-            T.ptxd.cvt.rn.bf16x2.ue8m0x2(U32[0], U16[0])
-            T.ptxd.cvt.rn.bf16x2.e4m3x2(U32[1], U16[0])
-            T.ptxd.add.f32x2(U64[0], pair, pair)
+            T.ptx.cvt.rz.ue8m0x2.f32(U16[0], F32[1], F32[0])
+            T.ptx.cvt.rn.bf16x2.ue8m0x2(U32[0], U16[0])
+            T.ptx.cvt.rn.bf16x2.e4m3x2(U32[1], U16[0])
+            T.ptx.add.f32x2(U64[0], pair, pair)
 
     src, _ = _get_source(main)
     assert "cvt.rz.ue8m0x2.f32 %0, %1, %2;" in src
@@ -435,23 +435,23 @@ def test_megamoe_extracted_intrinsics_codegen():
         T.device_entry()
         tx = T.thread_id([32])
         if tx == 0:
-            T.ptxd.red.release.gpu.global_.or_.b64(U64.data, U64[0])
-            T.ptxd.red.release.sys.global_.add.s32(I32.data, I32[0])
-            T.ptxd.atom.release.gpu.global_.add.u32(U32[0], U32.data, U32[0])
-            T.ptxd.atom.sys.global_.add.u64(U64[0], U64.data, U64[0])
-            T.ptxd.red.gpu.global_.add.u32(U32.data, U32[0])
-            T.ptxd.st.shared.u32(U32.data, U32[0])
-            T.ptxd.st.shared.v4.b32(U32.data, U32[0], U32[1], U32[2], U32[3])
-            T.ptxd.st_bulk.weak.shared__cta(U32.data, T.uint64(16))
-            T.ptxd.fns.b32(U32[0], U32[0], U32[1], I32[0])
-            T.ptxd.stmatrix.sync.aligned.m16n8.x1.trans.shared.b8(U32.data, U32[0])
+            T.ptx.red.release.gpu.global_.or_.b64(U64.data, U64[0])
+            T.ptx.red.release.sys.global_.add.s32(I32.data, I32[0])
+            T.ptx.atom.release.gpu.global_.add.u32(U32[0], U32.data, U32[0])
+            T.ptx.atom.sys.global_.add.u64(U64[0], U64.data, U64[0])
+            T.ptx.red.gpu.global_.add.u32(U32.data, U32[0])
+            T.ptx.st.shared.u32(U32.data, U32[0])
+            T.ptx.st.shared.v4.b32(U32.data, U32[0], U32[1], U32[2], U32[3])
+            T.ptx.st_bulk.weak.shared__cta(U32.data, T.uint64(16))
+            T.ptx.fns.b32(U32[0], U32[0], U32[1], I32[0])
+            T.ptx.stmatrix.sync.aligned.m16n8.x1.trans.shared.b8(U32.data, U32[0])
 
             F32[1] = T.cuda.uint_as_float(U32[0])
-            T.ptxd.ld.global_.f32(F32[2], F32.data)
+            T.ptx.ld.global_.f32(F32[2], F32.data)
             F32[2] = T.cuda.ldg(T.handle_add_byte_offset(F32.data, 4), "float32")
             F32[3] = T.cuda.fdividef(F32[0], F32[1])
             U32[3] = T.cuda.float_as_uint(F32[1])
-            T.ptxd.add.rn.f32.bf16(F32[0], T.cast(U32[0], "uint16"), F32[0])
+            T.ptx.add.rn.f32.bf16(F32[0], T.cast(U32[0], "uint16"), F32[0])
             U64[0] = T.reinterpret("uint64", U32.data)
             U32[0] = T.cuda.ballot_sync(T.uint32(0xFFFFFFFF), I32[0])
             I32[0] = T.cuda.ffs_u32(U32[0])
@@ -528,18 +528,18 @@ def test_ptx_cp_async_bulk_non_tma_form_codegen():
         tx = T.thread_id([32])
         if tx == 0:
             smem = T.alloc_shared([128], "float32")
-            T.ptxd["cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes.L2::cache_hint"](
+            T.ptx["cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes.L2::cache_hint"](
                 smem.ptr_to([0]), A.data, T.uint32(64), smem.ptr_to([0]), C[0]
             )
-            T.ptxd[
+            T.ptx[
                 "cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint"
             ](smem.ptr_to([0]), A.data, T.uint32(64), smem.ptr_to([0]), C[0])
-            T.ptxd["cp.async.bulk.global.shared::cta.bulk_group.L2::cache_hint"](
+            T.ptx["cp.async.bulk.global.shared::cta.bulk_group.L2::cache_hint"](
                 B.data, smem.ptr_to([0]), T.uint32(64), C[0]
             )
-            T.ptxd.cp.async_.bulk.commit_group()
-            T.ptxd.cp.async_.bulk.wait_group.read(0)
-            T.ptxd.cp.async_.bulk.wait_group(1)
+            T.ptx.cp.async_.bulk.commit_group()
+            T.ptx.cp.async_.bulk.wait_group.read(0)
+            T.ptx.cp.async_.bulk.wait_group(1)
 
     src, _ = _get_source(main)
     assert "cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes.L2::cache_hint" in src
@@ -558,28 +558,28 @@ def test_ptx_sync_and_clc_codegen():
         if tx == 0:
             bar = T.alloc_buffer((5,), "uint64", scope="shared", align=16)
             response = T.alloc_buffer((4,), "uint32", scope="shared", align=16)
-            T.ptxd.cp.async_.mbarrier.arrive.shared.b64(bar.ptr_to([0]))
-            T.ptxd.cp.async_.mbarrier.arrive.noinc.shared__cta.b64(bar.ptr_to([0]))
+            T.ptx.cp.async_.mbarrier.arrive.shared.b64(bar.ptr_to([0]))
+            T.ptx.cp.async_.mbarrier.arrive.noinc.shared__cta.b64(bar.ptr_to([0]))
             T.cuda.mbarrier_wait(bar.ptr_to([0]), T.int32(0))
-            T.ptxd.mbarrier.complete_tx.shared.b64(bar.ptr_to([0]), T.uint32(T.uint32(16)))
-            T.ptxd.mbarrier.complete_tx.relaxed.cta.shared__cta.b64(bar.ptr_to([1]), T.uint32(24))
-            T.ptxd.mbarrier.complete_tx.relaxed.cta.shared__cta.b64(
+            T.ptx.mbarrier.complete_tx.shared.b64(bar.ptr_to([0]), T.uint32(T.uint32(16)))
+            T.ptx.mbarrier.complete_tx.relaxed.cta.shared__cta.b64(bar.ptr_to([1]), T.uint32(24))
+            T.ptx.mbarrier.complete_tx.relaxed.cta.shared__cta.b64(
                 bar.ptr_to([2]), T.uint32(28), pred=T.uint32(1)
             )
             # The remote form is a mapa plus a complete_tx on the mapped window
             # address, which is what the fused legacy helper emitted inside one
             # asm block.
             remote_bar = T.alloc_local([1], "uint32")
-            T.ptxd.mapa.shared__cluster.u32(
+            T.ptx.mapa.shared__cluster.u32(
                 remote_bar[0], T.cuda.cvta_generic_to_shared(bar.ptr_to([3])), T.uint32(1)
             )
-            T.ptxd.mbarrier.complete_tx.relaxed.cluster.shared__cluster.b64(
+            T.ptx.mbarrier.complete_tx.relaxed.cluster.shared__cluster.b64(
                 remote_bar[0], T.uint32(32)
             )
-            T.ptxd.mbarrier.complete_tx.relaxed.cluster.shared__cluster.b64(
+            T.ptx.mbarrier.complete_tx.relaxed.cluster.shared__cluster.b64(
                 remote_bar[0], T.uint32(40), pred=T.uint32(1)
             )
-            T.ptxd[
+            T.ptx[
                 "clusterlaunchcontrol.try_cancel.async.shared::cta"
                 ".mbarrier::complete_tx::bytes.multicast::cluster::all.b128"
             ](response.ptr_to([0]), bar.ptr_to([0]))
@@ -588,7 +588,7 @@ def test_ptx_sync_and_clc_codegen():
             A[0] = nxt
             query_cancel_first_ctaid_x(nxt, response.ptr_to([0]), use_ld_acquire=False)
             A[0] = nxt
-            T.ptxd.griddepcontrol.launch_dependents()
+            T.ptx.griddepcontrol.launch_dependents()
 
     target = tvm.target.Target({"kind": "cuda", "arch": "sm_100a"})
     with target:
@@ -607,7 +607,7 @@ def test_ptx_sync_and_clc_codegen():
     assert "mbarrier.complete_tx.relaxed.cta.shared::cta.b64" in src
     assert "@p mbarrier.complete_tx.relaxed.cta.shared::cta.b64" in src
     assert "@p mbarrier.complete_tx.relaxed.cluster.shared::cluster.b64" in src
-    # A ptxd helper is exactly one instruction, so the mapping is a call of its
+    # A ptx helper is exactly one instruction, so the mapping is a call of its
     # own rather than something folded into the complete_tx helper.
     assert "mapa.shared::cluster.u32" in src
     for helper in (
@@ -631,18 +631,18 @@ def test_ptx_mbarrier_arrive_new_forms_codegen():
         if tx == 0:
             bar = T.alloc_buffer((6,), "uint64", scope="shared", align=16)
             state = T.local_scalar("uint64")
-            T.ptxd.mbarrier.arrive.relaxed.cta.shared__cta.b64(bar.ptr_to([0]))
-            T.ptxd.mbarrier.arrive.relaxed.cluster.shared__cluster.b64(bar.ptr_to([1]))
-            T.ptxd.mbarrier.arrive.release.cta.shared.b64(bar.ptr_to([2]), pred=Pred[0])
-            T.ptxd.mbarrier.arrive.expect_tx.relaxed.cluster.shared__cluster.b64(
+            T.ptx.mbarrier.arrive.relaxed.cta.shared__cta.b64(bar.ptr_to([0]))
+            T.ptx.mbarrier.arrive.relaxed.cluster.shared__cluster.b64(bar.ptr_to([1]))
+            T.ptx.mbarrier.arrive.release.cta.shared.b64(bar.ptr_to([2]), pred=Pred[0])
+            T.ptx.mbarrier.arrive.expect_tx.relaxed.cluster.shared__cluster.b64(
                 bar.ptr_to([3]), T.uint32(128)
             )
-            T.ptxd.mbarrier.arrive.noComplete.release.cta.shared.b64(
+            T.ptx.mbarrier.arrive.noComplete.release.cta.shared.b64(
                 state, bar.ptr_to([4]), T.uint32(2)
             )
             # noComplete writes a real state result, yet pred= stays legal:
             # the accumulator binds "+", so a false predicate leaves it intact.
-            T.ptxd.mbarrier.arrive.noComplete.release.cta.shared__cta.b64(
+            T.ptx.mbarrier.arrive.noComplete.release.cta.shared__cta.b64(
                 state, bar.ptr_to([5]), T.uint32(3), pred=Pred[0]
             )
 
@@ -729,26 +729,26 @@ def test_tma_cache_policy_operand_codegen():
         if tx == 0:
             smem = T.alloc_buffer((128,), "float32", scope="shared", align=128)
             bar = T.shared_scalar("uint64")
-            T.ptxd[_TMA_G2S_CG2_CACHE](
+            T.ptx[_TMA_G2S_CG2_CACHE](
                 smem.data, T.address_of(A_map), 0, 0, T.address_of(bar), Cache[0]
             )
-            T.ptxd[_TMA_G2S_MC_CG2_CACHE](
+            T.ptx[_TMA_G2S_MC_CG2_CACHE](
                 smem.data, T.address_of(A_map), 0, 0, T.address_of(bar), 3, Cache[0]
             )
-            T.ptxd[_TMA_S2G_CACHE](T.address_of(A_map), 0, 0, smem.data, Cache[0])
-            T.ptxd[_TMA_CTA_GATHER4_CG2_CACHE](
+            T.ptx[_TMA_S2G_CACHE](T.address_of(A_map), 0, 0, smem.data, Cache[0])
+            T.ptx[_TMA_CTA_GATHER4_CG2_CACHE](
                 smem.data, T.address_of(A_map), 0, 1, 2, 3, 4, T.address_of(bar), Cache[0]
             )
             leader_mbar_addr = T.cuda.sm100_2sm_leader_smem_addr(T.address_of(bar))
-            T.ptxd[_TMA_G2S_CG2_CACHE](
+            T.ptx[_TMA_G2S_CG2_CACHE](
                 smem.data, T.address_of(A_map), 0, 0, leader_mbar_addr, Cache[0]
             )
             if tx == 0:
-                T.ptxd[_TMA_G2S_CG2_CACHE](
+                T.ptx[_TMA_G2S_CG2_CACHE](
                     smem.data, T.address_of(A_map), 0, 0, leader_mbar_addr, Cache[0]
                 )
             else:
-                T.ptxd[_TMA_G2S_CG2_CACHE](
+                T.ptx[_TMA_G2S_CG2_CACHE](
                     smem.data, T.address_of(B_map), 0, 0, leader_mbar_addr, Cache[0]
                 )
 
@@ -945,15 +945,15 @@ def test_ptx_cp_async(cp_size, cache_hint, prefetch_size, predicate, fill_mode):
         A_shared = T.alloc_shared([N], "float16")
         for i in T.vectorized(N):
             A_shared[i] = 5.0
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.proxy.async_.shared__cta()
         if fill_mode == "zero":
-            T.ptxd[chain](A_shared.ptr_to([0]), A.ptr_to([0]), cp_size, src_size, *cache_args)
+            T.ptx[chain](A_shared.ptr_to([0]), A.ptr_to([0]), cp_size, src_size, *cache_args)
         elif has_pred:
-            T.ptxd[chain](A_shared.ptr_to([0]), A.ptr_to([0]), cp_size, *cache_args, pred=predicate)
+            T.ptx[chain](A_shared.ptr_to([0]), A.ptr_to([0]), cp_size, *cache_args, pred=predicate)
         else:
-            T.ptxd[chain](A_shared.ptr_to([0]), A.ptr_to([0]), cp_size, *cache_args)
-        T.ptxd.cp.async_.commit_group()
-        T.ptxd.cp.async_.wait_group(0)
+            T.ptx[chain](A_shared.ptr_to([0]), A.ptr_to([0]), cp_size, *cache_args)
+        T.ptx.cp.async_.commit_group()
+        T.ptx.cp.async_.wait_group(0)
         for i in T.serial(N):
             A[i] = A_shared[i] + 1.0
         # fmt: on
@@ -981,7 +981,7 @@ def test_ptx_cp_async(cp_size, cache_hint, prefetch_size, predicate, fill_mode):
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 @pytest.mark.parametrize("trans", [False, True])
 @pytest.mark.parametrize("num", [1, 2, 4])
-def test_ptxd_ldmatrix(trans, num):
+def test_ptx_ldmatrix(trans, num):
     # fmt: off
     @T.prim_func
     def main(A: T.Buffer((16, 16), "float16"), B: T.Buffer((16, 16), "float16")):
@@ -1000,18 +1000,18 @@ def test_ptxd_ldmatrix(trans, num):
         # view, two fp16 elements per word.
         A_words = A_local.view("uint32")
         if num == 1:
-            T.ptxd[f"ldmatrix.sync.aligned.m8n8.x1{'.trans' if trans else ''}.shared.b16"](
+            T.ptx[f"ldmatrix.sync.aligned.m8n8.x1{'.trans' if trans else ''}.shared.b16"](
                 A_words[0],
                 A_shared.ptr_to([tx % 16, tx // 16 * 8]),
             )
         elif num == 2:
-            T.ptxd[f"ldmatrix.sync.aligned.m8n8.x2{'.trans' if trans else ''}.shared.b16"](
+            T.ptx[f"ldmatrix.sync.aligned.m8n8.x2{'.trans' if trans else ''}.shared.b16"](
                 A_words[0],
                 A_words[1],
                 A_shared.ptr_to([tx % 16, tx // 16 * 8]),
             )
         else:
-            T.ptxd[f"ldmatrix.sync.aligned.m8n8.x4{'.trans' if trans else ''}.shared.b16"](
+            T.ptx[f"ldmatrix.sync.aligned.m8n8.x4{'.trans' if trans else ''}.shared.b16"](
                 A_words[0],
                 A_words[1],
                 A_words[2],

--- a/tests/python/tirx/codegen/test_codegen_dsmem.py
+++ b/tests/python/tirx/codegen/test_codegen_dsmem.py
@@ -59,7 +59,7 @@ def test_ptx_cp_async_bulk_s2c_codegen():
         # fmt: on
 
     src = _get_source(main)
-    assert "tvm_builtin_ptxd_cp_async_bulk_s2c" in src
+    assert "tvm_builtin_ptx_cp_async_bulk_s2c" in src
     assert "cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes" in src
 
 
@@ -137,7 +137,7 @@ def test_mapa_pointer_bind_codegen():
     src = _get_source(main)
     assert "uint64_t* remote_ptr" in src
     assert "A_ptr[0] = remote_ptr[0]" in src
-    assert "tvm_builtin_ptxd_mapa_u64" in src
+    assert "tvm_builtin_ptx_mapa_u64" in src
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/codegen/test_codegen_dsmem.py
+++ b/tests/python/tirx/codegen/test_codegen_dsmem.py
@@ -33,7 +33,7 @@ def _get_source(func: tvm.tirx.PrimFunc) -> str:
 
 
 def test_ptx_cp_async_bulk_s2c_codegen():
-    """Test that the ptxd cp.async.bulk s2c chain emits the correct PTX instruction."""
+    """Test that the ptx cp.async.bulk s2c chain emits the correct PTX instruction."""
 
     # fmt: off
     @T.prim_func
@@ -46,11 +46,11 @@ def test_ptx_cp_async_bulk_s2c_codegen():
             A_smem[i] = A[i]
                 # Use the raw PTX instruction directly
         mapped = T.alloc_local([2], "uint64")
-        T.ptxd.mapa.u64(mapped[0], A_smem.ptr_to([0]), T.uint32(1))
-        T.ptxd.mapa.u64(mapped[1], A_smem.ptr_to([0]), T.uint32(1))
+        T.ptx.mapa.u64(mapped[0], A_smem.ptr_to([0]), T.uint32(1))
+        T.ptx.mapa.u64(mapped[1], A_smem.ptr_to([0]), T.uint32(1))
         dst_ptr = mapped[0]
         mbar_ptr = mapped[1]
-        T.ptxd["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
+        T.ptx["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
             T.cast(dst_ptr, "uint32"),
             A_smem.ptr_to([0]),
             T.uint32(256),  # 128 elements * 2 bytes
@@ -76,11 +76,11 @@ def test_ptx_cp_async_bulk_s2c_codegen_address_conversion():
         for i in T.serial(64):
             A_smem[i] = A[i]
         mapped = T.alloc_local([2], "uint64")
-        T.ptxd.mapa.u64(mapped[0], A_smem.ptr_to([0]), T.uint32(0))
-        T.ptxd.mapa.u64(mapped[1], A_smem.ptr_to([0]), T.uint32(0))
+        T.ptx.mapa.u64(mapped[0], A_smem.ptr_to([0]), T.uint32(0))
+        T.ptx.mapa.u64(mapped[1], A_smem.ptr_to([0]), T.uint32(0))
         dst_ptr = mapped[0]
         mbar_ptr = mapped[1]
-        T.ptxd["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
+        T.ptx["cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes"](
             T.cast(dst_ptr, "uint32"),
             A_smem.ptr_to([0]),
             T.uint32(256),  # 64 * 4 bytes
@@ -105,7 +105,7 @@ def test_mapa_pointer_bind_codegen():
         tid = T.thread_id([1])
         mbar = T.alloc_shared([2], "uint64")
         mapped = T.alloc_local([1], "uint64")
-        T.ptxd.mapa.u64(mapped[0], mbar.ptr_to([0]), T.uint32(0))
+        T.ptx.mapa.u64(mapped[0], mbar.ptr_to([0]), T.uint32(0))
         remote_ptr = T.reinterpret(ptr_ty, mapped[0])
         remote_mbar = T.decl_buffer([1], "uint64", data=remote_ptr, scope="shared")
         A[0] = remote_mbar[0]

--- a/tests/python/tirx/codegen/test_codegen_hopper.py
+++ b/tests/python/tirx/codegen/test_codegen_hopper.py
@@ -63,14 +63,14 @@ def _run_tensormap_encode(shape, dtype, encode_args):
 @pytest.mark.parametrize("inc", [False, True])
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda_compute(9), reason="need cuda compute >= 9.0")
-def test_ptxd_setmaxnreg(inc):
+def test_ptx_setmaxnreg(inc):
     # fmt: off
     @T.prim_func
     def func(A: T.Buffer(1)):
         T.device_entry()
         cta_id = T.cta_id([1])
         tid = T.thread_id([128])
-        T.ptxd[f"setmaxnreg.{'inc' if inc else 'dec'}.sync.aligned.u32"](32)
+        T.ptx[f"setmaxnreg.{'inc' if inc else 'dec'}.sync.aligned.u32"](32)
         # fmt: on
 
     src, mod = _get_source(func)
@@ -98,7 +98,7 @@ def test_stmatrix_sync_aligned(trans):
         # stmatrix stores 4 b32 registers; reg is fp16, so they ride a uint32
         # view, two elements per word.
         reg_words = reg.view("uint32")
-        T.ptxd[f"stmatrix.sync.aligned.m8n8.x4{'.trans' if trans else ''}.shared.b16"](
+        T.ptx[f"stmatrix.sync.aligned.m8n8.x4{'.trans' if trans else ''}.shared.b16"](
             A_smem.ptr_to([tx % 16, tx // 16 * 8]),
             reg_words[0], reg_words[1], reg_words[2], reg_words[3],
         )
@@ -151,7 +151,7 @@ def test_stmatrix_sync_aligned(trans):
 @pytest.mark.parametrize("trans", [False, True])
 @pytest.mark.parametrize("num", [1, 2, 4])
 @pytest.mark.gpu
-def test_ptxd_stmatrix(trans, num):
+def test_ptx_stmatrix(trans, num):
     # fmt: off
     @T.prim_func
     def main(A: T.Buffer((16, 16), "float16")):
@@ -167,7 +167,7 @@ def test_ptxd_stmatrix(trans, num):
         for i in range(8):
             A_local[i] = (i // 2) * 64 + tx * 2 + i % 2
         A_words = A_local.view("uint32")
-        T.ptxd[f"stmatrix.sync.aligned.m8n8.x{num}{'.trans' if trans else ''}.shared.b16"](
+        T.ptx[f"stmatrix.sync.aligned.m8n8.x{num}{'.trans' if trans else ''}.shared.b16"](
             A_shared.ptr_to([tx % 16, tx // 16 * 8]),
             *[A_words[i] for i in range(num)],
         )
@@ -214,7 +214,7 @@ def test_ptxd_stmatrix(trans, num):
 @pytest.mark.parametrize("num", [1, 2, 4])
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda_compute(9), reason="need cuda compute >= 9.0")
-def test_ptxd_stmatrix_noncontiguous(trans, num):
+def test_ptx_stmatrix_noncontiguous(trans, num):
     """Symmetric stmatrix API: ``num`` independent src handles.
 
     Spaces fragments by 4 fp16 (vs the natural 2 contiguous) so per-src
@@ -240,7 +240,7 @@ def test_ptxd_stmatrix_noncontiguous(trans, num):
             A_local[i * STRIDE + 0] = T.float16(i * 64 + tx * 2 + 0)
             A_local[i * STRIDE + 1] = T.float16(i * 64 + tx * 2 + 1)
         A_words = A_local.view("uint32")
-        T.ptxd[f"stmatrix.sync.aligned.m8n8.x{num}{'.trans' if trans else ''}.shared.b16"](
+        T.ptx[f"stmatrix.sync.aligned.m8n8.x{num}{'.trans' if trans else ''}.shared.b16"](
             A_shared.ptr_to([tx % 16, tx // 16 * 8]),
             *[A_words[i * STRIDE // 2] for i in range(num)],
         )
@@ -294,7 +294,7 @@ def test_bar_arrive():
         T.device_entry()
         cta_id = T.cta_id([1])
         tid = T.thread_id([128])
-        T.ptxd.bar.arrive(0, 128)
+        T.ptx.bar.arrive(0, 128)
         # fmt: on
 
     src, mod = _get_source(func)
@@ -311,7 +311,7 @@ def test_bar_sync():
         T.device_entry()
         cta_id = T.cta_id([1])
         tid = T.thread_id([128])
-        T.ptxd.bar.sync(0, 128)
+        T.ptx.bar.sync(0, 128)
         # fmt: on
 
     src, mod = _get_source(func)
@@ -328,7 +328,7 @@ def test_barrier_sync_unaligned():
         T.device_entry()
         cta_id = T.cta_id([1])
         tid = T.thread_id([128])
-        T.ptxd.barrier.sync(0, 128)
+        T.ptx.barrier.sync(0, 128)
         # fmt: on
 
     src, mod = _get_source(func)
@@ -345,7 +345,7 @@ def test_fence_mbarrier_init_release_clsuter():
         T.device_entry()
         cta_id = T.cta_id([1])
         tid = T.thread_id([128])
-        T.ptxd.fence.mbarrier_init.release.cluster()
+        T.ptx.fence.mbarrier_init.release.cluster()
         # fmt: on
 
     src, mod = _get_source(func)
@@ -380,7 +380,7 @@ def test_ptx_fence(sem, scope):
         T.device_entry()
         cta_id = T.cta_id([1])
         tid = T.thread_id([128])
-        T.ptxd[f"fence.{sem}.{scope}"]()
+        T.ptx[f"fence.{sem}.{scope}"]()
         # fmt: on
 
     src, mod = _get_source(func)
@@ -396,8 +396,8 @@ def test_fence_proxy_async():
         T.device_entry()
         cta_id = T.cta_id([1])
         tid = T.thread_id([128])
-        T.ptxd.fence.proxy.async_.global_()
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.proxy.async_.global_()
+        T.ptx.fence.proxy.async_.shared__cta()
 
         # fmt: on
 
@@ -448,22 +448,22 @@ def test_cp_async_bulk_tensor_global_to_shared_unicast(dtype, inputs):
 
                     phase = 0
                     if threadIdx == 0:
-                        T.ptxd.mbarrier.init.shared.b64(T.address_of(bar), T.uint32(1))
-                        T.ptxd.fence.proxy.async_.shared__cta()
-                        T.ptxd[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes"](A_smem.data, T.address_of(A_map), *coord, T.address_of(bar))  # noqa: E501
-                        T.ptxd.mbarrier.arrive.expect_tx.shared.b64(
+                        T.ptx.mbarrier.init.shared.b64(T.address_of(bar), T.uint32(1))
+                        T.ptx.fence.proxy.async_.shared__cta()
+                        T.ptx[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes"](A_smem.data, T.address_of(A_map), *coord, T.address_of(bar))  # noqa: E501
+                        T.ptx.mbarrier.arrive.expect_tx.shared.b64(
                             T.address_of(bar), T.uint32(total_bytes)
                         )
                     T.cuda.mbarrier_wait(T.address_of(bar), phase)
                     phase = phase ^ 1
 
                     T.cuda.cta_sync()
-                    T.ptxd.fence.proxy.async_.shared__cta()
+                    T.ptx.fence.proxy.async_.shared__cta()
 
                     if threadIdx == 0:
-                        T.ptxd[f"cp.async.bulk.tensor.{len(shape)}d.global.shared::cta.tile.bulk_group"](T.address_of(B_map), *coord, A_smem.access_ptr("r", offset=0))  # noqa: E501
-                        T.ptxd.cp.async_.bulk.commit_group()
-                        T.ptxd.cp.async_.bulk.wait_group(0)
+                        T.ptx[f"cp.async.bulk.tensor.{len(shape)}d.global.shared::cta.tile.bulk_group"](T.address_of(B_map), *coord, A_smem.access_ptr("r", offset=0))  # noqa: E501
+                        T.ptx.cp.async_.bulk.commit_group()
+                        T.ptx.cp.async_.bulk.wait_group(0)
             # fmt: on
 
         return main
@@ -641,22 +641,22 @@ def test_cp_async_bulk_tensor_global_to_shared_swizzle(swizzle, dtype):
 
                     phase = 0
                     if threadIdx == 0:
-                        T.ptxd.mbarrier.init.shared.b64(T.address_of(bar), T.uint32(1))
-                        T.ptxd.fence.proxy.async_.shared__cta()
-                        T.ptxd[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes"](A_smem.data, T.address_of(A_map), *coord, T.address_of(bar))  # noqa: E501
-                        T.ptxd.mbarrier.arrive.expect_tx.shared.b64(
+                        T.ptx.mbarrier.init.shared.b64(T.address_of(bar), T.uint32(1))
+                        T.ptx.fence.proxy.async_.shared__cta()
+                        T.ptx[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes"](A_smem.data, T.address_of(A_map), *coord, T.address_of(bar))  # noqa: E501
+                        T.ptx.mbarrier.arrive.expect_tx.shared.b64(
                             T.address_of(bar), T.uint32(total_bytes)
                         )
                         T.cuda.mbarrier_wait(T.address_of(bar), phase)
                     phase = phase ^ 1
 
                     T.cuda.cta_sync()
-                    T.ptxd.fence.proxy.async_.shared__cta()
+                    T.ptx.fence.proxy.async_.shared__cta()
 
                     if threadIdx == 0:
-                        T.ptxd[f"cp.async.bulk.tensor.{len(shape)}d.global.shared::cta.tile.bulk_group"](T.address_of(B_map), *coord, A_smem.access_ptr("r", offset=0))  # noqa: E501
-                        T.ptxd.cp.async_.bulk.commit_group()
-                        T.ptxd.cp.async_.bulk.wait_group(0)
+                        T.ptx[f"cp.async.bulk.tensor.{len(shape)}d.global.shared::cta.tile.bulk_group"](T.address_of(B_map), *coord, A_smem.access_ptr("r", offset=0))  # noqa: E501
+                        T.ptx.cp.async_.bulk.commit_group()
+                        T.ptx.cp.async_.bulk.wait_group(0)
             # fmt: on
 
         return main, shape
@@ -736,25 +736,25 @@ def test_cp_async_bulk_tensor_global_to_shared_multicast1(inputs):
                         phase = 0
                         if tx == 0:
                                     # leader thread in each CTA
-                            T.ptxd.mbarrier.init.shared.b64(T.address_of(bar), T.uint32(1))
-                            T.ptxd.fence.proxy.async_.shared__cta()
-                            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(
+                            T.ptx.mbarrier.init.shared.b64(T.address_of(bar), T.uint32(1))
+                            T.ptx.fence.proxy.async_.shared__cta()
+                            T.ptx.mbarrier.arrive.expect_tx.shared.b64(
                                 T.address_of(bar), T.uint32(total_bytes)
                             )
                             if clusterCtaIdx == 0:
                                         # only the first CTA in the cluster does the copy, and then multicast  # noqa: E501
-                                T.ptxd[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster"](A_smem.data, T.address_of(A_map), *coord, T.address_of(bar), int("1111", 2))  # noqa: E501
+                                T.ptx[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster"](A_smem.data, T.address_of(A_map), *coord, T.address_of(bar), int("1111", 2))  # noqa: E501
                                 # wait for the copy to finish
                         T.cuda.mbarrier_wait(T.address_of(bar), phase)
                         phase = phase ^ 1
                         T.cuda.cta_sync()
-                        T.ptxd.fence.proxy.async_.shared__cta()
+                        T.ptx.fence.proxy.async_.shared__cta()
 
                         if bx == 2:
                             if tx == 0:
-                                T.ptxd[f"cp.async.bulk.tensor.{len(shape)}d.global.shared::cta.tile.bulk_group"](T.address_of(B_map), *coord, A_smem.access_ptr("r", offset=0))  # noqa: E501
-                                T.ptxd.cp.async_.bulk.commit_group()
-                                T.ptxd.cp.async_.bulk.wait_group(0)
+                                T.ptx[f"cp.async.bulk.tensor.{len(shape)}d.global.shared::cta.tile.bulk_group"](T.address_of(B_map), *coord, A_smem.access_ptr("r", offset=0))  # noqa: E501
+                                T.ptx.cp.async_.bulk.commit_group()
+                                T.ptx.cp.async_.bulk.wait_group(0)
             # fmt: on
 
         return main
@@ -824,22 +824,22 @@ def test_cp_async_bulk_tensor_global_to_shared_multicast2(inputs):
                         phase = 0
                         if tx == 0:
                                     # leader thread in each CTA
-                            T.ptxd.mbarrier.init.shared.b64(T.address_of(bar), T.uint32(1))
-                            T.ptxd.fence.proxy.async_.shared__cta()
-                            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(
+                            T.ptx.mbarrier.init.shared.b64(T.address_of(bar), T.uint32(1))
+                            T.ptx.fence.proxy.async_.shared__cta()
+                            T.ptx.mbarrier.arrive.expect_tx.shared.b64(
                                 T.address_of(bar), T.uint32(total_bytes)
                             )
                             if clusterCtaIdx == 0:
-                                T.ptxd[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster"](A_smem.access_ptr(BufferAccessKind.WRITE, offset=A_smem.elem_offset_of(coord0[::-1])),  # noqa: E501
+                                T.ptx[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster"](A_smem.access_ptr(BufferAccessKind.WRITE, offset=A_smem.elem_offset_of(coord0[::-1])),  # noqa: E501
                                                                T.address_of(A_map), *coord0, T.address_of(bar), int("1111", 2))  # noqa: E501
                             if clusterCtaIdx == 1:
-                                T.ptxd[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster"](A_smem.access_ptr(BufferAccessKind.WRITE, offset=A_smem.elem_offset_of(coord1[::-1])),  # noqa: E501
+                                T.ptx[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster"](A_smem.access_ptr(BufferAccessKind.WRITE, offset=A_smem.elem_offset_of(coord1[::-1])),  # noqa: E501
                                                                T.address_of(A_map), *coord1, T.address_of(bar), int("1111", 2))  # noqa: E501
                             if clusterCtaIdx == 2:
-                                T.ptxd[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster"](A_smem.access_ptr(BufferAccessKind.WRITE, offset=A_smem.elem_offset_of(coord2[::-1])),  # noqa: E501
+                                T.ptx[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster"](A_smem.access_ptr(BufferAccessKind.WRITE, offset=A_smem.elem_offset_of(coord2[::-1])),  # noqa: E501
                                                                T.address_of(A_map), *coord2, T.address_of(bar), int("1111", 2))  # noqa: E501
                             if clusterCtaIdx == 3:
-                                T.ptxd[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster"](A_smem.access_ptr(BufferAccessKind.WRITE, offset=A_smem.elem_offset_of(coord3[::-1])),  # noqa: E501
+                                T.ptx[f"cp.async.bulk.tensor.{len(shape)}d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster"](A_smem.access_ptr(BufferAccessKind.WRITE, offset=A_smem.elem_offset_of(coord3[::-1])),  # noqa: E501
                                                                T.address_of(A_map), *coord3, T.address_of(bar), int("1111", 2))  # noqa: E501
                                 # wait for the copy to finish
                         T.cuda.mbarrier_wait(T.address_of(bar), phase)
@@ -848,9 +848,9 @@ def test_cp_async_bulk_tensor_global_to_shared_multicast2(inputs):
 
                         if bx == 1:
                             if tx == 0:
-                                T.ptxd[f"cp.async.bulk.tensor.{len(shape)}d.global.shared::cta.tile.bulk_group"](T.address_of(B_map), *coord0, A_smem.access_ptr("r", offset=0))  # noqa: E501
-                                T.ptxd.cp.async_.bulk.commit_group()
-                                T.ptxd.cp.async_.bulk.wait_group(0)
+                                T.ptx[f"cp.async.bulk.tensor.{len(shape)}d.global.shared::cta.tile.bulk_group"](T.address_of(B_map), *coord0, A_smem.access_ptr("r", offset=0))  # noqa: E501
+                                T.ptx.cp.async_.bulk.commit_group()
+                                T.ptx.cp.async_.bulk.wait_group(0)
             # fmt: on
 
         return main
@@ -909,13 +909,13 @@ def test_cp_async_bulk_tensor_shared_to_global(inputs):
             if tx == 0:
                 for i in T.serial(0, elems):
                     A_smem[i] = i
-            T.ptxd.fence.proxy.async_.shared__cta()
+            T.ptx.fence.proxy.async_.shared__cta()
             T.cuda.cta_sync()
 
             if tx == 0:
-                T.ptxd[f"cp.async.bulk.tensor.{len(shape)}d.global.shared::cta.tile.bulk_group"](T.address_of(A_map), *coord, A_smem.access_ptr("r", offset=0))  # noqa: E501
-                T.ptxd.cp.async_.bulk.commit_group()
-                T.ptxd.cp.async_.bulk.wait_group(0)
+                T.ptx[f"cp.async.bulk.tensor.{len(shape)}d.global.shared::cta.tile.bulk_group"](T.address_of(A_map), *coord, A_smem.access_ptr("r", offset=0))  # noqa: E501
+                T.ptx.cp.async_.bulk.commit_group()
+                T.ptx.cp.async_.bulk.wait_group(0)
             # fmt: on
 
         return main
@@ -1003,14 +1003,14 @@ def test_wgmma_ss_nt():
                     # init phase and bar
             phase = 0
             if tx == 0:
-                T.ptxd.mbarrier.init.shared.b64(T.address_of(bar), T.uint32(1))
-            T.ptxd.fence.proxy.async_.shared__cta()
+                T.ptx.mbarrier.init.shared.b64(T.address_of(bar), T.uint32(1))
+            T.ptx.fence.proxy.async_.shared__cta()
             T.cuda.cta_sync()
                     # load A and B to smem
             if tx == 0:
-                T.ptxd[f"cp.async.bulk.tensor.{len(shapeA)}d.shared::cluster.global.mbarrier::complete_tx::bytes"](A_smem.data, T.address_of(A_map), *coordA, T.address_of(bar))  # noqa: E501
-                T.ptxd[f"cp.async.bulk.tensor.{len(shapeB)}d.shared::cluster.global.mbarrier::complete_tx::bytes"](B_smem.data, T.address_of(B_map), *coordB, T.address_of(bar))  # noqa: E501
-                T.ptxd.mbarrier.arrive.expect_tx.shared.b64(
+                T.ptx[f"cp.async.bulk.tensor.{len(shapeA)}d.shared::cluster.global.mbarrier::complete_tx::bytes"](A_smem.data, T.address_of(A_map), *coordA, T.address_of(bar))  # noqa: E501
+                T.ptx[f"cp.async.bulk.tensor.{len(shapeB)}d.shared::cluster.global.mbarrier::complete_tx::bytes"](B_smem.data, T.address_of(B_map), *coordB, T.address_of(bar))  # noqa: E501
+                T.ptx.mbarrier.arrive.expect_tx.shared.b64(
                     T.address_of(bar), T.uint32(A_bytes + B_bytes)
                 )
             T.cuda.mbarrier_wait(T.address_of(bar), phase)
@@ -1025,11 +1025,11 @@ def test_wgmma_ss_nt():
                     # do wgmma
             T.cuda.wgmma.encode_matrix_descriptor(T.address_of(descA), A_smem.data, *A_encode_args)  # noqa: F821
             T.cuda.wgmma.encode_matrix_descriptor(T.address_of(descB), B_smem.data, *B_encode_args)  # noqa: F821
-            T.ptxd.wgmma.fence.sync.aligned()
-            T.ptxd[mma_chain](*get_accum_list(C_local, C_elems), descA, descB,  # noqa: F821
+            T.ptx.wgmma.fence.sync.aligned()
+            T.ptx[mma_chain](*get_accum_list(C_local, C_elems), descA, descB,  # noqa: F821
                               0, 1, 1, int(transA), int(transB))
-            T.ptxd.wgmma.commit_group.sync.aligned()
-            T.ptxd.wgmma.wait_group.sync.aligned(0)
+            T.ptx.wgmma.commit_group.sync.aligned()
+            T.ptx.wgmma.wait_group.sync.aligned(0)
 
             for i in T.serial(0, C_elems):
                 T.cuda.wgmma.noop_barrier(C_local[i])
@@ -1169,13 +1169,13 @@ def test_wgmma_rs_nt():
                 A_local[i * 4 + 3] = A[row + 8, col + 1]
                     # init bar, and make sure it's visible to all threads and async proxy
             if tx == 0:
-                T.ptxd.mbarrier.init.shared.b64(T.address_of(bar), T.uint32(1))
-            T.ptxd.fence.proxy.async_.shared__cta()
+                T.ptx.mbarrier.init.shared.b64(T.address_of(bar), T.uint32(1))
+            T.ptx.fence.proxy.async_.shared__cta()
             T.cuda.cta_sync()
                     # load B to smem
             if tx == 0:
-                T.ptxd[f"cp.async.bulk.tensor.{len(shapeB)}d.shared::cluster.global.mbarrier::complete_tx::bytes"](B_smem.data, T.address_of(B_map), *coordB, T.address_of(bar))  # noqa: E501
-                T.ptxd.mbarrier.arrive.expect_tx.shared.b64(T.address_of(bar), T.uint32(B_bytes))
+                T.ptx[f"cp.async.bulk.tensor.{len(shapeB)}d.shared::cluster.global.mbarrier::complete_tx::bytes"](B_smem.data, T.address_of(B_map), *coordB, T.address_of(bar))  # noqa: E501
+                T.ptx.mbarrier.arrive.expect_tx.shared.b64(T.address_of(bar), T.uint32(B_bytes))
             T.cuda.mbarrier_wait(T.address_of(bar), 0)
             T.cuda.cta_sync()
 
@@ -1190,11 +1190,11 @@ def test_wgmma_rs_nt():
                 T.cuda.wgmma.noop_barrier(C_local[i])
                     # do wgmma
             T.cuda.wgmma.encode_matrix_descriptor(T.address_of(descB), B_smem.data, *B_encode_args)  # noqa: F821
-            T.ptxd.wgmma.fence.sync.aligned()
-            T.ptxd[mma_chain](*get_accum_list(C_local, C_elems), *get_A_list(A_local_b32, A_elems_b32),  # noqa: E501
+            T.ptx.wgmma.fence.sync.aligned()
+            T.ptx[mma_chain](*get_accum_list(C_local, C_elems), *get_A_list(A_local_b32, A_elems_b32),  # noqa: E501
                               descB, 0, 1, 1, int(transB))  # noqa: F821
-            T.ptxd.wgmma.commit_group.sync.aligned()
-            T.ptxd.wgmma.wait_group.sync.aligned(0)
+            T.ptx.wgmma.commit_group.sync.aligned()
+            T.ptx.wgmma.wait_group.sync.aligned(0)
 
                     # fence A_local
             for i in T.serial(0, A_elems_b32):
@@ -1279,7 +1279,7 @@ def test_mapa():
         A_smem = T.alloc_buffer([1], "uint32", scope="shared")
         mapped = T.alloc_local([1], "uint64")
         if cbx == 0 and tx == 0:
-            T.ptxd.mapa.u64(mapped[0], A_smem.data, T.uint32(cbx))
+            T.ptx.mapa.u64(mapped[0], A_smem.data, T.uint32(cbx))
 
     src, mod = _get_source(func)
     print(src)

--- a/tests/python/tirx/codegen/test_codegen_hopper.py
+++ b/tests/python/tirx/codegen/test_codegen_hopper.py
@@ -298,7 +298,7 @@ def test_bar_arrive():
         # fmt: on
 
     src, mod = _get_source(func)
-    assert "tvm_builtin_ptxd_bar_arrive_arrive((uint)0, (uint)128)" in src
+    assert "tvm_builtin_ptx_bar_arrive_arrive((uint)0, (uint)128)" in src
     assert 'bar.arrive %0, %1;" :  : "r"(__a), "r"(__b) : "memory"' in src
 
 
@@ -315,7 +315,7 @@ def test_bar_sync():
         # fmt: on
 
     src, mod = _get_source(func)
-    assert "tvm_builtin_ptxd_bar_sync_count_sync((uint)0, (uint)128)" in src
+    assert "tvm_builtin_ptx_bar_sync_count_sync((uint)0, (uint)128)" in src
     assert 'bar.sync %0, %1;" :  : "r"(__a), "r"(__b) : "memory"' in src
 
 
@@ -332,7 +332,7 @@ def test_barrier_sync_unaligned():
         # fmt: on
 
     src, mod = _get_source(func)
-    assert "tvm_builtin_ptxd_barrier_sync_count_sync((uint)0, (uint)128)" in src
+    assert "tvm_builtin_ptx_barrier_sync_count_sync((uint)0, (uint)128)" in src
     assert 'barrier.sync %0, %1;" :  : "r"(__a), "r"(__b) : "memory"' in src
 
 
@@ -1283,7 +1283,7 @@ def test_mapa():
 
     src, mod = _get_source(func)
     print(src)
-    assert "tvm_builtin_ptxd_mapa_u64(" in src
+    assert "tvm_builtin_ptx_mapa_u64(" in src
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/codegen/test_ptx_cvt.py
+++ b/tests/python/tirx/codegen/test_ptx_cvt.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""The ptxd cvt entries: one case per registered syntax line of ISA 9.7.9.22."""
+"""The ptx cvt entries: one case per registered syntax line of ISA 9.7.9.22."""
 
 import pytest
 
@@ -251,7 +251,7 @@ def test_cvt_form_renders_its_instruction(entry_name, slots, instruction):
     # single-instruction invariant's job, not this test's.
     assert f"{instruction} " in source
     assert helper.startswith("tvm_builtin_ptxd_cvt_")
-    # Every ptxd helper is void: the destination is an operand, not a return.
+    # Every ptx helper is void: the destination is an operand, not a return.
     assert source.startswith("__forceinline__ __device__ void ")
 
 

--- a/tests/python/tirx/codegen/test_ptx_cvt.py
+++ b/tests/python/tirx/codegen/test_ptx_cvt.py
@@ -250,7 +250,7 @@ def test_cvt_form_renders_its_instruction(entry_name, slots, instruction):
     # text. That those bodies emit it as their own statement is the
     # single-instruction invariant's job, not this test's.
     assert f"{instruction} " in source
-    assert helper.startswith("tvm_builtin_ptxd_cvt_")
+    assert helper.startswith("tvm_builtin_ptx_cvt_")
     # Every ptx helper is void: the destination is an operand, not a return.
     assert source.startswith("__forceinline__ __device__ void ")
 
@@ -284,7 +284,7 @@ def test_cvt_e2m1x2_stages_its_b8_operand():
     and bridge it to the 16-bit "h" carrier; uint8_t is what the caller sees.
     """
     _, _, source = render_variant(TABLE["cvt_f4x2_f32"], ("rn", "satfinite", "", "e2m1x2", "f32"))
-    assert "void tvm_builtin_ptxd_cvt_f4x2_f32_rn_satfinite_e2m1x2_f32(" in source
+    assert "void tvm_builtin_ptx_cvt_f4x2_f32_rn_satfinite_e2m1x2_f32(" in source
     assert "(uint8_t& __d, float __a, float __b)" in source
     assert (
         '"{ .reg .b8 raw_d; cvt.rn.satfinite.e2m1x2.f32 raw_d, %1, %2;'

--- a/tests/python/tirx/codegen/test_ptx_dialect.py
+++ b/tests/python/tirx/codegen/test_ptx_dialect.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Tests for the table-driven PTX dialect prototype (``T.ptx``)."""
+"""Tests for the table-driven PTX dialect (``T.ptx``)."""
 
 import os
 import re

--- a/tests/python/tirx/codegen/test_ptx_dialect.py
+++ b/tests/python/tirx/codegen/test_ptx_dialect.py
@@ -79,7 +79,7 @@ def test_ptx_prefetch_codegen():
 
     src = _cuda_source(kernel)
     assert "prefetch.global.L2 [%0];" in src
-    assert "tvm_builtin_ptxd_prefetch_global_L2" in src
+    assert "tvm_builtin_ptx_prefetch_global_L2" in src
 
 
 def test_ptx_ld_st_codegen():
@@ -102,8 +102,8 @@ def test_ptx_ld_st_codegen():
     # regardless of the order they were written in the chain.
     assert "ld.acquire.gpu.global.b32 %0, [%1];" in src
     assert "st.release.gpu.global.b32 [%0], %1;" in src
-    assert "tvm_builtin_ptxd_ld_acquire_gpu_global_b32" in src
-    assert "tvm_builtin_ptxd_st_release_gpu_global_b32" in src
+    assert "tvm_builtin_ptx_ld_acquire_gpu_global_b32" in src
+    assert "tvm_builtin_ptx_st_release_gpu_global_b32" in src
 
 
 def test_ptx_st_shared_coercion():
@@ -140,7 +140,7 @@ def test_ptx_explicit_cvta():
 
     src = _cuda_source(kernel)
     assert "cvta.to.shared.u64 %0, %1;" in src
-    assert "tvm_builtin_ptxd_cvta_to_shared_u64" in src
+    assert "tvm_builtin_ptx_cvta_to_shared_u64" in src
 
 
 def test_ptx_red_codegen():
@@ -172,7 +172,7 @@ def test_ptx_predication_codegen():
         A[tx] = A[tx]
 
     src = _cuda_source(kernel)
-    assert "tvm_builtin_ptxd_red_relaxed_gpu_global_add_u32_pred" in src
+    assert "tvm_builtin_ptx_red_relaxed_gpu_global_add_u32_pred" in src
     assert "setp.ne.b32 p, %2, 0; @p red.relaxed.gpu.global.add.u32 [%0], %1;" in src
 
 
@@ -319,8 +319,8 @@ def test_ptx_register_group_codegen():
     assert "mov.b64 {%0, %1}, %2;" in src
     # Both shapes share the mnemonic; the operand shape picks the entry, which
     # is the same information ptxas resolves them by.
-    assert "tvm_builtin_ptxd_mov_pack_b32x2_b64_u64_f32(" in src
-    assert "tvm_builtin_ptxd_mov_unpack_b32x2_b64_f32_u64(" in src
+    assert "tvm_builtin_ptx_mov_pack_b32x2_b64_u64_f32(" in src
+    assert "tvm_builtin_ptx_mov_unpack_b32x2_b64_f32_u64(" in src
 
 
 def test_ptx_register_group_errors():
@@ -454,9 +454,9 @@ def test_ptx_bit_width_axis():
 
     src = _cuda_source(kernel)
     # One instruction text, three signatures, named by the dtypes they carry.
-    assert "tvm_builtin_ptxd_ld_global_b32_f32(float& __d" in src
-    assert "tvm_builtin_ptxd_ld_global_b32_s32(int32_t& __d" in src
-    assert "tvm_builtin_ptxd_st_global_b32_f32(const void* __addr, float __value" in src
+    assert "tvm_builtin_ptx_ld_global_b32_f32(float& __d" in src
+    assert "tvm_builtin_ptx_ld_global_b32_s32(int32_t& __d" in src
+    assert "tvm_builtin_ptx_st_global_b32_f32(const void* __addr, float __value" in src
     assert '"=f"(__d)' in src and '"=r"(__d)' in src
     assert src.count("ld.global.b32 %0, [%1];") >= 1
     # The float binds "f" directly. Routing it through the canonical uint32_t
@@ -468,7 +468,7 @@ def test_ptx_bit_width_axis():
 
     ld = TABLE["ld"]
     tokens = tokens_for(ld, space="global", type="b32")
-    assert render_variant(ld, tokens)[1] == "tvm_builtin_ptxd_ld_global_b32"
+    assert render_variant(ld, tokens)[1] == "tvm_builtin_ptx_ld_global_b32"
 
 
 def test_ptx_u64_address_handle_is_reinterpreted():
@@ -565,7 +565,7 @@ def test_ptx_helper_source_golden():
         tokens_for(TABLE["ld"], space="global")
 
     assert render("prefetch", space="global", level="L2") == (
-        "__forceinline__ __device__ void tvm_builtin_ptxd_prefetch_global_L2"
+        "__forceinline__ __device__ void tvm_builtin_ptx_prefetch_global_L2"
         "(const void* __addr) {\n"
         '  asm volatile("prefetch.global.L2 [%0];" :  : "l"(__addr) : "memory");\n'
         "}\n"
@@ -573,7 +573,7 @@ def test_ptx_helper_source_golden():
     # A destination is an ordinary operand taken by reference, so the C
     # parameter list is the PTX operand list in order and the helper is void.
     assert render("ld", sem="acquire", scope="gpu", space="global", type="b32") == (
-        "__forceinline__ __device__ void tvm_builtin_ptxd_ld_acquire_gpu_global_b32"
+        "__forceinline__ __device__ void tvm_builtin_ptx_ld_acquire_gpu_global_b32"
         "(uint32_t& __d, const void* __addr) {\n"
         '  asm volatile("ld.acquire.gpu.global.b32 %0, [%1];" : "=r"(__d) : "l"(__addr)'
         ' : "memory");\n'
@@ -583,7 +583,7 @@ def test_ptx_helper_source_golden():
     # carrier register and is narrowed into the reference afterwards. The asm
     # block still holds exactly one instruction.
     assert render("ld", space="global", type="b8") == (
-        "__forceinline__ __device__ void tvm_builtin_ptxd_ld_global_b8"
+        "__forceinline__ __device__ void tvm_builtin_ptx_ld_global_b8"
         "(uint8_t& __d, const void* __addr) {\n"
         "  uint16_t __d_reg;\n"
         '  asm volatile("ld.global.b8 %0, [%1];" : "=h"(__d_reg) : "l"(__addr) : "memory");\n'
@@ -592,7 +592,7 @@ def test_ptx_helper_source_golden():
     )
     # Shared-space addr slot: helper takes uint32_t (post-coercion form), not void*.
     assert render("st", space="shared::cta", type="b32") == (
-        "__forceinline__ __device__ void tvm_builtin_ptxd_st_shared__cta_b32"
+        "__forceinline__ __device__ void tvm_builtin_ptx_st_shared__cta_b32"
         "(uint32_t __addr, uint32_t __value) {\n"
         '  asm volatile("st.shared::cta.b32 [%0], %1;" :  : "r"(__addr), "r"(__value)'
         ' : "memory");\n'
@@ -600,7 +600,7 @@ def test_ptx_helper_source_golden():
     )
     # Register-only op: plain asm (asm_volatile=False), no memory clobber.
     assert render("cvta", dir="to", space="shared", type="u64") == (
-        "__forceinline__ __device__ void tvm_builtin_ptxd_cvta_to_shared_u64"
+        "__forceinline__ __device__ void tvm_builtin_ptx_cvta_to_shared_u64"
         "(uint64_t& __d, const void* __ptr) {\n"
         '  asm("cvta.to.shared.u64 %0, %1;" : "=l"(__d) : "l"(__ptr));\n'
         "}\n"
@@ -610,7 +610,7 @@ def test_ptx_helper_source_golden():
     assert render(
         "red", predicated=True, sem="relaxed", scope="gpu", space="global", op="add", type="u32"
     ) == (
-        "__forceinline__ __device__ void tvm_builtin_ptxd_red_relaxed_gpu_global_add_u32_pred"
+        "__forceinline__ __device__ void tvm_builtin_ptx_red_relaxed_gpu_global_add_u32_pred"
         "(const void* __addr, uint32_t __value, uint32_t __pred) {\n"
         '  asm volatile("{ .reg .pred p; setp.ne.b32 p, %2, 0; '
         '@p red.relaxed.gpu.global.add.u32 [%0], %1; }"'
@@ -627,7 +627,7 @@ def test_ptx_helper_source_golden():
         src_space="global",
         completion="mbarrier::complete_tx::bytes",
     ) == (
-        "__forceinline__ __device__ void tvm_builtin_ptxd_cp_async_bulk_shared__cta_global"
+        "__forceinline__ __device__ void tvm_builtin_ptx_cp_async_bulk_shared__cta_global"
         "_mbarrier__complete_tx__bytes"
         "(uint32_t __dst, const void* __src, uint32_t __size, uint32_t __mbar) {\n"
         '  asm volatile("cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes '
@@ -640,13 +640,13 @@ def test_ptx_helper_source_golden():
     # the group is braces in the asm text and flat C parameters around it. An
     # unpack turns that into two "=" outputs.
     assert render("mov_pack_b32x2", type="b64") == (
-        "__forceinline__ __device__ void tvm_builtin_ptxd_mov_pack_b32x2_b64"
+        "__forceinline__ __device__ void tvm_builtin_ptx_mov_pack_b32x2_b64"
         "(uint64_t& __d, uint32_t __a0, uint32_t __a1) {\n"
         '  asm("mov.b64 %0, {%1, %2};" : "=l"(__d) : "r"(__a0), "r"(__a1));\n'
         "}\n"
     )
     assert render("mov_unpack_b32x2", type="b64") == (
-        "__forceinline__ __device__ void tvm_builtin_ptxd_mov_unpack_b32x2_b64"
+        "__forceinline__ __device__ void tvm_builtin_ptx_mov_unpack_b32x2_b64"
         "(uint32_t& __d0, uint32_t& __d1, uint64_t __a) {\n"
         '  asm("mov.b64 {%0, %1}, %2;" : "=r"(__d0), "=r"(__d1) : "l"(__a));\n'
         "}\n"
@@ -654,7 +654,7 @@ def test_ptx_helper_source_golden():
     # 128-bit destination on the "q" constraint, and asm_volatile=False: a
     # register shuffle nvcc is free to common up.
     assert render("mov_pack_b64x2", type="b128") == (
-        "__forceinline__ __device__ void tvm_builtin_ptxd_mov_pack_b64x2_b128"
+        "__forceinline__ __device__ void tvm_builtin_ptx_mov_pack_b64x2_b128"
         "(__uint128_t& __d, uint64_t __a0, uint64_t __a1) {\n"
         '  asm("mov.b128 %0, {%1, %2};" : "=q"(__d) : "l"(__a0), "l"(__a1));\n'
         "}\n"
@@ -663,7 +663,7 @@ def test_ptx_helper_source_golden():
     # moves the lanes to "f", and nothing else moves. This is the shape the
     # packed-f32x2 call sites use.
     assert render("mov_pack_b32x2", type="b64", dtypes=("uint64", "float32")) == (
-        "__forceinline__ __device__ void tvm_builtin_ptxd_mov_pack_b32x2_b64_u64_f32"
+        "__forceinline__ __device__ void tvm_builtin_ptx_mov_pack_b32x2_b64_u64_f32"
         "(uint64_t& __d, float __a0, float __a1) {\n"
         '  asm("mov.b64 %0, {%1, %2};" : "=l"(__d) : "f"(__a0), "f"(__a1));\n'
         "}\n"

--- a/tests/python/tirx/codegen/test_ptx_dialect.py
+++ b/tests/python/tirx/codegen/test_ptx_dialect.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Tests for the table-driven PTX dialect prototype (``T.ptxd``)."""
+"""Tests for the table-driven PTX dialect prototype (``T.ptx``)."""
 
 import os
 import re
@@ -43,10 +43,10 @@ def _cuda_source(func) -> str:
 # higher (tcgen05, clusterlaunchcontrol, several cp.async.bulk forms) MUST be
 # certified at their own floor: assembling them below it makes ptxas report
 # legal variants as illegal, which would then get baked into a check().
-PTXD_ARCH = os.environ.get("PTXD_ARCH", "sm_90")
+PTX_ARCH = os.environ.get("PTX_ARCH", "sm_90")
 
 
-def _assert_ptxas_ok(src: str, rdc: bool = False, arch: str = PTXD_ARCH) -> None:
+def _assert_ptxas_ok(src: str, rdc: bool = False, arch: str = PTX_ARCH) -> None:
     """Assemble through ptxas (cubin) — `-ptx` alone never validates inline asm."""
     from tvm.support import nvcc
 
@@ -54,27 +54,27 @@ def _assert_ptxas_ok(src: str, rdc: bool = False, arch: str = PTXD_ARCH) -> None
     nvcc.compile_cuda(src, target_format="cubin", arch=arch, options=options, compiler="nvcc")
 
 
-def test_ptxd_registration():
+def test_ptx_registration():
     from tvm.backend.cuda.intrinsics.registry import CODEGEN_REGISTRY
     from tvm.backend.cuda.ptx_dialect.table import TABLE
 
-    assert hasattr(T, "ptxd")
+    assert hasattr(T, "ptx")
     for entry in TABLE.values():
         op = Op.get(entry.op_name)  # raises if unregistered
         assert op.get_attr("TCallEffectKind") is not None, entry.name
         family = entry.family  # several entries may share a mnemonic
-        assert op.get_attr("TScriptPrinterName") == f"ptxd.{family}", entry.name
+        assert op.get_attr("TScriptPrinterName") == f"ptx.{family}", entry.name
         assert entry.op_name in CODEGEN_REGISTRY, entry.name
 
 
-def test_ptxd_prefetch_codegen():
+def test_ptx_prefetch_codegen():
     @T.prim_func
     def kernel(a_ptr: T.handle):
         A = T.match_buffer(a_ptr, (32,), "float32")
         T.device_entry()
         T.cta_id([1])
         tx = T.thread_id([32])
-        T.ptxd.prefetch.global_.L2(A.ptr_to([0]))
+        T.ptx.prefetch.global_.L2(A.ptr_to([0]))
         A[tx] = T.float32(0)  # keep-alive store so the buffer is not elided
 
     src = _cuda_source(kernel)
@@ -82,7 +82,7 @@ def test_ptxd_prefetch_codegen():
     assert "tvm_builtin_ptxd_prefetch_global_L2" in src
 
 
-def test_ptxd_ld_st_codegen():
+def test_ptx_ld_st_codegen():
     @T.prim_func
     def kernel(a_ptr: T.handle, b_ptr: T.handle):
         A = T.match_buffer(a_ptr, (32,), "uint32")
@@ -93,8 +93,8 @@ def test_ptxd_ld_st_codegen():
         if tx == 0:
             # Declare the register, then name it as an operand — the PTX model.
             val = T.local_scalar("uint32")
-            T.ptxd.ld.global_.acquire.gpu.b32(val, A.ptr_to([0]))
-            T.ptxd.st.release.gpu.global_.b32(B.ptr_to([0]), val)
+            T.ptx.ld.global_.acquire.gpu.b32(val, A.ptr_to([0]))
+            T.ptx.st.release.gpu.global_.b32(B.ptr_to([0]), val)
         B[tx] = B[tx]
 
     src = _cuda_source(kernel)
@@ -106,7 +106,7 @@ def test_ptxd_ld_st_codegen():
     assert "tvm_builtin_ptxd_st_release_gpu_global_b32" in src
 
 
-def test_ptxd_st_shared_coercion():
+def test_ptx_st_shared_coercion():
     @T.prim_func
     def kernel(out_ptr: T.handle):
         out = T.match_buffer(out_ptr, (1,), "uint32")
@@ -117,7 +117,7 @@ def test_ptxd_st_shared_coercion():
         if tx == 0:
             # Shared-space slot fed a shared-scope pointer: engine must
             # auto-wrap with cvta_generic_to_shared.
-            T.ptxd.st.shared__cta.b32(smem.ptr_to([0]), T.uint32(7))
+            T.ptx.st.shared__cta.b32(smem.ptr_to([0]), T.uint32(7))
         T.cuda.cta_sync()
         out[0] = smem[0]
 
@@ -126,7 +126,7 @@ def test_ptxd_st_shared_coercion():
     assert "cvta_generic_to_shared" in src
 
 
-def test_ptxd_explicit_cvta():
+def test_ptx_explicit_cvta():
     @T.prim_func
     def kernel(out_ptr: T.handle):
         out = T.match_buffer(out_ptr, (1,), "uint64")
@@ -136,14 +136,14 @@ def test_ptxd_explicit_cvta():
         smem = T.alloc_buffer((4,), "uint32", scope="shared")
         smem[tx % 4] = T.uint32(0)
         if tx == 0:
-            T.ptxd.cvta.to.shared.u64(out[0], smem.data)
+            T.ptx.cvta.to.shared.u64(out[0], smem.data)
 
     src = _cuda_source(kernel)
     assert "cvta.to.shared.u64 %0, %1;" in src
     assert "tvm_builtin_ptxd_cvta_to_shared_u64" in src
 
 
-def test_ptxd_red_codegen():
+def test_ptx_red_codegen():
     @T.prim_func
     def kernel(a_ptr: T.handle):
         A = T.match_buffer(a_ptr, (1,), "uint32")
@@ -151,14 +151,14 @@ def test_ptxd_red_codegen():
         T.cta_id([1])
         tx = T.thread_id([32])
         if tx == 0:
-            T.ptxd.red.relaxed.gpu.global_.add.u32(A.ptr_to([0]), T.uint32(1))
+            T.ptx.red.relaxed.gpu.global_.add.u32(A.ptr_to([0]), T.uint32(1))
         A[0] = A[0]
 
     src = _cuda_source(kernel)
     assert "red.relaxed.gpu.global.add.u32 [%0], %1;" in src
 
 
-def test_ptxd_predication_codegen():
+def test_ptx_predication_codegen():
     @T.prim_func
     def kernel(a_ptr: T.handle):
         A = T.match_buffer(a_ptr, (32,), "uint32")
@@ -168,7 +168,7 @@ def test_ptxd_predication_codegen():
         flag: T.uint32 = T.uint32(0)
         if tx == 0:
             flag = T.uint32(1)
-        T.ptxd.red.relaxed.gpu.global_.add.u32(A.ptr_to([0]), T.uint32(1), pred=flag)
+        T.ptx.red.relaxed.gpu.global_.add.u32(A.ptr_to([0]), T.uint32(1), pred=flag)
         A[tx] = A[tx]
 
     src = _cuda_source(kernel)
@@ -176,9 +176,9 @@ def test_ptxd_predication_codegen():
     assert "setp.ne.b32 p, %2, 0; @p red.relaxed.gpu.global.add.u32 [%0], %1;" in src
 
 
-def test_ptxd_string_form_matches_chain():
-    chain_call = T.ptxd.ld.global_.acquire.gpu.b32
-    string_call = T.ptxd["ld.acquire.gpu.global.b32"]
+def test_ptx_string_form_matches_chain():
+    chain_call = T.ptx.ld.global_.acquire.gpu.b32
+    string_call = T.ptx["ld.acquire.gpu.global.b32"]
 
     def make(fn):
         @T.prim_func
@@ -197,14 +197,14 @@ def test_ptxd_string_form_matches_chain():
     tvm.ir.assert_structural_equal(make(chain_call), make(string_call))
 
 
-def test_ptxd_trace_time_errors():
+def test_ptx_trace_time_errors():
     # Global ld fed a raw uint32 address.
     with pytest.raises((ValueError, tvm.error.DiagnosticError), match="shared state space"):
 
         @T.prim_func
         def bad_global_addr(out: T.Buffer((1,), "uint32")):
             T.device_entry()
-            T.ptxd.ld.global_.b32(out[0], T.uint32(0))
+            T.ptx.ld.global_.b32(out[0], T.uint32(0))
 
     # Bogus modifier token.
     with pytest.raises((AttributeError, tvm.error.DiagnosticError), match="not a valid modifier"):
@@ -212,17 +212,17 @@ def test_ptxd_trace_time_errors():
         @T.prim_func
         def bad_modifier(out: T.Buffer((1,), "uint32")):
             T.device_entry()
-            T.ptxd.ld.global_.bogus.b32(out[0], T.uint32(0))
+            T.ptx.ld.global_.bogus.b32(out[0], T.uint32(0))
 
     # Value dtype of the wrong *width*. A bit type accepts any dtype of its own
-    # width (see test_ptxd_bit_width_axis), so the rejection is about size.
+    # width (see test_ptx_bit_width_axis), so the rejection is about size.
     with pytest.raises((ValueError, tvm.error.DiagnosticError), match="must have dtype"):
 
         @T.prim_func
         def bad_value_dtype(a_ptr: T.handle):
             A = T.match_buffer(a_ptr, (1,), "uint32")
             T.device_entry()
-            T.ptxd.st.global_.b32(A.ptr_to([0]), T.float64(1.0))
+            T.ptx.st.global_.b32(A.ptr_to([0]), T.float64(1.0))
 
     # Missing required modifier (no type token).
     with pytest.raises((ValueError, tvm.error.DiagnosticError), match="missing required modifier"):
@@ -231,7 +231,7 @@ def test_ptxd_trace_time_errors():
         def missing_type(a_ptr: T.handle):
             A = T.match_buffer(a_ptr, (1,), "uint32")
             T.device_entry()
-            T.ptxd.st.global_(A.ptr_to([0]), T.uint32(0))
+            T.ptx.st.global_(A.ptr_to([0]), T.uint32(0))
 
     # Per-slot legal tokens whose combination is illegal PTX: acquire
     # requires a scope — rejected by the entry's check function.
@@ -241,7 +241,7 @@ def test_ptxd_trace_time_errors():
         def acquire_without_scope(out: T.Buffer((1,), "uint32"), a_ptr: T.handle):
             A = T.match_buffer(a_ptr, (1,), "uint32")
             T.device_entry()
-            T.ptxd.ld.global_.acquire.b32(out[0], A.ptr_to([0]))
+            T.ptx.ld.global_.acquire.b32(out[0], A.ptr_to([0]))
 
     # A float is not an address in any state space.
     with pytest.raises((ValueError, tvm.error.DiagnosticError), match="pointer or uint64 handle"):
@@ -249,10 +249,10 @@ def test_ptxd_trace_time_errors():
         @T.prim_func
         def bad_addr_dtype(out: T.Buffer((1,), "uint32")):
             T.device_entry()
-            T.ptxd.ld.global_.b32(out[0], T.float32(0))
+            T.ptx.ld.global_.b32(out[0], T.float32(0))
 
 
-def test_ptxd_destination_errors():
+def test_ptx_destination_errors():
     """A destination is a register the caller declared: it must be a writable lvalue."""
     # Destination of the wrong width (a .b32 load into a 64-bit slot).
     with pytest.raises((ValueError, tvm.error.DiagnosticError), match="must have dtype"):
@@ -261,7 +261,7 @@ def test_ptxd_destination_errors():
         def wrong_dst_dtype(out: T.Buffer((1,), "float64"), a_ptr: T.handle):
             A = T.match_buffer(a_ptr, (1,), "uint32")
             T.device_entry()
-            T.ptxd.ld.global_.b32(out[0], A.ptr_to([0]))
+            T.ptx.ld.global_.b32(out[0], A.ptr_to([0]))
 
     # A T.let binding is immutable, so it cannot be written into. This is the
     # gate that keeps the analyzer from re-expanding one call into N.
@@ -272,7 +272,7 @@ def test_ptxd_destination_errors():
             A = T.match_buffer(a_ptr, (1,), "uint32")
             T.device_entry()
             bound: T.let = out[0] + T.uint32(1)
-            T.ptxd.ld.global_.b32(bound, A.ptr_to([0]))
+            T.ptx.ld.global_.b32(bound, A.ptr_to([0]))
 
     # An rvalue is not a destination either.
     with pytest.raises((ValueError, tvm.error.DiagnosticError), match="writable scalar"):
@@ -281,7 +281,7 @@ def test_ptxd_destination_errors():
         def rvalue_destination(a_ptr: T.handle):
             A = T.match_buffer(a_ptr, (1,), "uint32")
             T.device_entry()
-            T.ptxd.ld.global_.b32(T.uint32(0), A.ptr_to([0]))
+            T.ptx.ld.global_.b32(T.uint32(0), A.ptr_to([0]))
 
     # @p is rejected on any instruction that writes a destination.
     with pytest.raises((ValueError, tvm.error.DiagnosticError), match="without a destination"):
@@ -290,10 +290,10 @@ def test_ptxd_destination_errors():
         def predicated_destination(out: T.Buffer((1,), "uint32"), a_ptr: T.handle):
             A = T.match_buffer(a_ptr, (1,), "uint32")
             T.device_entry()
-            T.ptxd.ld.global_.b32(out[0], A.ptr_to([0]), pred=T.uint32(1))
+            T.ptx.ld.global_.b32(out[0], A.ptr_to([0]), pred=T.uint32(1))
 
 
-def test_ptxd_register_group_codegen():
+def test_ptx_register_group_codegen():
     """A `.lanes > 1` operand renders as braces in the asm, flat params in C.
 
     `{%1, %2}` is ONE PTX operand occupying two registers (ISA 9.7.9.4), which
@@ -310,8 +310,8 @@ def test_ptxd_register_group_codegen():
         packed = T.local_scalar("uint64")
         lo = T.local_scalar("float32")
         hi = T.local_scalar("float32")
-        T.ptxd.mov.b64(packed, A[0], A[1])  # pack: one dst, a 2-register source
-        T.ptxd.mov.b64(lo, hi, packed)  # unpack: a 2-register dst, one source
+        T.ptx.mov.b64(packed, A[0], A[1])  # pack: one dst, a 2-register source
+        T.ptx.mov.b64(lo, hi, packed)  # unpack: a 2-register dst, one source
         A[tx % 4] = lo + hi
 
     src = _cuda_source(kernel)
@@ -323,7 +323,7 @@ def test_ptxd_register_group_codegen():
     assert "tvm_builtin_ptxd_mov_unpack_b32x2_b64_f32_u64(" in src
 
 
-def test_ptxd_register_group_errors():
+def test_ptx_register_group_errors():
     """A register group is one operand: its arity is fixed and its lanes agree."""
     # No `mov` shape takes two operands, so nothing in the family matches.
     with pytest.raises((ValueError, tvm.error.DiagnosticError), match=r"expects \d+ operand"):
@@ -333,7 +333,7 @@ def test_ptxd_register_group_errors():
             A = T.match_buffer(a_ptr, (4,), "uint32")
             T.device_entry()
             packed = T.local_scalar("uint64")
-            T.ptxd.mov.b64(packed, A[0])
+            T.ptx.mov.b64(packed, A[0])
             A[0] = T.uint32(0)
 
     # Each lane of a destination group is its own register the caller declared,
@@ -346,7 +346,7 @@ def test_ptxd_register_group_errors():
             T.device_entry()
             packed = T.local_scalar("uint64")
             lo = T.local_scalar("uint32")
-            T.ptxd.mov.b64(lo, A[0] + T.uint32(1), packed)
+            T.ptx.mov.b64(lo, A[0] + T.uint32(1), packed)
             A[0] = T.uint32(0)
 
     # Lanes disagreeing on dtype: legal for each lane alone (both are 32-bit),
@@ -361,7 +361,7 @@ def test_ptxd_register_group_errors():
             packed = T.local_scalar("uint64")
             f = T.local_scalar("float32")
             u = T.local_scalar("uint32")
-            T.ptxd.mov.b64(packed, f, u)
+            T.ptx.mov.b64(packed, f, u)
             A[0] = T.uint32(0)
 
     # A bare float literal names no dtype: on a .b32 lane it could be the
@@ -373,7 +373,7 @@ def test_ptxd_register_group_errors():
             A = T.match_buffer(a_ptr, (4,), "uint32")
             T.device_entry()
             packed = T.local_scalar("uint64")
-            T.ptxd.mov.b64(packed, 1.5, 2.5)
+            T.ptx.mov.b64(packed, 1.5, 2.5)
             A[0] = T.uint32(0)
 
     # An explicit constant is accepted and picks the float32 helper.
@@ -384,13 +384,13 @@ def test_ptxd_register_group_errors():
         T.cta_id([1])
         tx = T.thread_id([32])
         packed = T.local_scalar("uint64")
-        T.ptxd.mov.b64(packed, T.float32(1.5), T.float32(2.5))
+        T.ptx.mov.b64(packed, T.float32(1.5), T.float32(2.5))
         A[tx % 4] = A[tx % 4]
 
     assert "mov_pack_b32x2_b64_u64_f32" in _cuda_source(typed_literal)
 
 
-def test_ptxd_optional_operand_arity_dispatch():
+def test_ptx_optional_operand_arity_dispatch():
     """A no-count and a counted syntax line share a mnemonic, split by arity.
 
     This only works because `pred` is keyword-only: the old positional-pred
@@ -407,11 +407,11 @@ def test_ptxd_optional_operand_arity_dispatch():
         T.cta_id([1])
         tx = T.thread_id([32])
         bar = T.alloc_buffer((2,), "uint64", scope="shared")
-        T.ptxd.bar.sync(T.uint32(0))
-        T.ptxd.bar.sync(T.uint32(0), T.uint32(64))
-        T.ptxd.mbarrier.arrive.shared.b64(bar.ptr_to([0]))
-        T.ptxd.mbarrier.arrive.shared.b64(bar.ptr_to([0]), T.uint32(2))
-        T.ptxd.mbarrier.arrive.shared.b64(bar.ptr_to([1]), pred=T.uint32(1))
+        T.ptx.bar.sync(T.uint32(0))
+        T.ptx.bar.sync(T.uint32(0), T.uint32(64))
+        T.ptx.mbarrier.arrive.shared.b64(bar.ptr_to([0]))
+        T.ptx.mbarrier.arrive.shared.b64(bar.ptr_to([0]), T.uint32(2))
+        T.ptx.mbarrier.arrive.shared.b64(bar.ptr_to([1]), pred=T.uint32(1))
         A[tx % 4] = A[tx % 4]
 
     src = _cuda_source(kernel)
@@ -428,7 +428,7 @@ def test_ptxd_optional_operand_arity_dispatch():
     tvm.ir.assert_structural_equal(kernel, reparsed)
 
 
-def test_ptxd_bit_width_axis():
+def test_ptx_bit_width_axis():
     """A `.bN` operand takes any dtype of that width, each with its own helper.
 
     PTX ISA 5.2: "The bit-size type is compatible with any fundamental type
@@ -447,9 +447,9 @@ def test_ptxd_bit_width_axis():
         tx = T.thread_id([32])
         fv = T.local_scalar("float32")
         sv = T.local_scalar("int32")
-        T.ptxd.ld.global_.b32(fv, A.ptr_to([0]))  # .b32 destination, float32
-        T.ptxd.ld.global_.b32(sv, A.ptr_to([1]))  # .b32 destination, int32
-        T.ptxd.st.global_.b32(Out.ptr_to([0]), fv)  # .b32 source, float32
+        T.ptx.ld.global_.b32(fv, A.ptr_to([0]))  # .b32 destination, float32
+        T.ptx.ld.global_.b32(sv, A.ptr_to([1]))  # .b32 destination, int32
+        T.ptx.st.global_.b32(Out.ptr_to([0]), fv)  # .b32 source, float32
         Out[tx % 4] = A[tx % 4]
 
     src = _cuda_source(kernel)
@@ -471,7 +471,7 @@ def test_ptxd_bit_width_axis():
     assert render_variant(ld, tokens)[1] == "tvm_builtin_ptxd_ld_global_b32"
 
 
-def test_ptxd_u64_address_handle_is_reinterpreted():
+def test_ptx_u64_address_handle_is_reinterpreted():
     """A 64-bit address handle is accepted via an explicit, visible cast.
 
     Some PTX address operands reach us as u64 handles rather than typed
@@ -480,13 +480,13 @@ def test_ptxd_u64_address_handle_is_reinterpreted():
     rather than being punned inside the helper.
     """
     handle = tvm.tirx.Var("h", "uint64")
-    call = T.ptxd.prefetch.tensormap(handle)
+    call = T.ptx.prefetch.tensormap(handle)
     addr = call.args[0]
     assert addr.op.name == "tirx.reinterpret", addr
     assert addr.args[0].same_as(handle)
 
 
-def test_ptxd_parser_roundtrip():
+def test_ptx_parser_roundtrip():
     """script() output re-parses to a structurally equal PrimFunc."""
 
     @T.prim_func
@@ -505,13 +505,13 @@ def test_ptxd_parser_roundtrip():
             packed = T.local_scalar("uint64")
             # Several `mov` entries share one mnemonic; the printed form names
             # the family and reparsing re-dispatches on the operand shape.
-            T.ptxd.mov.b64(packed, lo, hi)
-            T.ptxd.mov.b64(lo, hi, packed)
-            T.ptxd.ld.global_.acquire.gpu.b32(val, A.ptr_to([0]))
-            T.ptxd.st.shared__cta.b32(smem.ptr_to([0]), val)
-            T.ptxd.red.relaxed.gpu.global_.add.u32(B.ptr_to([0]), T.uint32(1), pred=val)
-            T.ptxd.prefetch.global_.L2(A.ptr_to([16]))
-            T.ptxd.cvta.to.shared.u64(smem_addr, smem.data)
+            T.ptx.mov.b64(packed, lo, hi)
+            T.ptx.mov.b64(lo, hi, packed)
+            T.ptx.ld.global_.acquire.gpu.b32(val, A.ptr_to([0]))
+            T.ptx.st.shared__cta.b32(smem.ptr_to([0]), val)
+            T.ptx.red.relaxed.gpu.global_.add.u32(B.ptr_to([0]), T.uint32(1), pred=val)
+            T.ptx.prefetch.global_.L2(A.ptr_to([16]))
+            T.ptx.cvta.to.shared.u64(smem_addr, smem.data)
         T.cuda.cta_sync()
         B[tx] = smem[tx % 4]
 
@@ -519,7 +519,7 @@ def test_ptxd_parser_roundtrip():
     tvm.ir.assert_structural_equal(kernel, reparsed)
 
 
-def test_ptxd_printer_form():
+def test_ptx_printer_form():
     @T.prim_func
     def kernel(a_ptr: T.handle, b_ptr: T.handle):
         A = T.match_buffer(a_ptr, (32,), "uint32")
@@ -528,11 +528,11 @@ def test_ptxd_printer_form():
         T.cta_id([1])
         tx = T.thread_id([32])
         if tx == 0:
-            T.ptxd.ld.global_.acquire.gpu.b32(B[0], A.ptr_to([0]))
+            T.ptx.ld.global_.acquire.gpu.b32(B[0], A.ptr_to([0]))
         B[tx] = B[tx]
 
     script = kernel.script()
-    assert "T.ptxd.ld(" in script
+    assert "T.ptx.ld(" in script
     assert '"acquire"' in script
 
 
@@ -542,7 +542,7 @@ def test_ptxd_printer_form():
 # ---------------------------------------------------------------------------
 
 
-def test_ptxd_helper_source_golden():
+def test_ptx_helper_source_golden():
     """Exact generated helper source, one per family (executable documentation)."""
     from tvm.backend.cuda.ptx_dialect.render import render_variant
     from tvm.backend.cuda.ptx_dialect.table import TABLE, tokens_for
@@ -670,7 +670,7 @@ def test_ptxd_helper_source_golden():
     )
 
 
-def test_ptxd_coercion_ir_forms():
+def test_ptx_coercion_ir_forms():
     """The trace-time addr coercion, written down as IR-level assertions."""
     from tvm.ir.type import PointerType, PrimType
 
@@ -680,17 +680,17 @@ def test_ptxd_coercion_ir_forms():
     val = tvm.tirx.Var("v", "uint32")
 
     # Shared slot + shared pointer: engine wraps with an explicit cvta call node.
-    call = T.ptxd.st.shared__cta.b32(shared_ptr, val)
+    call = T.ptx.st.shared__cta.b32(shared_ptr, val)
     addr = call.args[0]
     assert addr.op.name == "tirx.cuda.cvta_generic_to_shared"
     assert addr.args[0].same_as(shared_ptr)
 
     # Shared slot + raw uint32: passthrough, no conversion inserted.
-    call = T.ptxd.st.shared__cta.b32(raw_u32, val)
+    call = T.ptx.st.shared__cta.b32(raw_u32, val)
     assert call.args[0].same_as(raw_u32)
 
     # Global slot + global pointer: passthrough.
-    call = T.ptxd.st.release.gpu.global_.b32(global_ptr, val)
+    call = T.ptx.st.release.gpu.global_.b32(global_ptr, val)
     assert call.args[0].same_as(global_ptr)
 
     # Modifiers ride as trailing positional string args in slot order, then
@@ -710,20 +710,20 @@ def test_ptxd_coercion_ir_forms():
     # A shared-space slot converts whatever pointer it is given: TIRx pointer
     # scopes are not a reliable discriminator (a shared buffer's ptr_to()
     # reports 'global'), and the legacy helpers converted unconditionally too.
-    call = T.ptxd.st.shared__cta.b32(global_ptr, val)
+    call = T.ptx.st.shared__cta.b32(global_ptr, val)
     assert call.args[0].op.name == "tirx.cuda.cvta_generic_to_shared"
 
     # Predication: pred rides after the operands (codegen derives the
     # predicated form from the arg count).
     flag = tvm.tirx.Var("f", "uint32")
-    call = T.ptxd.st.release.gpu.global_.b32(global_ptr, val, pred=flag)
+    call = T.ptx.st.release.gpu.global_.b32(global_ptr, val, pred=flag)
     assert call.args[2].same_as(flag)
     assert len(call.args) == 2 + 1 + 7 + 1  # operands + pred + slot tokens + marker
     # @p on an instruction with a destination is rejected: a false predicate
     # leaves it unwritten while "=" tells nvcc its prior value is dead.
     dst = tvm.tirx.Var("d", "uint32")
     with pytest.raises(ValueError, match="without a destination"):
-        T.ptxd.ld.global_.b32(dst, global_ptr, pred=flag)
+        T.ptx.ld.global_.b32(dst, global_ptr, pred=flag)
 
 
 # fp16/bf16 dtypes bring in __half / __nv_bfloat16 and their bit-cast helpers.
@@ -765,8 +765,8 @@ def _sole_instruction(asm_text):
     return body
 
 
-def test_ptxd_single_instruction_invariant():
-    """Every ptxd variant emits exactly ONE native PTX instruction.
+def test_ptx_single_instruction_invariant():
+    """Every ptx variant emits exactly ONE native PTX instruction.
 
     This is the dialect's defining constraint, enforced mechanically so it
     cannot erode as the table grows: the only multi-statement form allowed is
@@ -828,7 +828,7 @@ def test_ptxd_single_instruction_invariant():
     assert checked > 0
 
 
-def test_ptxd_single_instruction_invariant_detects_violations():
+def test_ptx_single_instruction_invariant_detects_violations():
     """Falsify the probe: it must reject every shape the invariant forbids.
 
     A guard that has never been shown to fail is worth nothing, so exercise
@@ -850,7 +850,7 @@ def test_ptxd_single_instruction_invariant_detects_violations():
     assert _sole_instruction(guarded) == "red.relaxed.gpu.global.add.u32 [%0], %1;"
 
 
-def test_ptxd_all_variants_render_unique():
+def test_ptx_all_variants_render_unique():
     """Every legal variant renders; helper names (incl. @p twins) are unique."""
     from tvm.backend.cuda.ptx_dialect.render import render_variant
     from tvm.backend.cuda.ptx_dialect.table import TABLE, renderings, variants
@@ -878,7 +878,7 @@ def test_ptxd_all_variants_render_unique():
     assert total == 110831  # update when the table grows
 
 
-def test_ptxd_stub_up_to_date():
+def test_ptx_stub_up_to_date():
     """The checked-in tvm.script.tirx stub must match the generator."""
     from tvm.backend.cuda.ptx_dialect import gen_stubs
 
@@ -898,7 +898,7 @@ def test_ptxas_gate_rejects_invalid():
 
 
 @requires_nvcc
-def test_ptxd_sampled_helpers_assemble():
+def test_ptx_sampled_helpers_assemble():
     """Fast tier: a seeded sample of every family's variants assembles."""
     import random
 
@@ -908,7 +908,7 @@ def test_ptxd_sampled_helpers_assemble():
     rng = random.Random(20260802)
     by_arch = {}
     for entry in TABLE.values():
-        arch = entry.cert_arch or PTXD_ARCH
+        arch = entry.cert_arch or PTX_ARCH
         rendered = list(renderings(entry))
         for i in rng.sample(range(len(rendered)), min(48, len(rendered))):
             _, _, source = render_variant(entry, *_as_render_args(rendered[i]))
@@ -921,12 +921,12 @@ _CERT_SHARDS = 32
 
 
 @pytest.mark.skipif(
-    not os.environ.get("PTXD_CERT"),
-    reason="full-table ptxas certification; run with PTXD_CERT=1 after changing the table",
+    not os.environ.get("PTX_CERT"),
+    reason="full-table ptxas certification; run with PTX_CERT=1 after changing the table",
 )
 @requires_nvcc
 @pytest.mark.parametrize("shard", range(_CERT_SHARDS))
-def test_ptxd_all_helpers_certify(shard):
+def test_ptx_all_helpers_certify(shard):
     """Certification tier: EVERY legal variant assembles under ptxas.
 
     One scoped exception: an OPEN immediate operand (role="imm" with neither
@@ -938,7 +938,7 @@ def test_ptxd_all_helpers_certify(shard):
 
     Sharded so pytest-xdist can spread the nvcc work::
 
-        PTXD_CERT=1 pytest -n 16 -k certify tests/python/tirx/codegen/test_ptxd_dialect.py
+        PTX_CERT=1 pytest -n 16 -k certify tests/python/tirx/codegen/test_ptx_dialect.py
 
     Stride slicing keeps shards balanced (ld dominates the variant count).
     Variants are grouped by their family's arch floor and each group is
@@ -957,7 +957,7 @@ def test_ptxd_all_helpers_certify(shard):
     ):
         if index % _CERT_SHARDS == shard:
             covered += 1
-            arch = entry.cert_arch or PTXD_ARCH
+            arch = entry.cert_arch or PTX_ARCH
             _, _, src = render_variant(entry, *_as_render_args(rendering))
             by_arch.setdefault(arch, []).append(src.replace("__forceinline__ ", ""))
     assert covered, "empty shard: lower _CERT_SHARDS"
@@ -966,7 +966,7 @@ def test_ptxd_all_helpers_certify(shard):
 
 
 @requires_nvcc
-def test_ptxd_nvcc_smoke():
+def test_ptx_nvcc_smoke():
     @T.prim_func
     def kernel(a_ptr: T.handle, b_ptr: T.handle):
         A = T.match_buffer(a_ptr, (32,), "uint32")
@@ -977,10 +977,10 @@ def test_ptxd_nvcc_smoke():
         smem = T.alloc_buffer((4,), "uint32", scope="shared")
         if tx == 0:
             val = T.local_scalar("uint32")
-            T.ptxd.ld.global_.acquire.gpu.b32(val, A.ptr_to([0]))
-            T.ptxd.st.shared__cta.b32(smem.ptr_to([0]), val)
-            T.ptxd.red.relaxed.gpu.global_.add.u32(B.ptr_to([0]), T.uint32(1))
-            T.ptxd.prefetch.global_.L2(A.ptr_to([16]))
+            T.ptx.ld.global_.acquire.gpu.b32(val, A.ptr_to([0]))
+            T.ptx.st.shared__cta.b32(smem.ptr_to([0]), val)
+            T.ptx.red.relaxed.gpu.global_.add.u32(B.ptr_to([0]), T.uint32(1))
+            T.ptx.prefetch.global_.L2(A.ptr_to([16]))
         T.cuda.cta_sync()
         B[tx] = smem[tx % 4]
 
@@ -989,7 +989,7 @@ def test_ptxd_nvcc_smoke():
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="CUDA GPU not available")
-def test_ptxd_ld_st_gpu_roundtrip():
+def test_ptx_ld_st_gpu_roundtrip():
     @T.prim_func
     def kernel(a_ptr: T.handle, b_ptr: T.handle):
         A = T.match_buffer(a_ptr, (32,), "uint32")
@@ -998,8 +998,8 @@ def test_ptxd_ld_st_gpu_roundtrip():
         T.cta_id([1])
         tx = T.thread_id([32])
         val = T.local_scalar("uint32")
-        T.ptxd.ld.global_.acquire.gpu.b32(val, A.ptr_to([tx]))
-        T.ptxd.st.release.gpu.global_.b32(B.ptr_to([tx]), val)
+        T.ptx.ld.global_.acquire.gpu.b32(val, A.ptr_to([tx]))
+        T.ptx.st.release.gpu.global_.b32(B.ptr_to([tx]), val)
 
     with TARGET:
         mod = tvm.compile(tvm.IRModule({"main": kernel}), target=TARGET, tir_pipeline="tirx")

--- a/tests/python/tirx/codegen/test_ptx_ld_st_ops.py
+++ b/tests/python/tirx/codegen/test_ptx_ld_st_ops.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Unit tests for the ptxd ``ld`` / ``st`` entries, scalar and vector."""
+"""Unit tests for the ptx ``ld`` / ``st`` entries, scalar and vector."""
 
 import numpy as np
 import pytest
@@ -23,7 +23,7 @@ import tvm
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.testing import env
-from tvm.tirx.cuda.tile_primitive.copy._common import copy_ptxd_form
+from tvm.tirx.cuda.tile_primitive.copy._common import copy_ptx_form
 
 TARGET = tvm.target.Target("cuda")
 
@@ -71,7 +71,7 @@ def _shared_scratch_copy_kernel(num_bytes: int):
     fill_value = spec.get("fill_value")
     fill_fp16 = spec.get("fill_fp16")
     fill_u8 = spec.get("fill_u8")
-    tail, lanes, reg_dtype = copy_ptxd_form(num_bytes)
+    tail, lanes, reg_dtype = copy_ptx_form(num_bytes)
     ld_chain, st_chain = f"ld.shared.{tail}", f"st.shared.{tail}"
 
     @T.prim_func
@@ -97,8 +97,8 @@ def _shared_scratch_copy_kernel(num_bytes: int):
             src_buf[0] = T.uint32(fill_value)
         T.cuda.cta_sync()
         if lane == 0:
-            T.ptxd[ld_chain](*[tmp[i] for i in range(lanes)], src_buf.ptr_to([0]))
-            T.ptxd[st_chain](dst_buf.ptr_to([0]), *[tmp[i] for i in range(lanes)])
+            T.ptx[ld_chain](*[tmp[i] for i in range(lanes)], src_buf.ptr_to([0]))
+            T.ptx[st_chain](dst_buf.ptr_to([0]), *[tmp[i] for i in range(lanes)])
         T.cuda.cta_sync()
         if lane < nelems:
             out[lane] = dst_buf[lane]
@@ -121,10 +121,10 @@ def test_ptx_ld_st_codegen_emits_shared_asm():
         smem = T.alloc_buffer((4,), "uint32", scope="shared")
         reg = T.alloc_local((4,), "uint32")
         if tid_in_wg == 0:
-            T.ptxd.st.shared.v4.u32(smem.ptr_to([0]), reg[0], reg[1], reg[2], reg[3])
+            T.ptx.st.shared.v4.u32(smem.ptr_to([0]), reg[0], reg[1], reg[2], reg[3])
         T.cuda.cta_sync()
         if tid_in_wg == 0:
-            T.ptxd.ld.shared.v4.u32(reg[0], reg[1], reg[2], reg[3], smem.ptr_to([0]))
+            T.ptx.ld.shared.v4.u32(reg[0], reg[1], reg[2], reg[3], smem.ptr_to([0]))
         Tx.copy(D[0:4], reg[:])
     # fmt: on
 
@@ -147,16 +147,16 @@ def test_ptx_ld_st_raw_shared_address_codegen():
         values = T.alloc_local((4,), "uint32")
         if tx == 0:
             raw_addr: T.uint32 = T.cuda.cvta_generic_to_shared(smem.data)
-            T.ptxd.ld.shared.u64(out[0], raw_addr)
-            T.ptxd.ld.shared.u64(out[1], smem.data)
-            T.ptxd.st.weak.shared__cta.b128(raw_addr, values.view("uint128")[0])
+            T.ptx.ld.shared.u64(out[0], raw_addr)
+            T.ptx.ld.shared.u64(out[1], smem.data)
+            T.ptx.st.weak.shared__cta.b128(raw_addr, values.view("uint128")[0])
 
     with TARGET:
         mod = tvm.compile(tvm.IRModule({"main": main}), target=TARGET, tir_pipeline="tirx")
     src = mod.mod.imports[0].inspect_source("cuda")
     assert "ld.shared.u64 %0, [%1];" in src
     # One cvta, for the generic pointer. The raw window address is already a
-    # uint32 and passes straight through -- ptxd converts only pointers.
+    # uint32 and passes straight through -- ptx converts only pointers.
     assert src.count("__cvta_generic_to_shared") == 1
     assert '"st.weak.shared::cta.b128 [%0], %1;"' in src
     assert '"q"(__value)' in src
@@ -173,7 +173,7 @@ def test_ptx_ld_global_nc_v8_codegen():
         tx = T.thread_id([32])
         tmp = T.alloc_local((8,), "int32")
         if tx == 0:
-            T.ptxd["ld.global.nc.L1::no_allocate.L2::evict_first.L2::256B.v8.s32"](
+            T.ptx["ld.global.nc.L1::no_allocate.L2::evict_first.L2::256B.v8.s32"](
                 *[tmp[i] for i in range(8)], src.data
             )
             for i in T.unroll(8):
@@ -198,7 +198,7 @@ def test_ptx_ld_global_nc_v4_u64_256b_codegen():
         tx = T.thread_id([32])
         tmp = T.alloc_local((4,), "uint64")
         if tx == 0:
-            T.ptxd["ld.global.nc.L1::no_allocate.L2::evict_normal.L2::256B.v4.u64"](
+            T.ptx["ld.global.nc.L1::no_allocate.L2::evict_normal.L2::256B.v4.u64"](
                 tmp[0], tmp[1], tmp[2], tmp[3], src.data
             )
             for i in T.unroll(4):
@@ -226,7 +226,7 @@ def test_ptx_ld_vector_scatter_dst_codegen():
         tmp2 = T.alloc_local((1,), "int32")
         tmp3 = T.alloc_local((1,), "int32")
         if tx == 0:
-            T.ptxd["ld.global.nc.v4.s32"](tmp0[0], tmp1[0], tmp2[0], tmp3[0], src.data)
+            T.ptx["ld.global.nc.v4.s32"](tmp0[0], tmp1[0], tmp2[0], tmp3[0], src.data)
             out[0] = tmp0[0]
             out[1] = tmp1[0]
             out[2] = tmp2[0]
@@ -261,7 +261,7 @@ def test_ptx_ld_st_shared_copy_gpu(num_bytes):
     else:
         np.testing.assert_array_equal(result, expected)
     src = mod.mod.imports[0].inspect_source("cuda")
-    tail, _lanes, _dtype = copy_ptxd_form(num_bytes)
+    tail, _lanes, _dtype = copy_ptx_form(num_bytes)
     vec = tail.split(".")[0] if tail.startswith("v") else ""
     if vec == "v4":
         assert "ld.shared.v4" in src

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
@@ -529,8 +529,8 @@ def test_ptx_st_from_src_f32_vector_preserves_values():
         out = T.alloc_local((4,), "float32")
         for i in range(4):
             reg[i] = T.cast(i + 1, "float32")
-        T.ptxd.st.shared.v4.f32(smem.ptr_to([0]), reg[0], reg[1], reg[2], reg[3])
-        T.ptxd.ld.shared.v4.f32(out[0], out[1], out[2], out[3], smem.ptr_to([0]))
+        T.ptx.st.shared.v4.f32(smem.ptr_to([0]), reg[0], reg[1], reg[2], reg[3])
+        T.ptx.ld.shared.v4.f32(out[0], out[1], out[2], out[3], smem.ptr_to([0]))
         for i in range(4):
             B[i] = out[i]
 

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_dsmem.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_dsmem.py
@@ -71,7 +71,7 @@ class _S2CCounter(StmtExprVisitor):
 
     def visit_evaluate_(self, op):
         if isinstance(op.value, tvm.ir.Call):
-            if op.value.op.name == "tirx.ptxd.cp_async_bulk_s2c":
+            if op.value.op.name == "tirx.ptx.cp_async_bulk_s2c":
                 n = 1
                 for e in self._loop_extents:
                     n *= e
@@ -186,13 +186,13 @@ def test_dsmem(shape, dtype, src_spec, dst_spec, expected):
         pool.commit()
 
         mbar.init(1)
-        T.ptxd.fence.mbarrier_init.release.cluster()
+        T.ptx.fence.mbarrier_init.release.cluster()
         T.cuda.cluster_sync()
 
         if tid == 0:
             if cbx == 0:
                 Tx.copy(src_smem[r], A[r])
-                T.ptxd.fence.proxy.async_.shared__cta()
+                T.ptx.fence.proxy.async_.shared__cta()
 
                 Tx.copy_async(
                     dst_smem[r], src_smem[r],
@@ -201,7 +201,7 @@ def test_dsmem(shape, dtype, src_spec, dst_spec, expected):
                     remote_cta_id=T.int32(1),
                 )
             else:
-                T.ptxd.mbarrier.arrive.expect_tx.shared.b64(mbar.ptr_to([0]), T.uint32(copy_bytes))
+                T.ptx.mbarrier.arrive.expect_tx.shared.b64(mbar.ptr_to([0]), T.uint32(copy_bytes))
                 mbar.wait(0, 0)
 
                 Tx.copy(B[r], dst_smem[r])

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_ldgsts.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_ldgsts.py
@@ -89,8 +89,8 @@ def test_copy_g2s_s2g_cta_vec_load(task, dtype):
         A_smem = T.alloc_buffer(s_shape, dtype, scope="shared", layout=layoutS)
 
         Tx.cta.copy_async(A_smem[tuple(r_smem)], A[tuple(r_gmem)], dispatch="ldgsts")
-        T.ptxd.cp.async_.commit_group()
-        T.ptxd.cp.async_.wait_group(0)
+        T.ptx.cp.async_.commit_group()
+        T.ptx.cp.async_.wait_group(0)
         T.cuda.cta_sync()
         Tx.cta.copy(B[tuple(r_gmem)], A_smem[tuple(r_smem)])
         # fmt: on

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tcgen05_cp.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tcgen05_cp.py
@@ -373,7 +373,7 @@ def test_cp_4x256b_compile_emits_shape_and_count():
     mod = _compile(kernel)
     src = mod.mod.imports[0].inspect_source()
     assert "tcgen05.cp.cta_group::1.4x256b" in src, f"cp asm missing; src=\n{src}"
-    helper_refs = src.count("tvm_builtin_ptxd_tcgen05_cp_cp_cta_group__1_4x256b")
+    helper_refs = src.count("tvm_builtin_ptx_tcgen05_cp_cp_cta_group__1_4x256b")
     assert helper_refs - 1 == 2, f"expected 2 cp calls, got {helper_refs - 1}; src=\n{src}"
 
 
@@ -688,7 +688,7 @@ def test_cp_default_32x128b_instruction_sequence_unchanged():
     cp_lines = [
         line
         for line in src.splitlines()
-        if "tvm_builtin_ptxd_tcgen05_cp_cp_cta_group__1_32x128b_warpx4(" in line
+        if "tvm_builtin_ptx_tcgen05_cp_cp_cta_group__1_32x128b_warpx4(" in line
         and "__forceinline__" not in line
     ]
     assert len(cp_lines) == 4, f"expected 4 cp calls, got {len(cp_lines)}"

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tcgen05_cp.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tcgen05_cp.py
@@ -163,12 +163,12 @@ def _make_cp_kernel(
         cp_mbar = T.alloc_shared([1], "uint64")
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_addr), T.uint32(n_tmem_cols)
                 )
             if tid_in_wg == 0:
-                T.ptxd.mbarrier.init.shared.b64(cp_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.fence.proxy.async_.shared__cta()
+                T.ptx.mbarrier.init.shared.b64(cp_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.fence.proxy.async_.shared__cta()
             T.cuda.cta_sync()
             Tx.cta.copy(A_smem[s_full_sl], A[s_full_sl])
             T.cuda.cta_sync()
@@ -180,33 +180,33 @@ def _make_cp_kernel(
                 for i in range(W32):
                     zero_reg[i] = T.uint32(0)
                 for i in range(W32):
-                    T.ptxd["tcgen05.st.sync.aligned.32x32b.x1.b32"](
+                    T.ptx["tcgen05.st.sync.aligned.32x32b.x1.b32"](
                         T.cuda.get_tmem_addr(tmem_addr[0], 0, i), zero_reg[i]
                     )
-                T.ptxd.tcgen05.wait__st.sync.aligned()
+                T.ptx.tcgen05.wait__st.sync.aligned()
                 T.cuda.cta_sync()
-                T.ptxd.tcgen05.fence__after_thread_sync()
+                T.ptx.tcgen05.fence__after_thread_sync()
             if tid_in_wg == 0:
                 Tx.copy_async(tmem[t_sl], A_smem[s_sl], **cfg)
-                T.ptxd.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
+                T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
                     cp_mbar.ptr_to([0])
                 )
             T.cuda.mbarrier_wait(cp_mbar.ptr_to([0]), 0)
             T.cuda.cta_sync()
-            T.ptxd.tcgen05.fence__after_thread_sync()
+            T.ptx.tcgen05.fence__after_thread_sync()
             # Each of the 4 warps reads its own 32-lane slab (taddr lane 0 is
             # warp-slab-relative for .32x32b), covering all 128 TMEM lanes.
             reg = T.alloc_buffer((W32,), "uint32", scope="local")
             for i in range(W32):
-                T.ptxd["tcgen05.ld.sync.aligned.32x32b.x1.b32"](
+                T.ptx["tcgen05.ld.sync.aligned.32x32b.x1.b32"](
                     reg[i], T.cuda.get_tmem_addr(tmem_addr[0], 0, i)
                 )
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             for i in range(W32):
                 B[tid_in_wg, i] = reg[i]
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
                     tmem_addr[0], T.uint32(n_tmem_cols)
                 )
 
@@ -488,16 +488,16 @@ def _make_cp_kernel_cta2(s_full, s_shape, t_full, t_shape, dtype, cfg, W32, n_co
         tmem_addr = T.alloc_shared([1], "uint32")
         cp_mbar = T.alloc_shared([1], "uint64")
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(cp_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(cp_mbar.ptr_to([0]), T.uint32(1))
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(n_cols)
             )
         tmem = T.decl_buffer(
             t_shape, dtype, scope="tmem", allocated_addr=tmem_addr[0], layout=t_full
         )
-        T.ptxd.fence.mbarrier_init.release.cluster()
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.mbarrier_init.release.cluster()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         T.cuda.cluster_sync()
         # Pre-zero both CTAs' tmem: alloc does not clear it, and the
@@ -506,34 +506,34 @@ def _make_cp_kernel_cta2(s_full, s_shape, t_full, t_shape, dtype, cfg, W32, n_co
         for i in range(W32):
             zero_reg[i] = T.uint32(0)
         for i in range(W32):
-            T.ptxd["tcgen05.st.sync.aligned.32x32b.x1.b32"](
+            T.ptx["tcgen05.st.sync.aligned.32x32b.x1.b32"](
                 T.cuda.get_tmem_addr(tmem_addr[0], 0, i), zero_reg[i]
             )
-        T.ptxd.tcgen05.wait__st.sync.aligned()
+        T.ptx.tcgen05.wait__st.sync.aligned()
         Tx.cta.copy(A_smem[s_sl], A[(cbx, *s_sl)])
         T.cuda.cta_sync()
         T.cuda.cluster_sync()
         if cbx == 0:
             if tid_in_wg == 0:
                 Tx.copy_async(tmem[t_sl], A_smem[s_sl], **cfg)
-                T.ptxd.tcgen05.commit.cta_group__2.mbarrier__arrive__one.shared__cluster.multicast__cluster.b64(
+                T.ptx.tcgen05.commit.cta_group__2.mbarrier__arrive__one.shared__cluster.multicast__cluster.b64(
                     cp_mbar.ptr_to([0]), T.uint16(3)
                 )
         T.cuda.mbarrier_wait(cp_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         reg = T.alloc_buffer((W32,), "uint32", scope="local")
         for i in range(W32):
-            T.ptxd["tcgen05.ld.sync.aligned.32x32b.x1.b32"](
+            T.ptx["tcgen05.ld.sync.aligned.32x32b.x1.b32"](
                 reg[i], T.cuda.get_tmem_addr(tmem_addr[0], 0, i)
             )
-        T.ptxd.tcgen05.wait__ld.sync.aligned()
+        T.ptx.tcgen05.wait__ld.sync.aligned()
         for i in range(W32):
             B[cbx * 128 + tid_in_wg, i] = reg[i]
         T.cuda.cluster_sync()
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__2.sync.aligned.b32(tmem_addr[0], T.uint32(n_cols))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__2.sync.aligned.b32(tmem_addr[0], T.uint32(n_cols))
 
     return kernel
 
@@ -656,7 +656,7 @@ def test_cp_default_32x128b_instruction_sequence_unchanged():
         tmem_addr = T.alloc_shared([1], "uint32")
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_addr), T.uint32(32)
                 )
             T.cuda.cta_sync()
@@ -669,8 +669,8 @@ def test_cp_default_32x128b_instruction_sequence_unchanged():
                 # NOTE: no shape/multicast config — the legacy default route.
                 Tx.copy_async(tmem[:, :, :], A_smem[:, :, :], cta_group=1)
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(32))
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(32))
 
     mod = _compile(kernel)
     src = mod.mod.imports[0].inspect_source()
@@ -693,7 +693,7 @@ def test_cp_default_32x128b_instruction_sequence_unchanged():
     ]
     assert len(cp_lines) == 4, f"expected 4 cp calls, got {len(cp_lines)}"
     for i, (t_off, s_off) in enumerate([(0, 0), (4, 512), (8, 1024), (12, 1536)]):
-        # The tmem column is the whole first argument now: ptxd takes the
+        # The tmem column is the whole first argument now: ptx takes the
         # composed address, where the legacy helper took (addr, row, col).
         t_tok = "[0], " if t_off == 0 else f"[0] + (uint){t_off}), "
         assert t_tok in cp_lines[i], f"cp[{i}] tmem col: want {t_tok!r} in {cp_lines[i]!r}"
@@ -946,12 +946,12 @@ def _make_2d_kernel(
         cp_mbar = T.alloc_shared([1], "uint64")
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
+                T.ptx[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
                     T.address_of(tmem_addr), T.uint32(n_tmem_cols_total)
                 )
             if tid_in_wg == 0:
-                T.ptxd.mbarrier.init.shared.b64(cp_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.fence.proxy.async_.shared__cta()
+                T.ptx.mbarrier.init.shared.b64(cp_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.fence.proxy.async_.shared__cta()
             T.cuda.cta_sync()
             Tx.cta.copy(A_smem[:, :], A[:, :])
             T.cuda.cta_sync()
@@ -968,25 +968,25 @@ def _make_2d_kernel(
                     A_smem[s_r0:s_r1, s_c0:s_c1],
                     cta_group=cta_group,
                 )
-                T.ptxd[
+                T.ptx[
                     f"tcgen05.commit.cta_group::{cta_group}.mbarrier::arrive::one.shared::cluster.b64"
                 ](cp_mbar.ptr_to([0]))
             T.cuda.mbarrier_wait(cp_mbar.ptr_to([0]), 0)
             T.cuda.cta_sync()
-            T.ptxd.tcgen05.fence__after_thread_sync()
+            T.ptx.tcgen05.fence__after_thread_sync()
             if warp_id == 0:
                 reg = T.alloc_buffer((4,), "uint32", scope="local")
                 for i in range(4):
-                    T.ptxd["tcgen05.ld.sync.aligned.32x32b.x1.b32"](
+                    T.ptx["tcgen05.ld.sync.aligned.32x32b.x1.b32"](
                         reg[i], T.cuda.get_tmem_addr(tmem.allocated_addr[0], 0, i)
                     )
-                T.ptxd.tcgen05.wait__ld.sync.aligned()
+                T.ptx.tcgen05.wait__ld.sync.aligned()
                 B_bytes = reg.view(dtype)
                 for i in range(OUT_BYTES):
                     B[lane_id, i] = B_bytes[i]
             if warp_id == 0:
-                T.ptxd[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
-                T.ptxd[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
+                T.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
+                T.ptx[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
                     tmem_addr[0], T.uint32(n_tmem_cols_total)
                 )
 
@@ -1011,12 +1011,12 @@ def _make_3d_4tile_kernel(s_full, t_full, s_full_shape, t_full_shape, dtype, cta
         cp_mbar = T.alloc_shared([1], "uint64")
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
+                T.ptx[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
                     T.address_of(tmem_addr), T.uint32(n_tmem_cols_total)
                 )
             if tid_in_wg == 0:
-                T.ptxd.mbarrier.init.shared.b64(cp_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.fence.proxy.async_.shared__cta()
+                T.ptx.mbarrier.init.shared.b64(cp_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.fence.proxy.async_.shared__cta()
             T.cuda.cta_sync()
             Tx.cta.copy(A_smem[:, :, :], A[:, :, :])
             T.cuda.cta_sync()
@@ -1033,25 +1033,25 @@ def _make_3d_4tile_kernel(s_full, t_full, s_full_shape, t_full_shape, dtype, cta
                     A_smem[:, :, :],
                     cta_group=cta_group,
                 )
-                T.ptxd[
+                T.ptx[
                     f"tcgen05.commit.cta_group::{cta_group}.mbarrier::arrive::one.shared::cluster.b64"
                 ](cp_mbar.ptr_to([0]))
             T.cuda.mbarrier_wait(cp_mbar.ptr_to([0]), 0)
             T.cuda.cta_sync()
-            T.ptxd.tcgen05.fence__after_thread_sync()
+            T.ptx.tcgen05.fence__after_thread_sync()
             if warp_id == 0:
                 reg = T.alloc_buffer((4,), "uint32", scope="local")
                 for i in range(4):
-                    T.ptxd["tcgen05.ld.sync.aligned.32x32b.x1.b32"](
+                    T.ptx["tcgen05.ld.sync.aligned.32x32b.x1.b32"](
                         reg[i], T.cuda.get_tmem_addr(tmem.allocated_addr[0], 0, i)
                     )
-                T.ptxd.tcgen05.wait__ld.sync.aligned()
+                T.ptx.tcgen05.wait__ld.sync.aligned()
                 B_bytes = reg.view(dtype)
                 for i in range(16):
                     B[lane_id, i] = B_bytes[i]
             if warp_id == 0:
-                T.ptxd[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
-                T.ptxd[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
+                T.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
+                T.ptx[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
                     tmem_addr[0], T.uint32(n_tmem_cols_total)
                 )
 
@@ -1191,12 +1191,12 @@ def test_align_middle_2_to_1_nvfp4_sfb():
         cp_mbar = T.alloc_shared([1], "uint64")
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_addr), T.uint32(n_tmem_cols_total)
                 )
             if tid_in_wg == 0:
-                T.ptxd.mbarrier.init.shared.b64(cp_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.fence.proxy.async_.shared__cta()
+                T.ptx.mbarrier.init.shared.b64(cp_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.fence.proxy.async_.shared__cta()
             T.cuda.cta_sync()
             Tx.cta.copy(A_smem[:, :], A[:, :])
             T.cuda.cta_sync()
@@ -1209,25 +1209,25 @@ def test_align_middle_2_to_1_nvfp4_sfb():
             )
             if tid_in_wg == 0:
                 Tx.copy_async(tmem[:, :], A_smem[:, :], cta_group=1)
-                T.ptxd.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
+                T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
                     cp_mbar.ptr_to([0])
                 )
             T.cuda.mbarrier_wait(cp_mbar.ptr_to([0]), 0)
             T.cuda.cta_sync()
-            T.ptxd.tcgen05.fence__after_thread_sync()
+            T.ptx.tcgen05.fence__after_thread_sync()
             if warp_id == 0:
                 reg = T.alloc_buffer((4,), "uint32", scope="local")
                 for i in range(4):
-                    T.ptxd["tcgen05.ld.sync.aligned.32x32b.x1.b32"](
+                    T.ptx["tcgen05.ld.sync.aligned.32x32b.x1.b32"](
                         reg[i], T.cuda.get_tmem_addr(tmem.allocated_addr[0], 0, i)
                     )
-                T.ptxd.tcgen05.wait__ld.sync.aligned()
+                T.ptx.tcgen05.wait__ld.sync.aligned()
                 B_bytes = reg.view("uint8")
                 for i in range(16):
                     B[lane_id, i] = B_bytes[i]
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
                     tmem_addr[0], T.uint32(n_tmem_cols_total)
                 )
 

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tcgen05_ldst.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tcgen05_ldst.py
@@ -291,7 +291,7 @@ def _run_roundtrip_16b(
 
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_addr), T.uint32(tmem_col_width_32b)
                 )
 
@@ -314,21 +314,21 @@ def _run_roundtrip_16b(
             # reg_in -> TMEM via .<shape>.x<rep>.st.unpack::16b
             frag_in = reg_in.view(frag_rows, K_cols_elem, layout=atom_view)
             Tx.wg.copy_async(tmem[0:frag_rows, 0:K_cols_elem], frag_in[:, :])
-            T.ptxd.tcgen05.wait__st.sync.aligned()
+            T.ptx.tcgen05.wait__st.sync.aligned()
             T.cuda.cta_sync()
 
             # TMEM -> reg_out via .<shape>.x<rep>.ld.pack::16b
             reg_out = T.alloc_local((per_thread_elems,), dtype)
             frag_out = reg_out.view(frag_rows, K_cols_elem, layout=atom_view)
             Tx.wg.copy_async(frag_out[:, :], tmem[0:frag_rows, 0:K_cols_elem])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             T.cuda.cta_sync()
             for i in range(per_thread_elems):
                 B[tid_in_wg, i] = reg_out[i]
 
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
                     tmem_addr[0], T.uint32(tmem_col_width_32b)
                 )
 
@@ -527,7 +527,7 @@ def test_tcgen05_16xnb_sub_slab_view_read(shape, rep):
         tmem_addr = T.alloc_shared([1], "uint32")
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_addr), T.uint32(tmem_cols)
                 )
             T.tvm_storage_sync("shared")
@@ -557,33 +557,33 @@ def test_tcgen05_16xnb_sub_slab_view_read(shape, rep):
                 source[i] = A[tid, i]
             T.cuda.cta_sync()
             Tx.wg.copy_async(tmem_d[0:128, 0:cols], source.view(128, cols, layout=atom128))
-            T.ptxd.tcgen05.wait__st.sync.aligned()
+            T.ptx.tcgen05.wait__st.sync.aligned()
             T.cuda.cta_sync()
 
             full = T.alloc_local((regs128,), dtype)
             Tx.wg.copy_async(full.view(128, cols, layout=atom128), tmem_d[0:128, 0:cols])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             T.cuda.cta_sync()
             for i in range(regs128):
                 B128[tid, i] = full[i]
 
             lower = T.alloc_local((regs64,), dtype)
             Tx.wg.copy_async(lower.view(64, cols, layout=atom64), tmem_f0[0:64, 0:cols])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             T.cuda.cta_sync()
             for i in range(regs64):
                 B0[tid, i] = lower[i]
 
             upper = T.alloc_local((regs64,), dtype)
             Tx.wg.copy_async(upper.view(64, cols, layout=atom64), tmem_f1[0:64, 0:cols])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             T.cuda.cta_sync()
             for i in range(regs64):
                 B1[tid, i] = upper[i]
 
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
                     tmem_addr[0], T.uint32(tmem_cols)
                 )
 
@@ -778,7 +778,7 @@ def test_datapath_B_ld_st_roundtrip(n_cols, col_offset):
 
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_addr), T.uint32(tmem_cols)
                 )
             T.tvm_storage_sync("shared")
@@ -796,20 +796,20 @@ def test_datapath_B_ld_st_roundtrip(n_cols, col_offset):
                 frag_in_local[i] = A[tid, i]
             T.cuda.cta_sync()
             Tx.wg.copy_async(tmem[:, :], frag_in[:, :])
-            T.ptxd.tcgen05.wait__st.sync.aligned()
+            T.ptx.tcgen05.wait__st.sync.aligned()
             T.cuda.cta_sync()
 
             frag_out = T.alloc_tcgen05_ldst_frag("32x32b", (64, n_cols), "float32")
             Tx.wg.copy_async(frag_out[:, :], tmem[:, :])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             T.cuda.cta_sync()
             frag_out_local = frag_out.local()
             for i in range(n_half):
                 B[tid, i] = frag_out_local[i]
 
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
                     tmem_addr[0], T.uint32(tmem_cols)
                 )
 
@@ -890,7 +890,7 @@ def _run_load_test(shape: str, rep: int, dtype: str):
 
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_addr), T.uint32(tmem_col_width_32b)
                 )
 
@@ -925,7 +925,7 @@ def _run_load_test(shape: str, rep: int, dtype: str):
                     tmem[:, col_off_elem : col_off_elem + chunk_width_elem],
                     stage_local[:, :],
                 )
-            T.ptxd.tcgen05.wait__st.sync.aligned()
+            T.ptx.tcgen05.wait__st.sync.aligned()
             T.cuda.cta_sync()
 
             # TMEM[0:frag_rows, 0:K_cols] -> frag_local via .<shape>.x<rep>.ld.
@@ -935,14 +935,14 @@ def _run_load_test(shape: str, rep: int, dtype: str):
             frag_reg = T.alloc_local((per_thread_elems,), dtype)
             frag_local = frag_reg.view(frag_rows, K_cols_elem, layout=atom_view)
             Tx.wg.copy_async(frag_local[:, :], tmem[0:frag_rows, 0:K_cols_elem])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             T.cuda.cta_sync()
             for i in range(per_thread_elems):
                 B[tid_in_wg, i] = frag_reg[i]
 
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
                     tmem_addr[0], T.uint32(tmem_col_width_32b)
                 )
 
@@ -1056,7 +1056,7 @@ def test_tcgen05_st_16xnb_store(shape, rep, dtype):
 
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_addr), T.uint32(tmem_col_width_32b)
                 )
 
@@ -1079,14 +1079,14 @@ def test_tcgen05_st_16xnb_store(shape, rep, dtype):
             # frag_local -> TMEM via .<shape>.x<rep>.st
             frag_local = frag_reg.view(frag_rows, K_cols_elem, layout=atom_view)
             Tx.wg.copy_async(tmem[0:frag_rows, 0:K_cols_elem], frag_local[:, :])
-            T.ptxd.tcgen05.wait__st.sync.aligned()
+            T.ptx.tcgen05.wait__st.sync.aligned()
             T.cuda.cta_sync()
 
             # TMEM -> readout via .32x32b.ld
             stage_reg = T.alloc_local((stage_width_elem,), dtype)
             stage_local = stage_reg.view(128, stage_width_elem, layout=stage_view)
             Tx.wg.copy_async(stage_local[:, :], tmem[:, :])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             T.cuda.cta_sync()
             for i in range(stage_width_elem // VEC_LEN):
                 g_offset = T.meta_var(g_layout.apply(tid_in_wg, i, 0)["m"])
@@ -1096,8 +1096,8 @@ def test_tcgen05_st_16xnb_store(shape, rep, dtype):
                 )
 
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
                     tmem_addr[0], T.uint32(tmem_col_width_32b)
                 )
 
@@ -1183,7 +1183,7 @@ def test_alloc_tcgen05_frag_wrapper_compiles(shape, frag_rows, K_cols):
         tmem_addr = T.alloc_shared([1], "uint32")
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_addr), T.uint32(max(32, K_cols))
                 )
             T.tvm_storage_sync("shared")
@@ -1197,10 +1197,10 @@ def test_alloc_tcgen05_frag_wrapper_compiles(shape, frag_rows, K_cols):
             # One-liner: wrapper handles per-thread storage + layout.
             frag = T.alloc_tcgen05_ldst_frag(shape, (frag_rows, K_cols), "float32")
             Tx.wg.copy_async(frag[:, :], tmem[0:frag_rows, 0:K_cols])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
                     tmem_addr[0], T.uint32(max(32, K_cols))
                 )
 
@@ -1219,7 +1219,7 @@ def test_tcgen05_32x32b_float32_keeps_typed_register_operands():
     """The .32x32b float32 lowering should pass the local fragment's typed
     registers to the PTX helper. The helper reinterprets operands as b32, so a
     call-site uint32 view is unnecessary and makes generated CUDA diverge from
-    handwritten ``T.ptxd.tcgen05`` calls."""
+    handwritten ``T.ptx.tcgen05`` calls."""
 
     K_cols = 32
 
@@ -1237,7 +1237,7 @@ def test_tcgen05_32x32b_float32_keeps_typed_register_operands():
         tmem_addr = T.alloc_shared([1], "uint32")
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_addr), T.uint32(K_cols)
                 )
             T.tvm_storage_sync("shared")
@@ -1250,10 +1250,10 @@ def test_tcgen05_32x32b_float32_keeps_typed_register_operands():
             )
             frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, K_cols), "float32")
             Tx.wg.copy_async(frag[:, :], tmem[:, :])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(K_cols))
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(K_cols))
 
     target = tvm.target.Target("cuda")
     with target:
@@ -1274,7 +1274,7 @@ def test_tcgen05_ldst_constant_tmem_address_is_uint32():
     """A constant TMEM base address must still be passed as uint32.
 
     Sparse FlashMLA uses pool-relative constant TMEM columns. Handwritten
-    ``T.ptxd.tcgen05`` calls pass ``T.uint32(0)`` for the base address; the tile
+    ``T.ptx.tcgen05`` calls pass ``T.uint32(0)`` for the base address; the tile
     primitive should emit the same ABI shape instead of a bare integer literal.
     """
 
@@ -1300,9 +1300,9 @@ def test_tcgen05_ldst_constant_tmem_address_is_uint32():
             )
             frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, K_cols), "float32")
             Tx.wg.copy_async(frag[:, :], tmem[:, :])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             Tx.wg.copy_async(tmem[:, :], frag[:, :])
-            T.ptxd.tcgen05.wait__st.sync.aligned()
+            T.ptx.tcgen05.wait__st.sync.aligned()
 
     target = tvm.target.Target("cuda")
     with target:
@@ -1377,7 +1377,7 @@ def _run_sliced_vs_full_load(shape, full_rep, n_chunks):
         tmem_addr = T.alloc_shared([1], "uint32")
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_addr), T.uint32(tmem_col_width_32b)
                 )
             T.tvm_storage_sync("shared")
@@ -1398,14 +1398,14 @@ def _run_sliced_vs_full_load(shape, full_rep, n_chunks):
                     Tx.copy(stage_reg[i * VEC_LEN : i * VEC_LEN + VEC_LEN], A_flat[g : g + VEC_LEN])
                 T.cuda.cta_sync()
                 Tx.wg.copy_async(tmem[:, coff : coff + stage_w], stage_local[:, :])
-            T.ptxd.tcgen05.wait__st.sync.aligned()
+            T.ptx.tcgen05.wait__st.sync.aligned()
             T.cuda.cta_sync()
 
             # (a) one full-width load
             ff = T.alloc_local((per_thread_elems,), dtype)
             ffl = ff.view(frag_rows, K_cols_fp32, layout=atom_view)
             Tx.wg.copy_async(ffl[:, :], tmem[0:frag_rows, 0:K_cols_fp32])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             T.cuda.cta_sync()
             for i in range(per_thread_elems):
                 Bf[tid_in_wg, i] = ff[i]
@@ -1418,14 +1418,14 @@ def _run_sliced_vs_full_load(shape, full_rep, n_chunks):
                 Tx.wg.copy_async(
                     sfl[:, lo : lo + chunk_elem], tmem[0:frag_rows, lo : lo + chunk_elem]
                 )
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             T.cuda.cta_sync()
             for i in range(per_thread_elems):
                 Bs[tid_in_wg, i] = sf[i]
 
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
                     tmem_addr[0], T.uint32(tmem_col_width_32b)
                 )
 
@@ -1519,7 +1519,7 @@ def test_copy_tmem2reg_async(dtype, width_32b):
 
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(T.address_of(tmem_addr), T.uint32(max(32, next_power_of_2(width_32b))))  # noqa: E501
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(T.address_of(tmem_addr), T.uint32(max(32, next_power_of_2(width_32b))))  # noqa: E501
 
             T.tvm_storage_sync("shared")
 
@@ -1539,20 +1539,20 @@ def test_copy_tmem2reg_async(dtype, width_32b):
 
                     # A_local -> tmem (async)
             Tx.wg.copy_async(tmem[:, :], A_local[:, :])
-            T.ptxd.tcgen05.wait__st.sync.aligned()  # explicit wait
+            T.ptx.tcgen05.wait__st.sync.aligned()  # explicit wait
             T.cuda.cta_sync()
 
                     # tmem -> B_local (async)
             Tx.wg.copy_async(B_local[:, :], tmem[:, :])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()  # explicit wait
+            T.ptx.tcgen05.wait__ld.sync.aligned()  # explicit wait
             T.cuda.cta_sync()
             for i in range(WIDTH // VEC_LEN):
                 g_offset = T.meta_var(g_layout.apply(tid_in_wg, i, 0)["m"])
                 Tx.copy(B_flat[g_offset: g_offset + VEC_LEN], B_reg[i * VEC_LEN: i * VEC_LEN + VEC_LEN])  # noqa: E501
 
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(max(32, next_power_of_2(width_32b))))  # noqa: E501
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(max(32, next_power_of_2(width_32b))))  # noqa: E501
         # fmt: on
 
     target = tvm.target.Target("cuda")
@@ -1617,7 +1617,7 @@ def test_copy_tmem2reg(dtype, width_32b, offset_32b):
 
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(T.address_of(tmem_addr), T.uint32(max(32, next_power_of_2(offset_32b + width_32b))))  # noqa: E501
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(T.address_of(tmem_addr), T.uint32(max(32, next_power_of_2(offset_32b + width_32b))))  # noqa: E501
 
             T.tvm_storage_sync("shared")
 
@@ -1637,20 +1637,20 @@ def test_copy_tmem2reg(dtype, width_32b, offset_32b):
 
                     # A_local -> tmem
             Tx.wg.copy_async(tmem[:, OFFSET: OFFSET + WIDTH], A_local[:, :])
-            T.ptxd.tcgen05.wait__st.sync.aligned()
+            T.ptx.tcgen05.wait__st.sync.aligned()
             T.cuda.cta_sync()
 
                     # tmem -> B_local
             Tx.wg.copy_async(B_local[:, :], tmem[:, OFFSET: OFFSET + WIDTH])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             T.cuda.cta_sync()
             for i in range(WIDTH // VEC_LEN):
                 g_offset = T.meta_var(g_layout.apply(tid_in_wg, i, 0)["m"])
                 Tx.copy(B_flat[g_offset: g_offset + VEC_LEN], B_reg[i * VEC_LEN: i * VEC_LEN + VEC_LEN])  # noqa: E501
 
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(max(32, next_power_of_2(offset_32b + width_32b))))  # noqa: E501
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(max(32, next_power_of_2(offset_32b + width_32b))))  # noqa: E501
         # fmt: on
 
     target = tvm.target.Target("cuda")
@@ -1716,7 +1716,7 @@ def test_copy_tmem2reg_sliced_local(dtype, width_32b, local_offset_32b):
 
         if wg_id == 0:
             if warp_id == 0:
-                T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(T.address_of(tmem_addr), T.uint32(max(32, next_power_of_2(width_32b))))  # noqa: E501
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(T.address_of(tmem_addr), T.uint32(max(32, next_power_of_2(width_32b))))  # noqa: E501
 
             T.tvm_storage_sync("shared")
 
@@ -1736,20 +1736,20 @@ def test_copy_tmem2reg_sliced_local(dtype, width_32b, local_offset_32b):
 
                     # A_local[sliced] -> tmem (use sliced region)
             Tx.wg.copy_async(tmem[:, 0:WIDTH], A_local[:, LOCAL_OFFSET:LOCAL_OFFSET + WIDTH])
-            T.ptxd.tcgen05.wait__st.sync.aligned()
+            T.ptx.tcgen05.wait__st.sync.aligned()
             T.cuda.cta_sync()
 
                     # tmem -> B_local[sliced] (use sliced region)
             Tx.wg.copy_async(B_local[:, LOCAL_OFFSET:LOCAL_OFFSET + WIDTH], tmem[:, 0:WIDTH])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
             T.cuda.cta_sync()
             for i in range(WIDTH // VEC_LEN):
                 g_offset = T.meta_var(g_layout.apply(tid_in_wg, i, 0)["m"])
                 Tx.copy(B_flat[g_offset: g_offset + VEC_LEN], B_reg[LOCAL_OFFSET + i * VEC_LEN: LOCAL_OFFSET + i * VEC_LEN + VEC_LEN])  # noqa: E501
 
             if warp_id == 0:
-                T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-                T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(max(32, next_power_of_2(width_32b))))  # noqa: E501
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(max(32, next_power_of_2(width_32b))))  # noqa: E501
         # fmt: on
 
     target = tvm.target.Target("cuda")

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tcgen05_ldst.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tcgen05_ldst.py
@@ -1263,7 +1263,7 @@ def test_tcgen05_32x32b_float32_keeps_typed_register_operands():
     call_lines = [
         line
         for line in src.splitlines()
-        if "ptxd_tcgen05_ld_ld_sync_aligned_32x32b_x32_b32_f32(" in line
+        if "ptx_tcgen05_ld_ld_sync_aligned_32x32b_x32_b32_f32(" in line
         and "__forceinline__" not in line
     ]
     assert call_lines
@@ -1312,13 +1312,13 @@ def test_tcgen05_ldst_constant_tmem_address_is_uint32():
     ld_lines = [
         line
         for line in src.splitlines()
-        if "ptxd_tcgen05_ld_ld_sync_aligned_32x32b_x32_b32_f32(" in line
+        if "ptx_tcgen05_ld_ld_sync_aligned_32x32b_x32_b32_f32(" in line
         and "__forceinline__" not in line
     ]
     st_lines = [
         line
         for line in src.splitlines()
-        if "ptxd_tcgen05_st_st_sync_aligned_32x32b_x32_b32_f32(" in line
+        if "ptx_tcgen05_st_st_sync_aligned_32x32b_x32_b32_f32(" in line
         and "__forceinline__" not in line
     ]
     assert ld_lines

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tma.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tma.py
@@ -59,14 +59,14 @@ from tvm.tirx.stmt_functor import StmtExprVisitor
 from tvm.tirx.tile_primitive import DispatchContext
 
 _TMA_OPS = {
-    "tirx.ptxd.cp_async_bulk_tensor_g2s_cluster",
-    "tirx.ptxd.cp_async_bulk_tensor_s2g",
-    "tirx.ptxd.cp_reduce_async_bulk_tensor",
+    "tirx.ptx.cp_async_bulk_tensor_g2s_cluster",
+    "tirx.ptx.cp_async_bulk_tensor_s2g",
+    "tirx.ptx.cp_reduce_async_bulk_tensor",
 }
 
 
-def _ptxd_call_parts(call):
-    """Decode one ptxd Call: (modifier map, operand name -> args tuple).
+def _ptx_call_parts(call):
+    """Decode one ptx Call: (modifier map, operand name -> args tuple).
 
     The dialect's Call layout is [operands..., pred?][slot tokens][pred marker];
     the operand positions follow the table's layout for the call's tokens, so
@@ -74,7 +74,7 @@ def _ptxd_call_parts(call):
     """
     from tvm.backend.cuda.ptx_dialect.table import TABLE, mods, operand_layout
 
-    entry = TABLE[call.op.name.removeprefix("tirx.ptxd.")]
+    entry = TABLE[call.op.name.removeprefix("tirx.ptx.")]
     n_slots = len(entry.slots)
     tokens = [str(a.value) for a in call.args[len(call.args) - n_slots - 1 : -1]]
     mod_map = mods(entry, tokens)
@@ -145,7 +145,7 @@ class _PrefetchCollector(StmtExprVisitor):
         self.names = []
 
     def visit_call_(self, op):
-        if isinstance(op.op, tvm.ir.Op) and op.op.name == "tirx.ptxd.prefetch":
+        if isinstance(op.op, tvm.ir.Op) and op.op.name == "tirx.ptx.prefetch":
             addr = op.args[0]
             # A tensormap address arrives as a u64 handle, so the dialect
             # coerces it with an explicit reinterpret before the call.
@@ -964,7 +964,7 @@ def test_tma_codegen(case_id, kwargs):
     assert counter.total == 1
     assert len(counter.calls) == 1
     call = counter.calls[0]
-    mod_map, operands = _ptxd_call_parts(call)
+    mod_map, operands = _ptx_call_parts(call)
     assert mod_map["dim"] == f"{len(expected.dims)}d"
     assert _ints(operands["coords"]) == expected.coordinates
 
@@ -1147,7 +1147,7 @@ def bind_coordinate(D_ptr: T.handle):
     counter = _count_tma(lowered["main"])
     assert counter.total == 1
     call = counter.calls[0]
-    mod_map, operands = _ptxd_call_parts(call)
+    mod_map, operands = _ptx_call_parts(call)
     assert mod_map["dim"] == "3d"
     assert int(operands["coords"][0]) == 0
     assert int(operands["coords"][1]) == 0
@@ -1455,7 +1455,7 @@ def test_explicit_oob_reduce_and_tf32_configs():
     )
     counter = _count_tma(store_impl)
     assert counter.total == 1
-    assert counter.calls[0].op.name == "tirx.ptxd.cp_reduce_async_bulk_tensor"
+    assert counter.calls[0].op.name == "tirx.ptx.cp_reduce_async_bulk_tensor"
 
     _, tf32_host, _ = _lower_direct(
         "tma_explicit",
@@ -1494,7 +1494,7 @@ def test_explicit_gather_uses_extracted_swizzled_slice_pointer():
         config={"gather4": [0, 1, 2, 3]},
         target_arch="sm_100a",
     )
-    _, operands = _ptxd_call_parts(_count_tma(impl).calls[0])
+    _, operands = _ptx_call_parts(_count_tma(impl).calls[0])
     shared_ptr = _unwrap_shared_addr(operands["dst_mem"][0])
     assert shared_ptr.op.name == "tirx.address_of"
     assert int(shared_ptr.args[0].buffer.elem_offset) == 0
@@ -1512,7 +1512,7 @@ def test_explicit_shared_pointer_counts_each_offset_once():
         s_layout=layout,
         s_elem_offset=32,
     )
-    _, operands = _ptxd_call_parts(_count_tma(impl).calls[0])
+    _, operands = _ptx_call_parts(_count_tma(impl).calls[0])
     shared_ptr = _unwrap_shared_addr(operands["dst_mem"][0])
     assert shared_ptr.op.name == "tirx.address_of"
     pointer_index = shared_ptr.args[0].indices[0]
@@ -1562,7 +1562,7 @@ def selector_gather(
     )
     mbar = T.decl_buffer((1,), "uint64", dyn.data, elem_offset=64)
     if tid == 0:
-        T.ptxd.mbarrier.init.shared.b64(mbar.ptr_to([0]), T.uint32(1))
+        T.ptx.mbarrier.init.shared.b64(mbar.ptr_to([0]), T.uint32(1))
         Tx.copy_async(
             A_smem[:, :],
             A[0:1, :],
@@ -1789,8 +1789,8 @@ def test_sparse_decode_runtime_stride_q_tail_o_counts_and_descriptor_dedup():
     kernel = _build_sparse_decode_qo_tma_regression()
     lowered = _lower_module(kernel)
     counter = _count_tma(lowered["main"])
-    load_op = "tirx.ptxd.cp_async_bulk_tensor_g2s_cluster"
-    store_op = "tirx.ptxd.cp_async_bulk_tensor_s2g"
+    load_op = "tirx.ptx.cp_async_bulk_tensor_g2s_cluster"
+    store_op = "tirx.ptx.cp_async_bulk_tensor_s2g"
     assert sum(weight for call, weight in counter.weighted_calls if call.op.name == load_op) == 9
     assert sum(weight for call, weight in counter.weighted_calls if call.op.name == store_op) == 8
 
@@ -2011,8 +2011,8 @@ def _build_selector_gather_gpu_kernel(dtype="float16"):
         mbar = T.decl_buffer((1,), "uint64", dyn.data, elem_offset=shared_bytes // 8)
         mbar_ptr = T.meta_var(mbar.ptr_to([0]))
         if tid == 0:
-            T.ptxd.mbarrier.init.shared.b64(mbar_ptr, T.uint32(1))
-        T.ptxd.fence.proxy.async_.shared__cta()
+            T.ptx.mbarrier.init.shared.b64(mbar_ptr, T.uint32(1))
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         if tid == 0:
             Tx.copy_async(
@@ -2023,9 +2023,9 @@ def _build_selector_gather_gpu_kernel(dtype="float16"):
                 gather4=[7, 3, 19, 5],
                 src_selector=[(flag != 0, B)],
             )
-            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(mbar_ptr, T.uint32(shared_bytes))
+            T.ptx.mbarrier.arrive.expect_tx.shared.b64(mbar_ptr, T.uint32(shared_bytes))
         T.cuda.mbarrier_wait(mbar_ptr, 0)
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         Tx.cta.copy(Out[:, :], A_smem[:, :])
         # fmt: on

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tma.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tma.py
@@ -1601,7 +1601,7 @@ def test_explicit_gather_selector_encodes_each_map_selects_address_and_issues_on
     # descriptors into a single gather4 issue.
     assert (
         cuda_source.count(
-            "tvm_builtin_ptxd_cp_async_bulk_tensor_g2s_cluster_async_bulk_tensor_2d"
+            "tvm_builtin_ptx_cp_async_bulk_tensor_g2s_cluster_async_bulk_tensor_2d"
             "_shared__cluster_global_tile__gather4_mbarrier__complete_tx__bytes"
             "_cta_group__1("
         )

--- a/tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_binary.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_binary.py
@@ -570,12 +570,7 @@ def test_binary_op_packed_f32x2_auto_dispatch(op_type):
             "sub": r"sub\.[a-z]+\.ftz\.f32x2",
             "mul": r"mul\.[a-z]+\.ftz\.f32x2",
         }[op_type]
-        builtin_pat = {
-            "add": r"tvm_builtin_ptx_add_packed_",
-            "sub": r"tvm_builtin_ptx_sub_packed_",
-            "mul": r"tvm_builtin_ptx_mul_packed_",
-        }[op_type]
-        assert re.search(ptx_pat, src) or re.search(builtin_pat, src), src
+        assert re.search(ptx_pat, src), src
         if op_type == "add":
             A_ref = A_np + B_np
         elif op_type == "sub":
@@ -715,9 +710,9 @@ def test_binary_op_warpgroup_wg_local_emits_packed_f32x2(op_name, ptx_op):
         src = ex.mod.imports[0].inspect_source()
 
     # Codegen must use the packed f32x2 path, not scalar fallback.
-    assert re.search(rf"{ptx_op}\.[a-z]+\.ftz\.f32x2", src) or re.search(
-        rf"tvm_builtin_ptx_{ptx_op}_packed_[a-z]+_f32x2", src
-    ), f"expected packed f32x2 PTX for op={op_name}, source preview:\n{src[:2000]}"
+    assert re.search(rf"{ptx_op}\.[a-z]+\.ftz\.f32x2", src), (
+        f"expected packed f32x2 PTX for op={op_name}, source preview:\n{src[:2000]}"
+    )
 
 
 def test_fma_warpgroup_wg_local_emits_packed_f32x2():
@@ -757,9 +752,9 @@ def test_fma_warpgroup_wg_local_emits_packed_f32x2():
         ex = tvm.compile(mod, target=target, tir_pipeline="tirx")
         src = ex.mod.imports[0].inspect_source()
 
-    assert re.search(r"fma\.[a-z]+\.ftz\.f32x2", src) or re.search(
-        r"tvm_builtin_ptx_fma_packed_[a-z]+_f32x2", src
-    ), f"expected packed f32x2 fma PTX, source preview:\n{src[:2000]}"
+    assert re.search(r"fma\.[a-z]+\.ftz\.f32x2", src), (
+        f"expected packed f32x2 fma PTX, source preview:\n{src[:2000]}"
+    )
 
 
 # -----------------------------------------------------------------------------
@@ -792,9 +787,9 @@ def test_binary_add_f32_sm100_packed_f32x2_dispatch():
         mod = tvm.IRModule({"main": k})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         src = mod.mod.imports[0].inspect_source()
-    assert re.search(r"add\.[a-z]+\.ftz\.f32x2", src) or re.search(
-        r"tvm_builtin_ptx_add_packed_", src
-    ), f"expected packed add_f32x2; got:\n{src[:2000]}"
+    assert re.search(r"add\.[a-z]+\.ftz\.f32x2", src), (
+        f"expected packed add_f32x2; got:\n{src[:2000]}"
+    )
 
 
 @pytest.mark.gpu
@@ -896,9 +891,9 @@ def test_mul_tcgen05_16x256b_atom_warpgroup_dispatch():
     with target:
         mod = tvm.compile(tvm.IRModule({"main": kernel}), target=target, tir_pipeline="tirx")
         src = mod.mod.imports[0].inspect_source()
-    assert re.search(r"mul\.[a-z]+\.ftz\.f32x2", src) or re.search(
-        r"tvm_builtin_ptx_mul_packed_", src
-    ), f"expected packed mul_f32x2 for tcgen05 atom; got:\n{src[:2000]}"
+    assert re.search(r"mul\.[a-z]+\.ftz\.f32x2", src), (
+        f"expected packed mul_f32x2 for tcgen05 atom; got:\n{src[:2000]}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_fma.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_fma.py
@@ -207,9 +207,9 @@ def test_add_rounding_mode():
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         # Check that the PTX uses the rounding mode
         src = mod.mod.imports[0].inspect_source()
-        assert re.search(r"add\.rm\.ftz\.f32x2", src) or re.search(
-            r"tvm_builtin_ptx_add_packed_", src
-        ), f"Expected packed add with rm rounding in PTX:\n{src}"
+        assert re.search(r"add\.rm\.ftz\.f32x2", src), (
+            f"Expected packed add with rm rounding in PTX:\n{src}"
+        )
 
         def run_and_check():
             dev = tvm.cuda(0)
@@ -300,9 +300,9 @@ def test_sub_buffer_buffer_rounding():
         mod = tvm.IRModule({"main": test_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         src = mod.mod.imports[0].inspect_source()
-        assert re.search(r"sub\.rn\.ftz\.f32x2", src) or re.search(
-            r"tvm_builtin_ptx_sub_packed_", src
-        ), f"Expected packed sub with rn rounding in PTX:\n{src}"
+        assert re.search(r"sub\.rn\.ftz\.f32x2", src), (
+            f"Expected packed sub with rn rounding in PTX:\n{src}"
+        )
 
         def run_and_check():
             dev = tvm.cuda(0)
@@ -394,9 +394,9 @@ def test_fma_f32_sm100_packed_f32x2_dispatch():
         mod = tvm.IRModule({"main": k})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         src = mod.mod.imports[0].inspect_source()
-    assert re.search(r"fma\.[a-z]+\.ftz\.f32x2", src) or re.search(
-        r"tvm_builtin_ptx_fma_packed_", src
-    ), f"expected packed fma_f32x2; got:\n{src[:2000]}"
+    assert re.search(r"fma\.[a-z]+\.ftz\.f32x2", src), (
+        f"expected packed fma_f32x2; got:\n{src[:2000]}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/operator/tile_primitive/cuda/gemm/test_gemm_mma_m16n8k_.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/gemm/test_gemm_mma_m16n8k_.py
@@ -641,7 +641,7 @@ def test_cuda_gemm_mma_codegen_issue_count(Mt, Nt, Kt, kinst):
     src = mod.mod.imports[0].inspect_source()
     assert f"mma.sync.aligned.m16n8k{kinst}" in src
     # mma is emitted as one __device__ helper, invoked once per tile.
-    helper = f"ptxd_mma_sync_aligned_m16n8k{kinst}_row_col"
+    helper = f"ptx_mma_sync_aligned_m16n8k{kinst}_row_col"
     assert src.count(helper) - 1 == Mt * Nt * Kt
 
 

--- a/tests/python/tirx/operator/tile_primitive/cuda/gemm/test_gemm_mma_m16n8k_.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/gemm/test_gemm_mma_m16n8k_.py
@@ -375,7 +375,7 @@ def test_cuda_gemm_mma_lowers_to_mma_sync(dtype):
     the registers laid out in the fixed PTX fragment order."""
     script = _lower(_build_gemm(alpha=1.0, beta=0.0, dtype=dtype))["main"].script()
 
-    assert "T.ptxd.mma(" in script
+    assert "T.ptx.mma(" in script
     assert "m16n8k16" in script
     # beta == 0 clears the accumulator before the K loop.
     assert "T.float32(0" in script
@@ -397,7 +397,7 @@ def test_cuda_gemm_mma_accumulates_c_when_beta_one():
     """beta=1: the accumulator is initialized by copying C instead of zeroing."""
     script = _lower(_build_gemm(alpha=1.0, beta=1.0))["main"].script()
 
-    assert "T.ptxd.mma(" in script
+    assert "T.ptx.mma(" in script
     assert "m16n8k16" in script
     # The init reads C into D; nothing is zeroed.
     assert "c_local[" in script
@@ -611,7 +611,7 @@ def test_cuda_gemm_mma_lowers_tiled(Mt, Nt, Kt, kinst):
     (an extent-1 high-K register group must not be rejected as a thread axis).
     """
     script = _lower(_build_tiled(Mt, Nt, Kt, kinst))["main"].script()
-    assert "T.ptxd.mma(" in script
+    assert "T.ptx.mma(" in script
     assert f"m16n8k{kinst}" in script
 
 
@@ -654,7 +654,7 @@ def test_cuda_gemm_mma_lowers_transpose(transpose_A, transpose_B):
     """All four A/B orientations dispatch to the same m16n8k16. transpose only
     describes the input's logical orientation; the .row.col mma is unchanged."""
     script = _lower(_build_transpose(transpose_A, transpose_B))["main"].script()
-    assert "T.ptxd.mma(" in script
+    assert "T.ptx.mma(" in script
     assert "m16n8k16" in script
 
 

--- a/tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py
@@ -2322,7 +2322,7 @@ def test_gemm_tcgen05_cta_group_2_accepts_replicated_tmem_a_codegen():
     src = mod.mod.imports[0].inspect_source()
     assert "tcgen05.mma.cta_group::2" in src
     assert "tcgen05.mma.ws" not in src
-    assert "tvm_builtin_ptxd_tcgen05_mma_ts_" in src
+    assert "tvm_builtin_ptx_tcgen05_mma_ts_" in src
 
 
 def test_gemm_tcgen05_cta_group_2_rejects_flat_tmem_a_codegen():
@@ -2970,7 +2970,7 @@ def _compile_cuda_source(func):
 
 
 def _dense_mma_call_lines(src):
-    helper = "tvm_builtin_ptxd_tcgen05_mma_ss_mma_cta_group__1_kind__f16("
+    helper = "tvm_builtin_ptx_tcgen05_mma_ss_mma_cta_group__1_kind__f16("
     return [line for line in src.splitlines() if line.lstrip().startswith(helper)]
 
 
@@ -3006,7 +3006,7 @@ def test_gemm_tcgen05_explicit_mma_tile_changes_physical_instructions():
 def test_gemm_tcgen05_explicit_mma_m_is_cluster_total_for_cta_group_2(M_per_cta, mma_m):
     src = _compile_cuda_source(_build_explicit_cta2_dense_kernel(M_per_cta, mma_m))
     assert "tcgen05.mma.cta_group::2.kind::f16" in src
-    helper = "tvm_builtin_ptxd_tcgen05_mma_ss_mma_cta_group__2_kind__f16("
+    helper = "tvm_builtin_ptx_tcgen05_mma_ss_mma_cta_group__2_kind__f16("
     calls = [line for line in src.splitlines() if line.lstrip().startswith(helper)]
     assert len(calls) == 1
     assert {(desc >> 24) & 0x1F for desc in _mma_descriptor_values(calls)} == {mma_m // 16}
@@ -3014,7 +3014,7 @@ def test_gemm_tcgen05_explicit_mma_m_is_cluster_total_for_cta_group_2(M_per_cta,
 
 def test_gemm_tcgen05_block_scaled_explicit_mma_tile_splits_n():
     src = _compile_cuda_source(_build_explicit_block_scaled_split_n_kernel())
-    helper = "tvm_builtin_ptxd_tcgen05_mma_block_scale_ss_mma_cta_group__2_kind__mxf8f6f4"
+    helper = "tvm_builtin_ptx_tcgen05_mma_block_scale_ss_mma_cta_group__2_kind__mxf8f6f4"
     calls = [line for line in src.splitlines() if line.lstrip().startswith(helper)]
     assert len(calls) == 2
 
@@ -3220,7 +3220,7 @@ def test_gemm_tcgen05_cta1_m64_accepts_packed_c_layout_ws():
 
     src = mod.mod.imports[0].inspect_source()
     assert "tcgen05.mma.ws.cta_group::1.kind::f16" in src
-    assert "tvm_builtin_ptxd_tcgen05_mma_ws_ts_mma_ws_cta_group__1_kind__f16((uint)400," in src
+    assert "tvm_builtin_ptx_tcgen05_mma_ws_ts_mma_ws_cta_group__1_kind__f16((uint)400," in src
     assert "get_tmem_addr(400, 0, 0)" not in src
     assert "get_tmem_addr(400, 0, 64)" not in src
 
@@ -3232,7 +3232,7 @@ def test_gemm_tcgen05_explicit_mma_tile_preserves_inferred_ws_datapath():
         )
     )
     assert "tcgen05.mma.ws.cta_group::1.kind::f16" in src
-    helper = "tvm_builtin_ptxd_tcgen05_mma_ws_ts_mma_ws_cta_group__1_kind__f16("
+    helper = "tvm_builtin_ptx_tcgen05_mma_ws_ts_mma_ws_cta_group__1_kind__f16("
     calls = [line for line in src.splitlines() if line.lstrip().startswith(helper)]
     assert len(calls) == 2
 

--- a/tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py
@@ -60,7 +60,7 @@ from tvm.tirx.layout import tid_in_wg as axis_tid_in_wg
 def _mapa(ptr, rank):
     """`mapa.u64` into a declared register, returned as a value."""
     mapped = T.alloc_local([1], "uint64")
-    T.evaluate(T.ptxd.mapa.u64(mapped[0], ptr, T.uint32(rank)))
+    T.evaluate(T.ptx.mapa.u64(mapped[0], ptr, T.uint32(rank)))
     return mapped[0]
 
 
@@ -256,13 +256,13 @@ def test_gemm_tcgen05_cta_group_1(task):
         mma_mbar = T.alloc_shared([1], "uint64")
 
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
-        T.ptxd.fence.proxy.async_.shared__cta()
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
 
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(cols_alloc)
             )
         T.cuda.cta_sync()
@@ -272,28 +272,28 @@ def test_gemm_tcgen05_cta_group_1(task):
             tma_args = T.meta_var({"dispatch": "tma_auto", "mbar": tma_mbar.ptr_to([0])})
             Tx.copy_async(A_smem[tuple(r_gmem_A)], A[tuple(r_gmem_A)], **tma_args)
             Tx.copy_async(B_smem[tuple(r_gmem_B)], B[tuple(r_gmem_B)], **tma_args)
-            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
+            T.ptx.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
         T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
 
         if tid_in_wg == 0:
             Tx.gemm_async(tmem[tuple(r_tmem_C)], A_smem[tuple(r_smem_A)], B_smem[tuple(r_smem_B)], dispatch="tcgen05", mma_m=128, mma_n=64)  # noqa: E501
-            T.ptxd.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
+            T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
 
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         C_reg = T.alloc_local(width, dtype=C_dtype)
         C_view = C_reg.view(128, width, layout=TileLayout(S[(128, width) : (1@axis_tid_in_wg, 1)]))
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem[tuple(r_tmem_C)])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[tid_in_wg, C_region[1][0]:C_region[1][1]], C_reg[:])
 
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
         # fmt: on
 
     np.random.seed(0)
@@ -368,13 +368,13 @@ def test_gemm_tcgen05_cta_group_1_layout_f_m64():
         mma_mbar = T.alloc_shared([1], "uint64")
 
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
-        T.ptxd.fence.proxy.async_.shared__cta()
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
 
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(64)
             )
         T.cuda.cta_sync()
@@ -385,7 +385,7 @@ def test_gemm_tcgen05_cta_group_1_layout_f_m64():
             tma_args = T.meta_var({"dispatch": "tma_auto", "mbar": tma_mbar.ptr_to([0])})
             Tx.copy_async(A_smem[:, :], A[:, :], **tma_args)
             Tx.copy_async(B_smem[:, :], B[:, :], **tma_args)
-            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(
+            T.ptx.mbarrier.arrive.expect_tx.shared.b64(
                 tma_mbar.ptr_to([0]), T.uint32((M * K + N * K) * 2)
             )
         T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
@@ -393,17 +393,17 @@ def test_gemm_tcgen05_cta_group_1_layout_f_m64():
 
         if tid_in_wg == 0:
             Tx.gemm_async(tmem[0:64, 0:N], A_smem[:, :], B_smem[:, :], dispatch="tcgen05")
-            T.ptxd.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
+            T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
 
         # Read back via .16x256b M=64 (the canonical pairing).
         reg = T.alloc_local(32, dtype="float32")
         reg_view = reg.view(64, N, layout=tcgen05_atom_layout("16x256b", (64, N), "float32"))
         if wg_id == 0:
             Tx.wg.copy_async(reg_view[:, :], tmem[0:64, 0:N])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
 
         # Per-(reg -> row, col) decomposition for .16x256b M=64 fp32 (BT=64 -> rep=8):
@@ -419,8 +419,8 @@ def test_gemm_tcgen05_cta_group_1_layout_f_m64():
                     C[row, col] = reg[r]
 
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(64))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(64))
     # fmt: on
 
     np.random.seed(0)
@@ -516,16 +516,16 @@ def test_gemm_tcgen05_cta_group_2(task):
         tma_mbar_cta_0 = T.decl_buffer([1], "uint64", data=ptr, scope="shared")
 
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
 
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(cols_alloc)
             )
         tmem = T.decl_buffer((128, C_shape[1]), C_dtype, scope="tmem", allocated_addr=tmem_addr[0], layout=TileLayout(S[(128, C_shape[1]) : (1 @ TLane, 1 @ TCol)]))  # noqa: E501
-        T.ptxd.fence.mbarrier_init.release.cluster()
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.mbarrier_init.release.cluster()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         T.cuda.cluster_sync()
 
@@ -534,36 +534,36 @@ def test_gemm_tcgen05_cta_group_2(task):
             Tx.copy_async(A_smem[tuple(r_smem_A_in)], A[tuple(get_global_region(A_shape_per_cta, transA, cbx))], **tma_args)  # noqa: E501
             Tx.copy_async(B_smem[tuple(r_smem_B_in)], B[tuple(get_global_region(B_shape_per_cta, transB, cbx))], **tma_args)  # noqa: E501
             if cbx == 0:
-                T.ptxd.mbarrier.arrive.expect_tx.shared.b64(
+                T.ptx.mbarrier.arrive.expect_tx.shared.b64(
                     tma_mbar.ptr_to([0]), T.uint32(total_bytes)
                 )
 
         if cbx == 0:
             T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
-            T.ptxd.tcgen05.fence__after_thread_sync()
+            T.ptx.tcgen05.fence__after_thread_sync()
             T.cuda.cta_sync()
             if tid_in_wg == 0:
                 Tx.gemm_async(tmem[tuple(r_tmem_C)], A_smem[tuple(r_smem_A)], B_smem[tuple(r_smem_B)], dispatch="tcgen05", cta_group=2, mma_m=256, mma_n=128)  # noqa: E501
-                T.ptxd[
+                T.ptx[
                     "tcgen05.commit.cta_group::2.mbarrier::arrive::one"
                     ".shared::cluster.multicast::cluster.b64"
                 ](mma_mbar.ptr_to([0]), T.uint16(3)) # signal cta 1's mbarrier
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0) # both cta 0 and cta 1 have done mma
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         T.cuda.cta_sync()
 
         C_reg = T.alloc_local(width , dtype=C_dtype)
         C_view = C_reg.view(128, width, layout=TileLayout(S[(128, width) : (1@axis_tid_in_wg, 1)]))
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem[C_region[0][0]:C_region[0][1], C_region[1][0]:C_region[1][0] + width])  # noqa: E501
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[cbx * 128 +tid_in_wg, C_region[1][0]:C_region[1][0] + width], C_reg[:])
         T.cuda.cta_sync()
 
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__2.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__2.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
         # fmt: on
 
     np.random.seed(0)
@@ -655,18 +655,18 @@ def test_gemm_tcgen05_cta_group_2_layout_b():
         tma_mbar_cta_0 = T.decl_buffer([1], "uint64", data=ptr, scope="shared")
 
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
 
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(cols_alloc)
             )
         tmem = T.decl_buffer((M_per_cta, N_logical), C_dtype, scope="tmem", allocated_addr=tmem_addr[0], layout=TileLayout(S[(M_per_cta, 2, N_half) : (1 @ TLane, 64 @ TLane, 1 @ TCol)]))  # noqa: E501
                 # Physical TMEM view for readback: (128, N_half) standard layout
         tmem_phys = T.decl_buffer((128, N_half), C_dtype, scope="tmem", allocated_addr=tmem_addr[0], layout=TileLayout(S[(128, N_half) : (1 @ TLane, 1 @ TCol)]))  # noqa: E501
-        T.ptxd.fence.mbarrier_init.release.cluster()
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.mbarrier_init.release.cluster()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         T.cuda.cluster_sync()
 
@@ -676,22 +676,22 @@ def test_gemm_tcgen05_cta_group_2_layout_b():
             Tx.copy_async(A_smem[0:M_per_cta, 0:K], A[cbx * M_per_cta:(cbx + 1) * M_per_cta, 0:K], **tma_args)  # noqa: E501
             Tx.copy_async(B_smem[0:N_half, 0:K], B[cbx * N_half:(cbx + 1) * N_half, 0:K], **tma_args)  # noqa: E501
             if cbx == 0:
-                T.ptxd.mbarrier.arrive.expect_tx.shared.b64(
+                T.ptx.mbarrier.arrive.expect_tx.shared.b64(
                     tma_mbar.ptr_to([0]), T.uint32(total_bytes)
                 )
 
         if cbx == 0:
             T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
-            T.ptxd.tcgen05.fence__after_thread_sync()
+            T.ptx.tcgen05.fence__after_thread_sync()
             T.cuda.cta_sync()
             if tid_in_wg == 0:
                 Tx.gemm_async(tmem[0:M_per_cta, 0:N_logical], A_smem[0:M_per_cta, 0:K], B_smem[0:N_half, 0:K], dispatch="tcgen05", cta_group=2, mma_m=128, mma_n=128)  # noqa: E501
-                T.ptxd[
+                T.ptx[
                     "tcgen05.commit.cta_group::2.mbarrier::arrive::one"
                     ".shared::cluster.multicast::cluster.b64"
                 ](mma_mbar.ptr_to([0]), T.uint16(3))
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         T.cuda.cta_sync()
 
                 # Readback from physical TMEM view (128 rows x N_half cols)
@@ -701,15 +701,15 @@ def test_gemm_tcgen05_cta_group_2_layout_b():
         C_view = C_reg.view(128, N_half, layout=TileLayout(S[(128, N_half) : (1 @ axis_tid_in_wg, 1)]))  # noqa: E501
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem_phys[0:128, 0:N_half])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         n_off = (tid_in_wg // 64) * N_half
         Tx.copy(C[cbx * M_per_cta + tid_in_wg % 64, n_off : n_off + N_half], C_reg[:])
         T.cuda.cta_sync()
 
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__2.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__2.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
         # fmt: on
 
     np.random.seed(0)
@@ -776,12 +776,12 @@ def test_gemm_tcgen05_cta_group_2_datapath_b_readback():
         mma_mbar = T.alloc_shared([1], "uint64")
 
         if tid == 0:
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(n_per_cta)
             )
-        T.ptxd.fence.mbarrier_init.release.cluster()
+        T.ptx.fence.mbarrier_init.release.cluster()
         T.cuda.cta_sync()
 
         tmem = T.decl_buffer(
@@ -803,11 +803,11 @@ def test_gemm_tcgen05_cta_group_2_datapath_b_readback():
                 cbx * n_per_cta + (tid + i * 128) // k, (tid + i * 128) % k
             ])
         T.cuda.cta_sync()
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cluster_sync()
 
         if cbx == 0:
-            T.ptxd.tcgen05.fence__after_thread_sync()
+            T.ptx.tcgen05.fence__after_thread_sync()
             T.cuda.cta_sync()
             if tid == 0:
                 Tx.gemm_async(
@@ -817,13 +817,13 @@ def test_gemm_tcgen05_cta_group_2_datapath_b_readback():
                     dispatch="tcgen05",
                     cta_group=2,
                 )
-                T.ptxd[
+                T.ptx[
                     "tcgen05.commit.cta_group::2.mbarrier::arrive::one"
                     ".shared::cluster.multicast::cluster.b64"
                 ](mma_mbar.ptr_to([0]), T.uint16(3))
 
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         T.cuda.cta_sync()
 
         frag = T.alloc_tcgen05_ldst_frag(
@@ -831,7 +831,7 @@ def test_gemm_tcgen05_cta_group_2_datapath_b_readback():
         )
         if wg_id == 0:
             Tx.wg.copy_async(frag[:, :], tmem[:, :])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
 
         frag_local = frag.local()
@@ -843,8 +843,8 @@ def test_gemm_tcgen05_cta_group_2_datapath_b_readback():
         T.cuda.cta_sync()
 
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__2.sync.aligned.b32(tmem_addr[0], T.uint32(n_per_cta))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__2.sync.aligned.b32(tmem_addr[0], T.uint32(n_per_cta))
         # fmt: on
 
     target = tvm.target.Target("cuda")
@@ -969,13 +969,13 @@ def test_gemm_block_scaled_fp8_cta_group_1(task):
         descSFB = T.alloc_buffer((1,), "uint64", scope="local")
 
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
-        T.ptxd.fence.proxy.async_.shared__cta()
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
 
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(cols_alloc)
             )
         T.cuda.cta_sync()
@@ -989,12 +989,12 @@ def test_gemm_block_scaled_fp8_cta_group_1(task):
             tma_args = T.meta_var({"dispatch": "tma_auto", "mbar": tma_mbar.ptr_to([0])})
             Tx.copy_async(A_smem[tuple(r_gmem_A)], A[tuple(r_gmem_A)], **tma_args)
             Tx.copy_async(B_smem[tuple(r_gmem_B)], B[tuple(r_gmem_B)], **tma_args)
-            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
+            T.ptx.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
         T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
         SFA_smem[tid_in_wg // 32, tid_in_wg % 32] = SFA_in[tid_in_wg]
         SFB_smem[tid_in_wg // 32, tid_in_wg % 32] = SFB_in[tid_in_wg]
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
 
                 # Transpose scale factors in shared memory
@@ -1006,28 +1006,28 @@ def test_gemm_block_scaled_fp8_cta_group_1(task):
                 # Copy SFA/SFB from shared to TMEM via tcgen05.cp, then issue MMA
         if tid_in_wg == 0:
             T.cuda.tcgen05.encode_matrix_descriptor(descSFA.data, SFA_smem.access_ptr("r", offset=0), ldo=16, sdo=8 * 4 * F32_BYTES // F128_BYTES, swizzle=0)  # noqa: E501
-            T.ptxd["tcgen05.cp.cta_group::1.32x128b.warpx4"](T.uint32(SFA_TMEM_START), descSFA[0])
+            T.ptx["tcgen05.cp.cta_group::1.32x128b.warpx4"](T.uint32(SFA_TMEM_START), descSFA[0])
             T.cuda.tcgen05.encode_matrix_descriptor(descSFB.data, SFB_smem.access_ptr("r", offset=0), ldo=16, sdo=8 * 4 * F32_BYTES // F128_BYTES, swizzle=0)  # noqa: E501
-            T.ptxd["tcgen05.cp.cta_group::1.32x128b.warpx4"](T.uint32(SFB_TMEM_START), descSFB[0])
+            T.ptx["tcgen05.cp.cta_group::1.32x128b.warpx4"](T.uint32(SFB_TMEM_START), descSFB[0])
 
             Tx.gemm_async(tmem[tuple(r_tmem_C)], A_smem[tuple(r_smem_A)], B_smem[tuple(r_smem_B)], SFA=sfa_tmem[0:M, 0:sf_mma_k], SFB=sfb_tmem[0:N, 0:sf_mma_k], dispatch="tcgen05")  # noqa: E501
-            T.ptxd.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
+            T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
 
                 # Copy result from tmem to global
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         C_reg = T.alloc_local(width, dtype=C_dtype)
         C_view = C_reg.view(128, width, layout=TileLayout(S[(128, width) : (1@axis_tid_in_wg, 1)]))
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem[tuple(r_tmem_C)])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[tid_in_wg, C_region[1][0]:C_region[1][1]], C_reg[:])
 
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
         # fmt: on
 
     np.random.seed(0)
@@ -1174,11 +1174,11 @@ def test_gemm_block_scaled_fp8_cta_group_2(task):
         tma_mbar_cta_0 = T.decl_buffer([1], "uint64", data=ptr, scope="shared")
 
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
 
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(cols_alloc)
             )
         tmem = T.decl_buffer((128, C_shape[1]), C_dtype, scope="tmem", allocated_addr=tmem_addr[0], layout=TileLayout(S[(128, C_shape[1]) : (1 @ TLane, 1 @ TCol)]))  # noqa: E501
@@ -1186,8 +1186,8 @@ def test_gemm_block_scaled_fp8_cta_group_2(task):
         sfa_tmem = T.decl_buffer((128, sf_mma_k), SF_dtype, scope="tmem", allocated_addr=SFA_TMEM_START, layout=sf_layout)  # noqa: E501
         sfb_tmem = T.decl_buffer((128, sf_mma_k), SF_dtype, scope="tmem", allocated_addr=SFB_TMEM_START, layout=sf_layout)  # noqa: E501
 
-        T.ptxd.fence.mbarrier_init.release.cluster()
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.mbarrier_init.release.cluster()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         T.cuda.cluster_sync()
 
@@ -1197,12 +1197,12 @@ def test_gemm_block_scaled_fp8_cta_group_2(task):
             Tx.copy_async(A_smem[tuple(r_smem_A_in)], A[tuple(get_global_region(A_shape_per_cta, transA, cbx))], **tma_args)  # noqa: E501
             Tx.copy_async(B_smem[tuple(r_smem_B_in)], B[tuple(get_global_region(B_shape_per_cta, transB, cbx))], **tma_args)  # noqa: E501
             if cbx == 0:
-                T.ptxd.mbarrier.arrive.expect_tx.shared.b64(
+                T.ptx.mbarrier.arrive.expect_tx.shared.b64(
                     tma_mbar.ptr_to([0]), T.uint32(total_bytes)
                 )
         SFA_smem[tid_in_wg // 32, tid_in_wg % 32] = SFA_in[cbx * 128 + tid_in_wg]
         SFB_smem[tid_in_wg // 32, tid_in_wg % 32] = SFB_in[tid_in_wg]
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
 
                 # Transpose scale factors (both CTAs)
@@ -1214,24 +1214,24 @@ def test_gemm_block_scaled_fp8_cta_group_2(task):
                 # Copy SFA/SFB from shared to TMEM via tcgen05.cp (both CTAs, cta_group=2)
         if tid_in_wg == 0:
             T.cuda.tcgen05.encode_matrix_descriptor(descSFA.data, SFA_smem.access_ptr("r", offset=0), ldo=16, sdo=8 * 4 * F32_BYTES // F128_BYTES, swizzle=0)  # noqa: E501
-            T.ptxd["tcgen05.cp.cta_group::2.32x128b.warpx4"](T.uint32(SFA_TMEM_START), descSFA[0])
+            T.ptx["tcgen05.cp.cta_group::2.32x128b.warpx4"](T.uint32(SFA_TMEM_START), descSFA[0])
             T.cuda.tcgen05.encode_matrix_descriptor(descSFB.data, SFB_smem.access_ptr("r", offset=0), ldo=16, sdo=8 * 4 * F32_BYTES // F128_BYTES, swizzle=0)  # noqa: E501
-            T.ptxd["tcgen05.cp.cta_group::2.32x128b.warpx4"](T.uint32(SFB_TMEM_START), descSFB[0])
+            T.ptx["tcgen05.cp.cta_group::2.32x128b.warpx4"](T.uint32(SFB_TMEM_START), descSFB[0])
         T.cuda.cta_sync()
         T.cuda.cluster_sync()
 
         if cbx == 0:
             T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
-            T.ptxd.tcgen05.fence__after_thread_sync()
+            T.ptx.tcgen05.fence__after_thread_sync()
             T.cuda.cta_sync()
             if tid_in_wg == 0:
                 Tx.gemm_async(tmem[tuple(r_tmem_C)], A_smem[tuple(r_smem_A)], B_smem[tuple(r_smem_B)], SFA=sfa_tmem[0:128, 0:sf_mma_k], SFB=sfb_tmem[0:128, 0:sf_mma_k], dispatch="tcgen05", cta_group=2)  # noqa: E501
-                T.ptxd[
+                T.ptx[
                     "tcgen05.commit.cta_group::2.mbarrier::arrive::one"
                     ".shared::cluster.multicast::cluster.b64"
                 ](mma_mbar.ptr_to([0]), T.uint16(3))
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         T.cuda.cta_sync()
 
                 # Copy result from tmem to global
@@ -1239,14 +1239,14 @@ def test_gemm_block_scaled_fp8_cta_group_2(task):
         C_view = C_reg.view(128, width, layout=TileLayout(S[(128, width) : (1@axis_tid_in_wg, 1)]))
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem[C_region[0][0]:C_region[0][1], C_region[1][0]:C_region[1][0] + width])  # noqa: E501
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[cbx * 128 + tid_in_wg, C_region[1][0]:C_region[1][0] + width], C_reg[:])
         T.cuda.cta_sync()
 
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__2.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__2.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
         # fmt: on
 
     np.random.seed(0)
@@ -1376,13 +1376,13 @@ def test_gemm_block_scaled_nvfp4_cta_group_1():
         descSFB = T.alloc_buffer((1,), "uint64", scope="local")
 
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
-        T.ptxd.fence.proxy.async_.shared__cta()
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
 
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(cols_alloc)
             )
         T.cuda.cta_sync()
@@ -1396,12 +1396,12 @@ def test_gemm_block_scaled_nvfp4_cta_group_1():
             tma_args = T.meta_var({"dispatch": "tma_auto", "mbar": tma_mbar.ptr_to([0])})
             Tx.copy_async(A_smem_packed[:, :], A_packed[:, :], **tma_args)
             Tx.copy_async(B_smem_packed[:, :], B_packed[:, :], **tma_args)
-            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
+            T.ptx.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
         T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
         SFA_smem[tid_in_wg // 32, tid_in_wg % 32] = SFA_in[tid_in_wg]
         SFB_smem[tid_in_wg // 32, tid_in_wg % 32] = SFB_in[tid_in_wg]
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
 
                 # Transpose scale factors in shared memory
@@ -1413,28 +1413,28 @@ def test_gemm_block_scaled_nvfp4_cta_group_1():
                 # Copy SFA/SFB from shared to TMEM via tcgen05.cp, then issue MMA
         if tid_in_wg == 0:
             T.cuda.tcgen05.encode_matrix_descriptor(descSFA.data, SFA_smem.access_ptr("r", offset=0), ldo=16, sdo=8 * 4 * F32_BYTES // F128_BYTES, swizzle=0)  # noqa: E501
-            T.ptxd["tcgen05.cp.cta_group::1.32x128b.warpx4"](T.uint32(SFA_TMEM_START), descSFA[0])
+            T.ptx["tcgen05.cp.cta_group::1.32x128b.warpx4"](T.uint32(SFA_TMEM_START), descSFA[0])
             T.cuda.tcgen05.encode_matrix_descriptor(descSFB.data, SFB_smem.access_ptr("r", offset=0), ldo=16, sdo=8 * 4 * F32_BYTES // F128_BYTES, swizzle=0)  # noqa: E501
-            T.ptxd["tcgen05.cp.cta_group::1.32x128b.warpx4"](T.uint32(SFB_TMEM_START), descSFB[0])
+            T.ptx["tcgen05.cp.cta_group::1.32x128b.warpx4"](T.uint32(SFB_TMEM_START), descSFB[0])
 
             Tx.gemm_async(tmem[0:128, 0:N], A_smem[:, :], B_smem[:, :], SFA=sfa_tmem[0:M, 0:sf_mma_k], SFB=sfb_tmem[0:N, 0:sf_mma_k], dispatch="tcgen05")  # noqa: E501
-            T.ptxd.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
+            T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
 
                 # Copy result from tmem to global
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         C_reg = T.alloc_local(width, dtype=C_dtype)
         C_view = C_reg.view(128, width, layout=TileLayout(S[(128, width) : (1@axis_tid_in_wg, 1)]))
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem[0:128, 0:N])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[tid_in_wg, 0:N], C_reg[:])
 
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
         # fmt: on
 
     np.random.seed(0)
@@ -1565,11 +1565,11 @@ def test_gemm_block_scaled_nvfp4_cta_group_2():
         tma_mbar_cta_0 = T.decl_buffer([1], "uint64", data=ptr, scope="shared")
 
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
 
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(cols_alloc)
             )
         tmem = T.decl_buffer((128, C_shape[1]), C_dtype, scope="tmem", allocated_addr=tmem_addr[0], layout=TileLayout(S[(128, C_shape[1]) : (1 @ TLane, 1 @ TCol)]))  # noqa: E501
@@ -1577,8 +1577,8 @@ def test_gemm_block_scaled_nvfp4_cta_group_2():
         sfa_tmem = T.decl_buffer((M_per_cta, sf_mma_k), SF_dtype, scope="tmem", allocated_addr=SFA_TMEM_START, layout=sfa_layout)  # noqa: E501
         sfb_tmem = T.decl_buffer((N_total, sf_mma_k), SF_dtype, scope="tmem", allocated_addr=SFB_TMEM_START, layout=sfb_layout)  # noqa: E501
 
-        T.ptxd.fence.mbarrier_init.release.cluster()
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.mbarrier_init.release.cluster()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         T.cuda.cluster_sync()
 
@@ -1588,12 +1588,12 @@ def test_gemm_block_scaled_nvfp4_cta_group_2():
             Tx.copy_async(A_smem_packed[:, :], A_packed[cbx * M_per_cta:(cbx + 1) * M_per_cta, :], **tma_args)  # noqa: E501
             Tx.copy_async(B_smem_packed[:, :], B_packed[cbx * N_per_cta:(cbx + 1) * N_per_cta, :], **tma_args)  # noqa: E501
             if cbx == 0:
-                T.ptxd.mbarrier.arrive.expect_tx.shared.b64(
+                T.ptx.mbarrier.arrive.expect_tx.shared.b64(
                     tma_mbar.ptr_to([0]), T.uint32(total_bytes)
                 )
         SFA_smem[tid_in_wg // 32, tid_in_wg % 32] = SFA_in[cbx * M_per_cta + tid_in_wg]
         SFB_smem[tid_in_wg // 32, tid_in_wg % 32] = SFB_in[tid_in_wg]
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
 
                 # Transpose scale factors
@@ -1605,24 +1605,24 @@ def test_gemm_block_scaled_nvfp4_cta_group_2():
                 # Copy SFA/SFB from shared to TMEM via tcgen05.cp
         if tid_in_wg == 0:
             T.cuda.tcgen05.encode_matrix_descriptor(descSFA.data, SFA_smem.access_ptr("r", offset=0), ldo=16, sdo=8 * 4 * F32_BYTES // F128_BYTES, swizzle=0)  # noqa: E501
-            T.ptxd["tcgen05.cp.cta_group::2.32x128b.warpx4"](T.uint32(SFA_TMEM_START), descSFA[0])
+            T.ptx["tcgen05.cp.cta_group::2.32x128b.warpx4"](T.uint32(SFA_TMEM_START), descSFA[0])
             T.cuda.tcgen05.encode_matrix_descriptor(descSFB.data, SFB_smem.access_ptr("r", offset=0), ldo=16, sdo=8 * 4 * F32_BYTES // F128_BYTES, swizzle=0)  # noqa: E501
-            T.ptxd["tcgen05.cp.cta_group::2.32x128b.warpx4"](T.uint32(SFB_TMEM_START), descSFB[0])
+            T.ptx["tcgen05.cp.cta_group::2.32x128b.warpx4"](T.uint32(SFB_TMEM_START), descSFB[0])
         T.cuda.cta_sync()
         T.cuda.cluster_sync()
 
         if cbx == 0:
             T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
-            T.ptxd.tcgen05.fence__after_thread_sync()
+            T.ptx.tcgen05.fence__after_thread_sync()
             T.cuda.cta_sync()
             if tid_in_wg == 0:
                 Tx.gemm_async(tmem[0:128, 0:N_total], A_smem[:, :], B_smem[:, :], SFA=sfa_tmem[0:128, 0:sf_mma_k], SFB=sfb_tmem[0:N_total, 0:sf_mma_k], dispatch="tcgen05", cta_group=2)  # noqa: E501
-                T.ptxd[
+                T.ptx[
                     "tcgen05.commit.cta_group::2.mbarrier::arrive::one"
                     ".shared::cluster.multicast::cluster.b64"
                 ](mma_mbar.ptr_to([0]), T.uint16(3))
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         T.cuda.cta_sync()
 
                 # Copy result from tmem to global
@@ -1630,14 +1630,14 @@ def test_gemm_block_scaled_nvfp4_cta_group_2():
         C_view = C_reg.view(128, width, layout=TileLayout(S[(128, width) : (1@axis_tid_in_wg, 1)]))
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem[0:128, 0:width])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[cbx * M_per_cta + tid_in_wg, 0:width], C_reg[:])
         T.cuda.cta_sync()
 
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__2.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__2.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
         # fmt: on
 
     np.random.seed(0)
@@ -1772,13 +1772,13 @@ def test_gemm_block_scaled_fp8_sf_id():
         descSFB = T.alloc_buffer((1,), "uint64", scope="local")
 
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
-        T.ptxd.fence.proxy.async_.shared__cta()
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
 
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(cols_alloc)
             )
         T.cuda.cta_sync()
@@ -1792,12 +1792,12 @@ def test_gemm_block_scaled_fp8_sf_id():
             tma_args = T.meta_var({"dispatch": "tma_auto", "mbar": tma_mbar.ptr_to([0])})
             Tx.copy_async(A_smem[0:M, 0:K], A[0:M, 0:K], **tma_args)
             Tx.copy_async(B_smem[0:N, 0:K], B[0:N, 0:K], **tma_args)
-            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
+            T.ptx.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
         T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
         SFA_smem[tid_in_wg // 32, tid_in_wg % 32] = SFA_in[tid_in_wg]
         SFB_smem[tid_in_wg // 32, tid_in_wg % 32] = SFB_in[tid_in_wg]
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
 
                 # Transpose scale factors in shared memory
@@ -1809,9 +1809,9 @@ def test_gemm_block_scaled_fp8_sf_id():
                 # Copy SF to TMEM, then single MMA call (schedule auto-derives sf_id per ki)
         if tid_in_wg == 0:
             T.cuda.tcgen05.encode_matrix_descriptor(descSFA.data, SFA_smem.access_ptr("r", offset=0), ldo=16, sdo=8 * 4 * F32_BYTES // F128_BYTES, swizzle=0)  # noqa: E501
-            T.ptxd["tcgen05.cp.cta_group::1.32x128b.warpx4"](T.uint32(SFA_TMEM_START), descSFA[0])
+            T.ptx["tcgen05.cp.cta_group::1.32x128b.warpx4"](T.uint32(SFA_TMEM_START), descSFA[0])
             T.cuda.tcgen05.encode_matrix_descriptor(descSFB.data, SFB_smem.access_ptr("r", offset=0), ldo=16, sdo=8 * 4 * F32_BYTES // F128_BYTES, swizzle=0)  # noqa: E501
-            T.ptxd["tcgen05.cp.cta_group::1.32x128b.warpx4"](T.uint32(SFB_TMEM_START), descSFB[0])
+            T.ptx["tcgen05.cp.cta_group::1.32x128b.warpx4"](T.uint32(SFB_TMEM_START), descSFB[0])
 
                     # Single call with K=128: schedule auto-encodes descI and
                     # rotates sf_id=0,1,2,3 for each of the 4 ki iterations.
@@ -1819,23 +1819,23 @@ def test_gemm_block_scaled_fp8_sf_id():
                     # so the schedule knows sf_id should rotate.
             Tx.gemm_async(tmem[0:128, 0:N], A_smem[0:M, 0:K], B_smem[0:N, 0:K], SFA=sfa_tmem[0:M, 0:sf_mma_k * num_ki], SFB=sfb_tmem[0:N, 0:sf_mma_k * num_ki], dispatch="tcgen05")  # noqa: E501
 
-            T.ptxd.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
+            T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
 
                 # Copy result from tmem to global
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         C_reg = T.alloc_local(N, dtype=C_dtype)
         C_view = C_reg.view(128, N, layout=TileLayout(S[(128, N) : (1@axis_tid_in_wg, 1)]))
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem[0:128, 0:N])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[tid_in_wg, 0:N], C_reg[:])
 
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
         # fmt: on
 
     def per_block_quantize_fp8(mat, block_size=32):
@@ -2117,13 +2117,13 @@ def test_gemm_tcgen05_arbitrary_tiles(task):
         mma_mbar = T.alloc_shared([1], "uint64")
 
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
-        T.ptxd.fence.proxy.async_.shared__cta()
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
 
         if warp_id == 0:
-            T.ptxd[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
+            T.ptx[f"tcgen05.alloc.cta_group::{cta_group}.sync.aligned.shared::cta.b32"](
                 T.address_of(tmem_addr), T.uint32(cols_alloc)
             )
         T.cuda.cta_sync()
@@ -2133,28 +2133,28 @@ def test_gemm_tcgen05_arbitrary_tiles(task):
             tma_args = T.meta_var({"dispatch": "tma_auto", "mbar": tma_mbar.ptr_to([0])})
             Tx.copy_async(A_smem[tuple(r_gmem_A)], A[tuple(r_gmem_A)], **tma_args)
             Tx.copy_async(B_smem[tuple(r_gmem_B)], B[tuple(r_gmem_B)], **tma_args)
-            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
+            T.ptx.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
         T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
 
         if tid_in_wg == 0:
             Tx.gemm_async(tmem[tuple(r_tmem_C)], A_smem[tuple(r_smem_A)], B_smem[tuple(r_smem_B)], transA=transA, transB=transB, dispatch="tcgen05", cta_group=cta_group)  # noqa: E501
-            T.ptxd[f"tcgen05.commit.cta_group::{cta_group}.mbarrier::arrive::one.shared::cluster.b64"](mma_mbar.ptr_to([0]))
+            T.ptx[f"tcgen05.commit.cta_group::{cta_group}.mbarrier::arrive::one.shared::cluster.b64"](mma_mbar.ptr_to([0]))
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
 
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         C_reg = T.alloc_local(N, dtype=C_dtype)
         C_view = C_reg.view(M, N, layout=TileLayout(S[(M, N) : (1@axis_tid_in_wg, 1)]))
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem[tuple(r_tmem_C)])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[tid_in_wg, C_region[1][0]:C_region[1][1]], C_reg[:])
 
         if warp_id == 0:
-            T.ptxd[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
-            T.ptxd[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
+            T.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
+            T.ptx[f"tcgen05.dealloc.cta_group::{cta_group}.sync.aligned.b32"](
                 tmem_addr[0], T.uint32(cols_alloc)
             )
         # fmt: on
@@ -2225,7 +2225,7 @@ def test_gemm_tcgen05_no_swizzle_smem_descriptor_codegen(a_layout_kind):
         B_smem = T.alloc_buffer((K, B_N), dtype, scope="shared", layout=B_layout)
         tmem_addr = T.alloc_shared([1], "uint32")
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr[0]), T.uint32(256)
             )
         T.cuda.cta_sync()
@@ -2284,7 +2284,7 @@ def test_gemm_tcgen05_cta_group_2_accepts_replicated_tmem_a_codegen():
         B_smem = T.alloc_buffer((N_half, K), dtype, scope="shared", layout=B_layout)
         tmem_addr = T.alloc_shared([1], "uint32")
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr[0]), T.uint32(128)
             )
         T.cuda.cta_sync()
@@ -2346,7 +2346,7 @@ def test_gemm_tcgen05_cta_group_2_rejects_flat_tmem_a_codegen():
         B_smem = T.alloc_buffer((N_half, K), dtype, scope="shared", layout=B_layout)
         tmem_addr = T.alloc_shared([1], "uint32")
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr[0]), T.uint32(128)
             )
         T.cuda.cta_sync()
@@ -2425,10 +2425,10 @@ def test_gemm_tcgen05_no_swizzle_col_major_a_ws_local_idesc():
         tmem_addr = T.alloc_shared([1], "uint32")
         mma_mbar = T.alloc_shared([1], "uint64")
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
         T.cuda.cta_sync()
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(128)
             )
         T.cuda.cta_sync()
@@ -2448,24 +2448,24 @@ def test_gemm_tcgen05_no_swizzle_col_major_a_ws_local_idesc():
         for i in range(K * N // 128):
             b_idx = i * 128 + tid_in_wg
             B_smem[b_idx // N, b_idx % N] = B[b_idx // N, b_idx % N]
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         if tid_in_wg == 0:
             Tx.gemm_async(tmem[:, :], A_smem[:, :], B_smem[:, :], transB=True, dispatch="tcgen05", cta_group=1, weight_stationary=True)  # noqa: E501
-            T.ptxd.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
+            T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         C_reg = T.alloc_local(N // 2, dtype="float32")
         C_view = C_reg.view(128, N // 2, layout=TileLayout(S[(128, N // 2) : (1@axis_tid_in_wg, 1)]))  # noqa: E501
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem_ldst[:, :])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[tid_in_wg, 0 : N // 2], C_reg[:])
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(128))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(128))
     # fmt: on
 
     with tvm.target.Target("cuda"):
@@ -2532,12 +2532,12 @@ def test_gemm_tcgen05_contiguous_kslice_partial_k(k_lo, k_hi):
         tma_mbar = T.alloc_shared([1], "uint64")
         mma_mbar = T.alloc_shared([1], "uint64")
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
-        T.ptxd.fence.proxy.async_.shared__cta()
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(128)
             )
         T.cuda.cta_sync()
@@ -2546,26 +2546,26 @@ def test_gemm_tcgen05_contiguous_kslice_partial_k(k_lo, k_hi):
             tma_args = T.meta_var({"dispatch": "tma_auto", "mbar": tma_mbar.ptr_to([0])})
             Tx.copy_async(A_smem[0:M, 0:K_alloc], A[0:M, 0:K_alloc], **tma_args)
             Tx.copy_async(B_smem[0:N, 0:K_alloc], B[0:N, 0:K_alloc], **tma_args)
-            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
+            T.ptx.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
         T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
         if tid_in_wg == 0:
             # Contiguous-axis K slice [k_lo:k_hi] -> must accumulate only that K range.
             Tx.gemm_async(tmem[0:128, 0:N], A_smem[0:M, k_lo:k_hi], B_smem[0:N, k_lo:k_hi], dispatch="tcgen05")  # noqa: E501
-            T.ptxd.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
+            T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         C_reg = T.alloc_local(N, dtype="float32")
         C_view = C_reg.view(128, N, layout=TileLayout(S[(128, N) : (1@axis_tid_in_wg, 1)]))
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem[0:128, 0:N])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[tid_in_wg, 0:N], C_reg[:])
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(128))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(128))
     # fmt: on
 
     np.random.seed(0)
@@ -2624,12 +2624,12 @@ def _run_dense_gemm(
         tma_mbar = T.alloc_shared([1], "uint64")
         mma_mbar = T.alloc_shared([1], "uint64")
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
-        T.ptxd.fence.proxy.async_.shared__cta()
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(cols_alloc)
             )
         T.cuda.cta_sync()
@@ -2643,27 +2643,27 @@ def _run_dense_gemm(
         if tid_in_wg == 0:
             Tx.copy_async(A_smem[:, :], A[:, :], dispatch="tma_auto", mbar=tma_mbar.ptr_to([0]))
             Tx.copy_async(B_smem[:, :], B[:, :], mbar=tma_mbar.ptr_to([0]), **b_tma_kw)
-            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
+            T.ptx.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
         T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
         if tid_in_wg == 0:
             Tx.gemm_async(tmem[:, :], A_smem[:, :], B_smem[:, :], **gemm_kw)
-            T.ptxd.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
+            T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
                 mma_mbar.ptr_to([0])
             )
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         C_reg = T.alloc_local(N, dtype=C_dtype)
         C_view = C_reg.view(128, N, layout=TileLayout(S[(128, N) : (1 @ axis_tid_in_wg, 1)]))
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem[:, :])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[tid_in_wg, 0:N], C_reg[:])
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
 
     np.random.seed(0)
     target = tvm.target.Target("cuda")
@@ -2748,12 +2748,12 @@ def _run_dense_gemm(
         tma_mbar = T.alloc_shared([1], "uint64")
         mma_mbar = T.alloc_shared([1], "uint64")
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
-        T.ptxd.fence.proxy.async_.shared__cta()
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(cols_alloc)
             )
         T.cuda.cta_sync()
@@ -2767,27 +2767,27 @@ def _run_dense_gemm(
         if tid_in_wg == 0:
             Tx.copy_async(A_smem[:, :], A[:, :], dispatch="tma_auto", mbar=tma_mbar.ptr_to([0]))
             Tx.copy_async(B_smem[:, :], B[:, :], mbar=tma_mbar.ptr_to([0]), **b_tma_kw)
-            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
+            T.ptx.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
         T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
         if tid_in_wg == 0:
             Tx.gemm_async(tmem[:, :], A_smem[:, :], B_smem[:, :], **gemm_kw)
-            T.ptxd.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
+            T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
                 mma_mbar.ptr_to([0])
             )
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         C_reg = T.alloc_local(N, dtype=C_dtype)
         C_view = C_reg.view(128, N, layout=TileLayout(S[(128, N) : (1 @ axis_tid_in_wg, 1)]))
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem[:, :])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[tid_in_wg, 0:N], C_reg[:])
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(cols_alloc))
 
     dev = tvm.cuda(0)
     np.random.seed(0)
@@ -2844,12 +2844,12 @@ def _build_smem_desc_kernel(smem_desc, weight_stationary=False, pass_descI=False
         tma_mbar = T.alloc_shared([1], "uint64")
         mma_mbar = T.alloc_shared([1], "uint64")
         if tid_in_wg == 0:
-            T.ptxd.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
-            T.ptxd.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
-        T.ptxd.fence.proxy.async_.shared__cta()
+            T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1))
+            T.ptx.mbarrier.init.shared.b64(mma_mbar.ptr_to([0]), T.uint32(1))
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.cta_sync()
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr), T.uint32(128)
             )
         T.cuda.cta_sync()
@@ -2858,7 +2858,7 @@ def _build_smem_desc_kernel(smem_desc, weight_stationary=False, pass_descI=False
             tma_args = T.meta_var({"dispatch": "tma_auto", "mbar": tma_mbar.ptr_to([0])})
             Tx.copy_async(A_smem[tuple(r_gmem_A)], A[tuple(r_gmem_A)], **tma_args)
             Tx.copy_async(B_smem[tuple(r_gmem_B)], B[tuple(r_gmem_B)], **tma_args)
-            T.ptxd.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
+            T.ptx.mbarrier.arrive.expect_tx.shared.b64(tma_mbar.ptr_to([0]), T.uint32(total_bytes))
         T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
         if tid_in_wg == 0:
@@ -2879,20 +2879,20 @@ def _build_smem_desc_kernel(smem_desc, weight_stationary=False, pass_descI=False
                 Tx.gemm_async(tmem[tuple(r_tmem_C)], A_smem[tuple(r_smem_A)], B_smem[tuple(r_smem_B)], dispatch="tcgen05", smem_desc=smem_desc, weight_stationary=weight_stationary, descI=desc_i, **mma_cfg)  # noqa: E501, F821
             else:
                 Tx.gemm_async(tmem[tuple(r_tmem_C)], A_smem[tuple(r_smem_A)], B_smem[tuple(r_smem_B)], dispatch="tcgen05", smem_desc=smem_desc, weight_stationary=weight_stationary, **mma_cfg)  # noqa: E501
-            T.ptxd.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
+            T.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(mma_mbar.ptr_to([0]))
         T.cuda.mbarrier_wait(mma_mbar.ptr_to([0]), 0)
         T.cuda.cta_sync()
-        T.ptxd.tcgen05.fence__after_thread_sync()
+        T.ptx.tcgen05.fence__after_thread_sync()
         C_reg = T.alloc_local(width, dtype=C_dtype)
         C_view = C_reg.view(128, width, layout=TileLayout(S[(128, width) : (1@axis_tid_in_wg, 1)]))
         if wg_id == 0:
             Tx.wg.copy_async(C_view[:, :], tmem[tuple(r_tmem_C)])
-            T.ptxd.tcgen05.wait__ld.sync.aligned()
+            T.ptx.tcgen05.wait__ld.sync.aligned()
         T.cuda.cta_sync()
         Tx.copy(C[tid_in_wg, C_region[1][0]:C_region[1][1]], C_reg[:])
         if warp_id == 0:
-            T.ptxd.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
-            T.ptxd.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(128))
+            T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(tmem_addr[0], T.uint32(128))
         # fmt: on
 
     return gemm_async
@@ -3168,7 +3168,7 @@ def _build_cta1_m64_packed_c_kernel(weight_stationary=None, mma_config=None):
         B_smem = T.alloc_buffer((N, K), B_dtype, scope="shared", layout=B_layout)
         tmem_addr = T.alloc_shared([1], "uint32")
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr[0]), T.uint32(512)
             )
         T.cuda.cta_sync()
@@ -3257,7 +3257,7 @@ def _build_cta1_m64_batched_c_kernel():
         B_smem = T.alloc_buffer((N, K), B_dtype, scope="shared", layout=B_layout)
         tmem_addr = T.alloc_shared([1], "uint32")
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr[0]), T.uint32(512)
             )
         T.cuda.cta_sync()
@@ -3311,7 +3311,7 @@ def _build_cta1_m64_identity_c_ws_kernel():
         B_smem = T.alloc_buffer((N, K), B_dtype, scope="shared", layout=B_layout)
         tmem_addr = T.alloc_shared([1], "uint32")
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr[0]), T.uint32(512)
             )
         T.cuda.cta_sync()
@@ -3379,7 +3379,7 @@ def _build_cta1_m64_flat_a_ws_kernel():
         B_smem = T.alloc_buffer((N, K), B_dtype, scope="shared", layout=B_layout)
         tmem_addr = T.alloc_shared([1], "uint32")
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr[0]), T.uint32(512)
             )
         T.cuda.cta_sync()
@@ -3447,7 +3447,7 @@ def _build_m128_batched_a_kernel():
         B_smem = T.alloc_buffer((N, K), B_dtype, scope="shared", layout=B_layout)
         tmem_addr = T.alloc_shared([1], "uint32")
         if warp_id == 0:
-            T.ptxd.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+            T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_addr[0]), T.uint32(512)
             )
         T.cuda.cta_sync()

--- a/tests/python/tirx/operator/tile_primitive/cuda/permute_layout/test_permute_layout.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/permute_layout/test_permute_layout.py
@@ -436,7 +436,7 @@ def test_shared_to_shared_uses_direct_ldst(dtype):
     ``buf[...]`` lowers the swizzled layout to a per-element IMAD flatten. The
     direct path computes one base ptr (``ptr_to(stride_offset)``) and adds a
     compile-time ``off * dtype_bytes`` per register slot, then issues
-    ``T.ptxd.ld/st(..., space="shared")``. The bits move through a uint
+    ``T.ptx.ld/st(..., space="shared")``. The bits move through a uint
     container, so ``float32`` (whose ``ld.b32`` cannot return a float) lowers
     the same way as the ``uint32`` SF case.
     """

--- a/tests/python/tirx/test_op_namespace_cleanup.py
+++ b/tests/python/tirx/test_op_namespace_cleanup.py
@@ -336,7 +336,7 @@ def test_registered_tirx_ops_have_exactly_one_category():
     categories = {"builtin", "tile_primitive", "device_intrin"}
     device_namespaces = {
         "cuda",
-        "ptxd",
+        "ptx",
         # `ptx_legacy` holds the Apache-compatible spellings, `s_tir` the
         # nodes that pipeline's own passes build; neither is a dialect surface.
         "ptx_legacy",

--- a/tests/python/tirx/test_parser_printer.py
+++ b/tests/python/tirx/test_parser_printer.py
@@ -2417,7 +2417,7 @@ def test_roundtrip_cp_async_bulk_tensor_g2s_cluster():
         with T.launch_thread("blockIdx.x", 1):
             T.launch_thread("threadIdx.x", 128)
             A_smem = T.alloc_buffer((16, 16), "float32", scope="shared")
-            T.ptxd["cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes"](
+            T.ptx["cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes"](
                 A_smem.data, T.address_of(A_map), 0, 0, T.uint32(0)
             )
     # fmt: on
@@ -2438,7 +2438,7 @@ def test_roundtrip_cp_async_bulk_tensor_s2g():
         with T.launch_thread("blockIdx.x", 1):
             T.launch_thread("threadIdx.x", 128)
             A_smem = T.alloc_buffer((16, 16), "float32", scope="shared")
-            T.ptxd["cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group"](
+            T.ptx["cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group"](
                 T.address_of(A_map), 0, 0, A_smem.data
             )
     # fmt: on
@@ -2458,7 +2458,7 @@ def test_roundtrip_cp_async_bulk_tensor_prefetch():
         A_map: T.let[T.handle("tensormap")] = T.tvm_stack_alloca("tensormap", 1)
         with T.launch_thread("blockIdx.x", 1):
             T.launch_thread("threadIdx.x", 128)
-            T.ptxd["cp.async.bulk.prefetch.tensor.2d.L2.global.tile"](
+            T.ptx["cp.async.bulk.prefetch.tensor.2d.L2.global.tile"](
                 T.address_of(A_map), 0, 0
             )
     # fmt: on
@@ -2479,7 +2479,7 @@ def test_roundtrip_cp_async_bulk_tensor_s2g_reduce():
         with T.launch_thread("blockIdx.x", 1):
             T.launch_thread("threadIdx.x", 128)
             A_smem = T.alloc_buffer((16, 16), "float32", scope="shared")
-            T.ptxd["cp.reduce.async.bulk.tensor.2d.global.shared::cta.add.tile.bulk_group"](
+            T.ptx["cp.reduce.async.bulk.tensor.2d.global.shared::cta.add.tile.bulk_group"](
                 T.address_of(A_map), 0, 0, A_smem.data
             )
     # fmt: on

--- a/tests/python/tirx/test_roundtrip_namespaces.py
+++ b/tests/python/tirx/test_roundtrip_namespaces.py
@@ -29,10 +29,10 @@ def test_roundtrip_tir_namespaces_minimal():
     @T.prim_func
     def func(a_ptr: T.handle) -> None:
         A = T.match_buffer(a_ptr, (2, 2), "float16")
-        T.ptxd.wgmma.commit_group.sync.aligned()
+        T.ptx.wgmma.commit_group.sync.aligned()
         T.cuda.cluster_sync()
-        T.ptxd.cp.async_.wait_group(0)
-        T.ptxd.fence.proxy.async_.shared__cta()
+        T.ptx.cp.async_.wait_group(0)
+        T.ptx.fence.proxy.async_.shared__cta()
         T.cuda.printf("ok")
         T.nvshmem.quiet()
         T.nki.identity(A[0, 0], 1)

--- a/tests/python/tirx/test_verifier.py
+++ b/tests/python/tirx/test_verifier.py
@@ -212,10 +212,10 @@ def test_host():
 
                 phase[0] = 0
                 if threadIdx == 0:
-                    T.ptxd.mbarrier.init.shared.b64(bar.data, T.uint32(1))
-                    T.ptxd.fence.proxy.async_.shared__cta()
-                    T.ptxd["cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes"](A_smem.data, T.address_of(A_map), 0, 0, bar.data)  # noqa: E501
-                    T.ptxd.mbarrier.arrive.expect_tx.shared.b64(bar.data, T.uint32(16*16*4))
+                    T.ptx.mbarrier.init.shared.b64(bar.data, T.uint32(1))
+                    T.ptx.fence.proxy.async_.shared__cta()
+                    T.ptx["cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes"](A_smem.data, T.address_of(A_map), 0, 0, bar.data)  # noqa: E501
+                    T.ptx.mbarrier.arrive.expect_tx.shared.b64(bar.data, T.uint32(16*16*4))
                 T.cuda.mbarrier_wait(bar.data, phase[0])
                 phase[0] = phase[0] ^ 1
                 T.print_buffer(A_smem.data, "float32", False, False, 2, 16*16)


### PR DESCRIPTION
## What

The table-driven PTX dialect takes over the `ptx` namespace it was always meant to have. `T.ptxd` becomes `T.ptx`, ops move from `tirx.ptxd.*` to `tirx.ptx.*` (174 of them), and the generated CUDA helper prefix `tvm_builtin_ptxd_` becomes `tvm_builtin_ptx_`.

## Why

`ptxd` was a quarantine name: when the dialect landed (#47) the name it wanted was still taken by the hand-written surface it was replacing. That surface is gone and `tirx.ptx.*` has been empty since, so the last step of the migration is to move in. No alias layer — the same clean break the legacy surface got when it was retired.

## Commits

1. **`refactor(op)` rename the namespace.** One property generates all 174 op names, so the semantic core is small: `InstructionEntry.op_name`, the printer/namespace attrs and codegen key in `register_table`, the script-namespace dict key in `backend/cuda/__init__.py`, and the two `Op::Get` literals the CUDA codegen holds for cp.async group tracking. The rest is call sites, the regenerated `tirx.pyi` stub, and the identifiers that carried the old name (`PTXDNamespace` → `PTXNamespace`, `_PTXD` → `_PTX`, `copy_ptxd_form` and friends, `test_ptxd_dialect.py` → `test_ptx_dialect.py`).
2. **`refactor(op)` rename the generated helper prefix.** Verified collision-free against the four legacy `tvm_builtin_ptx_*` helpers that survive on `T.cuda.*` code paths: all 225428 generated helper names were enumerated and the intersection with them is empty (a dialect name always repeats the mnemonic — `barrier.cluster.arrive` renders as `..._barrier_cluster_arrive_cluster_arrive`).
3. **`docs(op)` fix stale examples.** Around thirty snippets still showed the retired surface's call forms — kwargs like `tcgen05.alloc(n_cols=512, cta_group=1)`, positional `mma(shape_str, "row", "col", ...)`, an `add_f32x2` family that does not exist — so a mechanical rename would have made wrong examples look freshly correct. Rewritten against the real table entries and dispatch call sites.
4. **`test(op-dispatch)` drop dead assertions.** The packed-f32x2 checks each accepted a `tvm_builtin_ptx_<op>_packed_*` spelling no emitter produces, and one test asserted the absence of an op name that was deleted with the legacy surface (and never reaches generated CUDA anyway).

## Breaking

- `T.ptxd` and `tirx.ptxd.*` are gone with no alias. Downstream call sites move with the rename (companion PR in `tirx-kernels`).
- The certification shards read `PTX_ARCH` / `PTX_CERT` instead of `PTXD_ARCH` / `PTXD_CERT`. No in-repo CI references them, but external runbooks will need updating.

## Verification

On 4x B200 (sm_100), CUDA 13.2, against a pre-change baseline of the same suites:

- `tests/python/tirx/codegen/`, `tests/python/tirx/operator/tile_primitive/cuda/`, the namespace/roundtrip/printer/verifier tests, `inject_ptx_async_copy`, and the `tirx-base` ptx tests: **2051 passed, 71 skipped, 3 xpassed, 0 failed** — identical to baseline.
- Full-table ptxas certification (`PTX_CERT=1 -k certify`): **32 passed**.
- `tirx.pyi` regenerated; the freshness test passes.
- `pre-commit` clean on every changed file.
- `git grep -i ptxd` over the tree returns only `PTXDataType` / `PTXDType{From,To}String` (unrelated) and one base64 coincidence in `KEYS`.

One golden needed its two `cp.async.wait_group` helper *definitions* swapped: the CUDA codegen holds them in an `unordered_map` keyed by helper name, so preamble order follows the string hash. The set of definitions is unchanged.