### PR TITLE
[TIRx][TVMScript] Support uint32 loop and scope-id var dtypes

### DIFF
--- a/include/tvm/tirx/script/builder/ir.h
+++ b/include/tvm/tirx/script/builder/ir.h
@@ -131,15 +131,37 @@ SBlockFrame Block(ffi::String name, bool no_realize = false, ffi::String exec_sc
 
 void TilePrimitiveCall(tvm::tirx::TilePrimitiveCall op_call);
 
-ffi::Array<tvm::tirx::Var> KernelId(ffi::Array<PrimExpr> extents, ffi::String parent);
+/*!
+ * \brief Define a scope id. Pass `extents=std::nullopt` to defer the extent; it is
+ *        inferred at LowerTIRx from the sibling ScopeIdDef closure.
+ * \param extents The optional extents of the scope id.
+ * \param parent The parent scope name.
+ * \param name The user-facing API name, used in error messages.
+ * \param cur The current scope name.
+ * \param dtype The dtype of the introduced scope id vars ("int32" or "uint32").
+ * \return The introduced scope id vars.
+ */
+ffi::Array<tvm::tirx::Var> ScopeId(ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent,
+                                   ffi::String name, ffi::String cur,
+                                   PrimType dtype = PrimType::Int(32));
 
-ffi::Array<tvm::tirx::Var> CtaId(ffi::Array<PrimExpr> extents, ffi::String parent);
+ffi::Array<tvm::tirx::Var> ClusterId(ffi::Optional<ffi::Array<PrimExpr>> extents,
+                                     ffi::String parent, PrimType dtype = PrimType::Int(32));
 
-ffi::Array<tvm::tirx::Var> CtaIdInPair();
+ffi::Array<tvm::tirx::Var> CtaId(ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent,
+                                 ffi::Optional<ffi::Array<PrimExpr>> preferred = std::nullopt,
+                                 PrimType dtype = PrimType::Int(32));
 
-ffi::Array<tvm::tirx::Var> WarpId(ffi::Array<PrimExpr> extents, ffi::String parent);
+ffi::Array<tvm::tirx::Var> CtaIdInPair(PrimType dtype = PrimType::Int(32));
 
-ffi::Array<tvm::tirx::Var> ThreadId(ffi::Array<PrimExpr> extents, ffi::String parent);
+ffi::Array<tvm::tirx::Var> WarpgroupId(ffi::Optional<ffi::Array<PrimExpr>> extents,
+                                       ffi::String parent, PrimType dtype = PrimType::Int(32));
+
+ffi::Array<tvm::tirx::Var> WarpId(ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent,
+                                  PrimType dtype = PrimType::Int(32));
+
+ffi::Array<tvm::tirx::Var> ThreadId(ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent,
+                                    PrimType dtype = PrimType::Int(32));
 
 /*!
  * \brief The block initialization statement.
@@ -249,44 +271,53 @@ ffi::Array<Var> Remap(ffi::String kinds, ffi::Array<PrimExpr> bindings,
  * \param stop The maximum value of iteration.
  * \param annotations The optional annotations of the For statement.
  * \param step The optional step value of iteration.
+ * \param dtype The optional dtype of the loop var ("int32" or "uint32"). When omitted
+ *              it is inferred from the bounds.
  * \return The ForFrame.
  */
 ForFrame Serial(PrimExpr start, PrimExpr stop,
                 ffi::Optional<ffi::Map<ffi::String, Any>> annotations = std::nullopt,
-                ffi::Optional<PrimExpr> step = std::nullopt);
+                ffi::Optional<PrimExpr> step = std::nullopt,
+                ffi::Optional<PrimType> dtype = std::nullopt);
 /*!
  * \brief The parallel For statement.
  * \param start The minimum value of iteration.
  * \param stop The maximum value of iteration.
  * \param annotations The optional annotations of the For statement.
  * \param step The optional step value of iteration.
+ * \param dtype The optional dtype of the loop var ("int32" or "uint32").
  * \return The ForFrame.
  */
 ForFrame Parallel(PrimExpr start, PrimExpr stop,
                   ffi::Optional<ffi::Map<ffi::String, Any>> annotations = std::nullopt,
-                  ffi::Optional<PrimExpr> step = std::nullopt);
+                  ffi::Optional<PrimExpr> step = std::nullopt,
+                  ffi::Optional<PrimType> dtype = std::nullopt);
 /*!
  * \brief The vectorized For statement.
  * \param start The minimum value of iteration.
  * \param stop The maximum value of iteration.
  * \param annotations The optional annotations of the For statement.
  * \param step The optional step value of iteration.
+ * \param dtype The optional dtype of the loop var ("int32" or "uint32").
  * \return The ForFrame.
  */
 ForFrame Vectorized(PrimExpr start, PrimExpr stop,
                     ffi::Optional<ffi::Map<ffi::String, Any>> annotations = std::nullopt,
-                    ffi::Optional<PrimExpr> step = std::nullopt);
+                    ffi::Optional<PrimExpr> step = std::nullopt,
+                    ffi::Optional<PrimType> dtype = std::nullopt);
 /*!
  * \brief The unrolled For statement.
  * \param start The minimum value of iteration.
  * \param stop The maximum value of iteration.
  * \param annotations The optional annotations of the For statement.
  * \param step The optional step value of iteration.
+ * \param dtype The optional dtype of the loop var ("int32" or "uint32").
  * \return The ForFrame.
  */
 ForFrame Unroll(PrimExpr start, PrimExpr stop,
                 ffi::Optional<ffi::Map<ffi::String, Any>> annotations = std::nullopt,
-                ffi::Optional<PrimExpr> step = std::nullopt);
+                ffi::Optional<PrimExpr> step = std::nullopt,
+                ffi::Optional<PrimType> dtype = std::nullopt);
 /*!
  * \brief The thread-binding For statement.
  * \param start The minimum value of iteration.
@@ -300,9 +331,12 @@ ForFrame ThreadBinding(PrimExpr start, PrimExpr stop, ffi::String thread,
 /*!
  * \brief The grid For statement.
  * \param extents The extents of the iteration.
+ * \param dtype The optional dtype of every loop var ("int32" or "uint32"). When omitted
+ *              each loop var takes the dtype of its own extent.
  * \return The ForFrame.
  */
-ForFrame Grid(ffi::Array<Variant<PrimExpr, ffi::Tuple<PrimExpr, PrimExpr>>> extents);
+ForFrame Grid(ffi::Array<Variant<PrimExpr, ffi::Tuple<PrimExpr, PrimExpr>>> extents,
+              ffi::Optional<PrimType> dtype = std::nullopt);
 
 /*!
  * \brief The assertion statement.

--- a/python/tvm/tirx/script/builder/ir.py
+++ b/python/tvm/tirx/script/builder/ir.py
@@ -609,94 +609,120 @@ def elected():
     )
 
 
-def scope_id(extents: list[Expr | int] | None, parent: str, cur: str) -> Var | list[Var]:
-    ret = _ffi_api.ScopeId(extents, parent, "T.scope_id", cur)  # type: ignore[attr-defined] # pylint: disable=no-member
+def scope_id(
+    extents: list[Expr | int] | None, parent: str, cur: str, dtype: str = "int32"
+) -> Var | list[Var]:
+    ret = _ffi_api.ScopeId(extents, parent, "T.scope_id", cur, dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
     if len(ret) == 1:
         return ret[0]
     return ret
 
 
-def cluster_id(extents: list[Expr | int] | None = None) -> Var | list[Var]:
+def cluster_id(extents: list[Expr | int] | None = None, dtype: str = "int32") -> Var | list[Var]:
     """Define a kernel→cluster scope id. Pass ``None`` (the default) to defer the
-    extent; it will be inferred at LowerTIRx from sibling ScopeIdDef closure."""
-    ret = _ffi_api.ClusterId(extents, "kernel")  # type: ignore[attr-defined] # pylint: disable=no-member
+    extent; it will be inferred at LowerTIRx from sibling ScopeIdDef closure.
+
+    ``dtype`` selects the dtype of the introduced vars (``"int32"`` or ``"uint32"``)."""
+    ret = _ffi_api.ClusterId(extents, "kernel", dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
     if len(ret) == 1:
         return ret[0]
     return ret
 
 
-def cta_id(extents: list[Expr | int] | None = None, preferred=None) -> Var | list[Var]:
+def cta_id(
+    extents: list[Expr | int] | None = None, preferred=None, dtype: str = "int32"
+) -> Var | list[Var]:
     """Define a kernel→cta scope id. Pass ``None`` (the default) to defer the
-    extent; it will be inferred at LowerTIRx from sibling ScopeIdDef closure."""
-    ret = _ffi_api.CtaId(extents, "kernel", preferred)  # type: ignore[attr-defined] # pylint: disable=no-member
+    extent; it will be inferred at LowerTIRx from sibling ScopeIdDef closure.
+
+    ``dtype`` selects the dtype of the introduced vars (``"int32"`` or ``"uint32"``)."""
+    ret = _ffi_api.CtaId(extents, "kernel", preferred, dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
     if len(ret) == 1:
         return ret[0]
     return ret
 
 
-def cta_id_in_cluster(extents: list[Expr | int] | None = None, preferred=None) -> Var | list[Var]:
+def cta_id_in_cluster(
+    extents: list[Expr | int] | None = None, preferred=None, dtype: str = "int32"
+) -> Var | list[Var]:
     """Define a cluster→cta scope id. Pass ``None`` (the default) to defer the
-    extent; it will be inferred at LowerTIRx from sibling ScopeIdDef closure."""
-    ret = _ffi_api.CtaId(extents, "cluster", preferred)  # type: ignore[attr-defined] # pylint: disable=no-member
+    extent; it will be inferred at LowerTIRx from sibling ScopeIdDef closure.
+
+    ``dtype`` selects the dtype of the introduced vars (``"int32"`` or ``"uint32"``)."""
+    ret = _ffi_api.CtaId(extents, "cluster", preferred, dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
     if len(ret) == 1:
         return ret[0]
     return ret
 
 
-def cta_id_in_pair() -> Var:
-    ret = _ffi_api.CtaIdInPair()  # type: ignore[attr-defined] # pylint: disable=no-member
+def cta_id_in_pair(dtype: str = "int32") -> Var:
+    ret = _ffi_api.CtaIdInPair(dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
     return ret[0]
 
 
-def warpgroup_id(extents: list[Expr | int] | None = None) -> Var | list[Var]:
+def warpgroup_id(extents: list[Expr | int] | None = None, dtype: str = "int32") -> Var | list[Var]:
     """Define a cta→warpgroup scope id. Pass ``None`` (the default) to defer
-    the extent; it will be inferred at LowerTIRx from sibling closure."""
-    ret = _ffi_api.WarpgroupId(extents, "cta")  # type: ignore[attr-defined] # pylint: disable=no-member
+    the extent; it will be inferred at LowerTIRx from sibling closure.
+
+    ``dtype`` selects the dtype of the introduced vars (``"int32"`` or ``"uint32"``)."""
+    ret = _ffi_api.WarpgroupId(extents, "cta", dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
     if len(ret) == 1:
         return ret[0]
     return ret
 
 
-def warp_id(extents: list[Expr | int] | None = None) -> Var | list[Var]:
+def warp_id(extents: list[Expr | int] | None = None, dtype: str = "int32") -> Var | list[Var]:
     """Define a cta→warp scope id. Pass ``None`` (the default) to defer the
-    extent; it will be inferred at LowerTIRx from sibling closure."""
-    ret = _ffi_api.WarpId(extents, "cta")  # type: ignore[attr-defined] # pylint: disable=no-member
+    extent; it will be inferred at LowerTIRx from sibling closure.
+
+    ``dtype`` selects the dtype of the introduced vars (``"int32"`` or ``"uint32"``)."""
+    ret = _ffi_api.WarpId(extents, "cta", dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
     if len(ret) == 1:
         return ret[0]
     return ret
 
 
-def warp_id_in_wg(extents: list[Expr | int] | None = None) -> Var | list[Var]:
+def warp_id_in_wg(extents: list[Expr | int] | None = None, dtype: str = "int32") -> Var | list[Var]:
     """Define a warpgroup→warp scope id. Pass ``None`` (the default) to defer
-    the extent; it will be inferred at LowerTIRx from sibling closure."""
-    ret = _ffi_api.WarpId(extents, "warpgroup")  # type: ignore[attr-defined] # pylint: disable=no-member
+    the extent; it will be inferred at LowerTIRx from sibling closure.
+
+    ``dtype`` selects the dtype of the introduced vars (``"int32"`` or ``"uint32"``)."""
+    ret = _ffi_api.WarpId(extents, "warpgroup", dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
     if len(ret) == 1:
         return ret[0]
     return ret
 
 
-def lane_id(extents: list[Expr | int] | None = None) -> Var | list[Var]:
+def lane_id(extents: list[Expr | int] | None = None, dtype: str = "int32") -> Var | list[Var]:
     """Define a warp→thread scope id. Pass ``None`` (the default) to defer the
-    extent; it will be inferred at LowerTIRx from sibling closure."""
-    ret = _ffi_api.ThreadId(extents, "warp")  # type: ignore[attr-defined] # pylint: disable=no-member
+    extent; it will be inferred at LowerTIRx from sibling closure.
+
+    ``dtype`` selects the dtype of the introduced vars (``"int32"`` or ``"uint32"``)."""
+    ret = _ffi_api.ThreadId(extents, "warp", dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
     if len(ret) == 1:
         return ret[0]
     return ret
 
 
-def thread_id(extents: list[Expr | int] | None = None) -> Var | list[Var]:
+def thread_id(extents: list[Expr | int] | None = None, dtype: str = "int32") -> Var | list[Var]:
     """Define a cta→thread scope id. Pass ``None`` (the default) to defer the
-    extent; it will be inferred at LowerTIRx from sibling closure."""
-    ret = _ffi_api.ThreadId(extents, "cta")  # type: ignore[attr-defined] # pylint: disable=no-member
+    extent; it will be inferred at LowerTIRx from sibling closure.
+
+    ``dtype`` selects the dtype of the introduced vars (``"int32"`` or ``"uint32"``)."""
+    ret = _ffi_api.ThreadId(extents, "cta", dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
     if len(ret) == 1:
         return ret[0]
     return ret
 
 
-def thread_id_in_wg(extents: list[Expr | int] | None = None) -> Var | list[Var]:
+def thread_id_in_wg(
+    extents: list[Expr | int] | None = None, dtype: str = "int32"
+) -> Var | list[Var]:
     """Define a warpgroup→thread scope id. Pass ``None`` (the default) to defer
-    the extent; it will be inferred at LowerTIRx from sibling closure."""
-    ret = _ffi_api.ThreadId(extents, "warpgroup")  # type: ignore[attr-defined] # pylint: disable=no-member
+    the extent; it will be inferred at LowerTIRx from sibling closure.
+
+    ``dtype`` selects the dtype of the introduced vars (``"int32"`` or ``"uint32"``)."""
+    ret = _ffi_api.ThreadId(extents, "warpgroup", dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
     if len(ret) == 1:
         return ret[0]
     return ret
@@ -1149,6 +1175,7 @@ def serial(
     annotations: dict[str, Any] | None = None,
     step: Expr | None = None,
     unroll: bool | None = None,
+    dtype: str | None = None,
 ) -> frame.ForFrame:
     """The serial For statement.
 
@@ -1172,6 +1199,12 @@ def serial(
         If False, adds ``{"disable_unroll": True}`` annotation.
         Shorthand for ``annotations={"disable_unroll": True}``.
 
+    dtype : str, optional
+        The dtype of the loop variable, either ``"int32"`` or ``"uint32"``. When
+        omitted it is inferred from the bounds. Bounds that do not already have this
+        dtype are converted (literals are retyped, other expressions get a Cast).
+        Note ``T.thread_binding`` does not support this; its loop var is always int32.
+
     Returns
     -------
     res : frame.ForFrame
@@ -1189,7 +1222,7 @@ def serial(
             start = IntImm(start.ty, 0)
         else:
             start = 0
-    return _ffi_api.Serial(start, stop, annotations, step)  # type: ignore[attr-defined] # pylint: disable=no-member
+    return _ffi_api.Serial(start, stop, annotations, step, dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
 
 
 def parallel(
@@ -1198,6 +1231,7 @@ def parallel(
     *,
     annotations: dict[str, Any] | None = None,
     step: Expr | None = None,
+    dtype: str | None = None,
 ) -> frame.ForFrame:
     """The parallel For statement.
 
@@ -1215,6 +1249,10 @@ def parallel(
     step : Expr
         The optional step value of iteration.
 
+    dtype : str, optional
+        The dtype of the loop variable, either ``"int32"`` or ``"uint32"``. When
+        omitted it is inferred from the bounds.
+
     Returns
     -------
     res : frame.ForFrame
@@ -1226,7 +1264,7 @@ def parallel(
             start = IntImm(start.ty, 0)
         else:
             start = 0
-    return _ffi_api.Parallel(start, stop, annotations, step)  # type: ignore[attr-defined] # pylint: disable=no-member
+    return _ffi_api.Parallel(start, stop, annotations, step, dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
 
 
 def vectorized(
@@ -1235,6 +1273,7 @@ def vectorized(
     *,
     annotations: dict[str, Any] | None = None,
     step: Expr | None = None,
+    dtype: str | None = None,
 ) -> frame.ForFrame:
     """The vectorized For statement.
 
@@ -1252,6 +1291,10 @@ def vectorized(
     step : Expr
         The optional step value of iteration.
 
+    dtype : str, optional
+        The dtype of the loop variable, either ``"int32"`` or ``"uint32"``. When
+        omitted it is inferred from the bounds.
+
     Returns
     -------
     res : frame.ForFrame
@@ -1263,7 +1306,7 @@ def vectorized(
             start = IntImm(start.ty, 0)
         else:
             start = 0
-    return _ffi_api.Vectorized(start, stop, annotations, step)  # type: ignore[attr-defined] # pylint: disable=no-member
+    return _ffi_api.Vectorized(start, stop, annotations, step, dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
 
 
 def unroll(
@@ -1272,6 +1315,7 @@ def unroll(
     *,
     annotations: dict[str, Any] | None = None,
     step: Expr | None = None,
+    dtype: str | None = None,
 ) -> frame.ForFrame:
     """The unrolled For statement.
 
@@ -1289,6 +1333,10 @@ def unroll(
     step : Expr
         The optional step value of iteration.
 
+    dtype : str, optional
+        The dtype of the loop variable, either ``"int32"`` or ``"uint32"``. When
+        omitted it is inferred from the bounds.
+
     Returns
     -------
     res : frame.ForFrame
@@ -1300,7 +1348,7 @@ def unroll(
             start = IntImm(start.ty, 0)
         else:
             start = 0
-    return _ffi_api.Unroll(start, stop, annotations, step)  # type: ignore[attr-defined] # pylint: disable=no-member
+    return _ffi_api.Unroll(start, stop, annotations, step, dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
 
 
 def thread_binding(
@@ -1351,7 +1399,7 @@ def thread_binding(
     )
 
 
-def grid(*extents: tuple[Expr | tuple[Expr, Expr]]) -> frame.ForFrame:
+def grid(*extents: tuple[Expr | tuple[Expr, Expr]], dtype: str | None = None) -> frame.ForFrame:
     """The grid For statement.
 
     Parameters
@@ -1361,6 +1409,10 @@ def grid(*extents: tuple[Expr | tuple[Expr, Expr]]) -> frame.ForFrame:
         If a tuple of two Expr is provided, the first is the start of the iteration,
         and the second is the extent of the iteration.
 
+    dtype : str, optional
+        The dtype of every loop variable, either ``"int32"`` or ``"uint32"``. When
+        omitted each loop variable takes the dtype of its own extent.
+
     Returns
     -------
     res : frame.ForFrame
@@ -1368,17 +1420,20 @@ def grid(*extents: tuple[Expr | tuple[Expr, Expr]]) -> frame.ForFrame:
     """
     # Convert integer extents to IntImm
     # TODO(@bohan): fix this after FFI refactor
+    imm_dtype = dtype if dtype is not None else "int32"
     processed_extents = []
     for extent in extents:
         if isinstance(extent, tuple):
             start, extent = extent
-            start = IntImm("int32", start) if isinstance(start, int) else start
-            extent = IntImm("int32", extent) if isinstance(extent, int) else extent
+            start = IntImm(imm_dtype, start) if isinstance(start, int) else start
+            extent = IntImm(imm_dtype, extent) if isinstance(extent, int) else extent
             processed_extents.append((start, extent))
         else:
-            processed_extents.append(IntImm("int32", extent) if isinstance(extent, int) else extent)
+            processed_extents.append(
+                IntImm(imm_dtype, extent) if isinstance(extent, int) else extent
+            )
     extents = tuple(processed_extents)
-    return _ffi_api.Grid(extents)  # type: ignore[attr-defined] # pylint: disable=no-member
+    return _ffi_api.Grid(extents, dtype)  # type: ignore[attr-defined] # pylint: disable=no-member
 
 
 def Assert(condition: Expr, message, error_kind: str = "RuntimeError") -> frame.AssertFrame:  # pylint: disable=invalid-name

--- a/src/tirx/ir/stmt.cc
+++ b/src/tirx/ir/stmt.cc
@@ -121,6 +121,21 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   });
 }
 
+namespace {
+/*!
+ * \brief Whether an integer literal can be represented exactly by `ty`.
+ * \note Mirrors the range checks performed by the IntImm constructor.
+ */
+bool IntImmValueFits(int64_t value, const PrimType& ty) {
+  int bits = ty.bits();
+  if (ty.MatchesCode(DLDataTypeCode::kDLUInt)) {
+    return value >= 0 && (bits >= 64 || value < (int64_t{1} << bits));
+  }
+  if (bits >= 64) return true;
+  return value >= -(int64_t{1} << (bits - 1)) && value < (int64_t{1} << (bits - 1));
+}
+}  // namespace
+
 // For
 For::For(PrimVar loop_var, PrimExpr min, PrimExpr extent, ForKind kind, Stmt body,
          ffi::Optional<IterVar> thread_binding, ffi::Map<ffi::String, Any> annotations,
@@ -141,20 +156,23 @@ For::For(PrimVar loop_var, PrimExpr min, PrimExpr extent, ForKind kind, Stmt bod
   require_scalar_int_dtype(min, "min");
   require_scalar_int_dtype(extent, "extent");
 
-  // When extent, min or step is an IntImm but has narrower dtype than loop_var
-  // we directly promote them without raising errors.
+  // When extent, min or step is an IntImm whose dtype differs from loop_var's
+  // (narrower bits and/or a different signedness code), we directly promote it
+  // to the loop var's dtype as long as the value stays representable.
   auto try_promote_imm_dtype = [&](const PrimExpr& e) -> PrimExpr {
     PrimType e_ty = e.ty();
     PrimType loop_var_ty = loop_var.ty();
+    if (e_ty == loop_var_ty) return e;
+    if (const IntImmNode* a = e.as<IntImmNode>()) {
+      TVM_FFI_ICHECK(IntImmValueFits(a->value, loop_var_ty))
+          << "Literal value " << a->value << " is not representable in the loop variable's dtype ("
+          << loop_var_ty << ")";
+      return IntImm(loop_var_ty, a->value);
+    }
     TVM_FFI_ICHECK(e_ty.bits() <= loop_var_ty.bits())
         << " Loop variable's dtype (" << loop_var_ty
         << ") is narrower than that of `min` or `extent` (" << e_ty << ")";
-    const IntImmNode* a = e.as<IntImmNode>();
-    if (a && e_ty.bits() < loop_var_ty.bits()) {
-      return IntImm(loop_var_ty, a->value);
-    } else {
-      return e;
-    }
+    return e;
   };
 
   min = try_promote_imm_dtype(min);

--- a/src/tirx/script/builder/ir.cc
+++ b/src/tirx/script/builder/ir.cc
@@ -184,8 +184,19 @@ SBlockFrame Block(ffi::String name, bool no_realize, ffi::String exec_scope) {
 
 void TilePrimitiveCall(tvm::tirx::TilePrimitiveCall op_call) { AddToParent(op_call); }
 
+/*!
+ * \brief Validate a user-requested loop / scope-id var dtype.
+ * \note Only scalar int32 and uint32 are supported.
+ */
+void CheckExplicitIndexDtype(const PrimType& dtype) {
+  TVM_FFI_ICHECK(dtype.IsScalar() && dtype.bits() == 32 &&
+                 dtype.MatchesCode(DLDataTypeCode::kDLInt, DLDataTypeCode::kDLUInt))
+      << "ValueError: dtype of a loop/scope-id var must be \"int32\" or \"uint32\", got " << dtype;
+}
+
 ffi::Array<tvm::tirx::Var> ScopeId(ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent,
-                                   ffi::String name, ffi::String cur) {
+                                   ffi::String name, ffi::String cur, PrimType dtype) {
+  CheckExplicitIndexDtype(dtype);
   // Determine the number of Vars to introduce. Deferred form (extents=None)
   // is always 1-axis; the verifier closure fills the extent at LowerTIRx.
   size_t n_vars = extents.has_value() ? extents.value().size() : 1;
@@ -195,7 +206,7 @@ ffi::Array<tvm::tirx::Var> ScopeId(ffi::Optional<ffi::Array<PrimExpr>> extents, 
   }
   ffi::Array<tvm::tirx::Var> scope_ids;
   for (size_t i = 0; i < n_vars; ++i) {
-    scope_ids.push_back(tvm::tirx::PrimVar(""));
+    scope_ids.push_back(tvm::tirx::PrimVar("", dtype));
   }
   // Emit a standalone ScopeIdDefStmt to the current TIRFrame's stmts list.
   // The def is visible to all subsequent stmts within the same enclosing
@@ -208,13 +219,14 @@ ffi::Array<tvm::tirx::Var> ScopeId(ffi::Optional<ffi::Array<PrimExpr>> extents, 
 }
 
 ffi::Array<tvm::tirx::Var> ClusterId(ffi::Optional<ffi::Array<PrimExpr>> extents,
-                                     ffi::String parent) {
-  return ScopeId(extents, parent, "T.cluster_id", "cluster");
+                                     ffi::String parent, PrimType dtype) {
+  return ScopeId(extents, parent, "T.cluster_id", "cluster", dtype);
 }
 
 ffi::Array<tvm::tirx::Var> CtaId(ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent,
-                                 ffi::Optional<ffi::Array<PrimExpr>> preferred) {
+                                 ffi::Optional<ffi::Array<PrimExpr>> preferred, PrimType dtype) {
   if (preferred.has_value()) {
+    CheckExplicitIndexDtype(dtype);
     TVM_FFI_ICHECK(parent == "cluster")
         << "ValueError: preferred is only valid when parent=\"cluster\", got parent=\"" << parent
         << "\"";
@@ -222,7 +234,7 @@ ffi::Array<tvm::tirx::Var> CtaId(ffi::Optional<ffi::Array<PrimExpr>> extents, ff
         << "ValueError: preferred=... requires explicit extents (deferred form is incompatible)";
     ffi::Array<tvm::tirx::Var> scope_ids;
     for (size_t i = 0; i < extents.value().size(); ++i) {
-      scope_ids.push_back(tvm::tirx::PrimVar(""));
+      scope_ids.push_back(tvm::tirx::PrimVar("", dtype));
     }
     tvm::tirx::ScopeIdDef def(
         scope_ids.Map([](tvm::tirx::Var var) { return var.as_or_throw<tvm::tirx::PrimVar>(); }),
@@ -230,11 +242,12 @@ ffi::Array<tvm::tirx::Var> CtaId(ffi::Optional<ffi::Array<PrimExpr>> extents, ff
     AddToParent(tvm::tirx::ScopeIdDefStmt(def));
     return scope_ids;
   }
-  return ScopeId(extents, parent, "T.cta_id", "cta");
+  return ScopeId(extents, parent, "T.cta_id", "cta", dtype);
 }
 
-ffi::Array<tvm::tirx::Var> CtaIdInPair() {
-  ffi::Array<tvm::tirx::Var> scope_ids{tvm::tirx::PrimVar("")};
+ffi::Array<tvm::tirx::Var> CtaIdInPair(PrimType dtype) {
+  CheckExplicitIndexDtype(dtype);
+  ffi::Array<tvm::tirx::Var> scope_ids{tvm::tirx::PrimVar("", dtype)};
   tvm::tirx::ScopeIdDef def(
       scope_ids.Map([](tvm::tirx::Var var) { return var.as_or_throw<tvm::tirx::PrimVar>(); }),
       ffi::Array<PrimExpr>{IntImm::Int32(2)}, tvm::tirx::ScopeBinding::kClusterCtaPair);
@@ -243,17 +256,18 @@ ffi::Array<tvm::tirx::Var> CtaIdInPair() {
 }
 
 ffi::Array<tvm::tirx::Var> WarpgroupId(ffi::Optional<ffi::Array<PrimExpr>> extents,
-                                       ffi::String parent) {
-  return ScopeId(extents, parent, "T.warpgroup_id", "warpgroup");
+                                       ffi::String parent, PrimType dtype) {
+  return ScopeId(extents, parent, "T.warpgroup_id", "warpgroup", dtype);
 }
 
-ffi::Array<tvm::tirx::Var> WarpId(ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent) {
-  return ScopeId(extents, parent, "T.warp_id", "warp");
+ffi::Array<tvm::tirx::Var> WarpId(ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent,
+                                  PrimType dtype) {
+  return ScopeId(extents, parent, "T.warp_id", "warp", dtype);
 }
 
-ffi::Array<tvm::tirx::Var> ThreadId(ffi::Optional<ffi::Array<PrimExpr>> extents,
-                                    ffi::String parent) {
-  return ScopeId(extents, parent, "T.thread_id", "thread");
+ffi::Array<tvm::tirx::Var> ThreadId(ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent,
+                                    PrimType dtype) {
+  return ScopeId(extents, parent, "T.thread_id", "thread", dtype);
 }
 
 BlockInitFrame Init() { return BlockInitFrame(ffi::make_object<BlockInitFrameNode>()); }
@@ -476,17 +490,54 @@ ffi::Array<Var> Remap(ffi::String kinds, ffi::Array<PrimExpr> bindings, PrimType
 
 }  // namespace axis
 
+/*!
+ * \brief Determine the dtype of a loop var from its bounds, or validate an explicit one.
+ *
+ * Without an explicit dtype the bit width is the max of both bounds and the
+ * signedness follows C-style promotion (unsigned wins), which is exactly what
+ * `PromoteBinaryOpType` applies to the `stop - start` extent.
+ */
+PrimType InferLoopVarDtype(const PrimExpr& start, const PrimExpr& stop,
+                           const ffi::Optional<PrimType>& dtype) {
+  if (dtype.has_value()) {
+    CheckExplicitIndexDtype(dtype.value());
+    return dtype.value();
+  }
+  PrimType start_ty = start.ty();
+  PrimType stop_ty = stop.ty();
+  bool is_unsigned =
+      start_ty.MatchesCode(DLDataTypeCode::kDLUInt) || stop_ty.MatchesCode(DLDataTypeCode::kDLUInt);
+  return PrimType(is_unsigned ? DLDataTypeCode::kDLUInt : DLDataTypeCode::kDLInt,
+                  std::max(start_ty.bits(), stop_ty.bits()), 1);
+}
+
+/*!
+ * \brief Coerce a loop bound to the loop var's dtype.
+ *
+ * Integer literals are re-created in the target dtype; any other mismatched
+ * expression gets an explicit Cast, so the loop header stays the single place
+ * where the index dtype has to be spelled out.
+ */
+PrimExpr ConvertLoopBound(const PrimExpr& e, const PrimType& var_ty) {
+  if (e.ty() == var_ty) return e;
+  if (const auto* imm = e.as<IntImmNode>()) {
+    return tvm::IntImm(var_ty, imm->value);
+  }
+  return tvm::tirx::Cast(var_ty, e);
+}
+
 #define TVM_TIRX_IR_BUILDER_FOR_FRAME(Method, Kind)                                        \
   ForFrame Method(PrimExpr start, PrimExpr stop,                                           \
                   ffi::Optional<ffi::Map<ffi::String, Any>> annotations,                   \
-                  ffi::Optional<PrimExpr> step) {                                          \
-    PrimExpr min = start;                                                                  \
-    PrimExpr extent = arith::Analyzer()->Simplify(stop - start);                           \
+                  ffi::Optional<PrimExpr> step, ffi::Optional<PrimType> dtype) {           \
+    PrimType var_ty = InferLoopVarDtype(start, stop, dtype);                               \
+    PrimExpr min = ConvertLoopBound(start, var_ty);                                        \
+    PrimExpr extent = arith::Analyzer()->Simplify(ConvertLoopBound(stop, var_ty) - min);   \
+    if (step.has_value()) {                                                                \
+      step = ConvertLoopBound(step.value(), var_ty);                                       \
+    }                                                                                      \
     ffi::ObjectPtr<ForFrameNode> n = ffi::make_object<ForFrameNode>();                     \
-    PrimType min_ty = min.ty();                                                            \
-    PrimType extent_ty = extent.ty();                                                      \
-    int bits = std::max(min_ty.bits(), extent_ty.bits());                                  \
-    n->vars = {Var("v", min_ty.WithBits(bits).WithLanes(1))};                              \
+    n->vars = {Var("v", var_ty)};                                                          \
     n->doms = {Range::FromMinExtent(min, extent)};                                         \
     n->steps = {step};                                                                     \
     n->f_make_for_loop = [annotations](ffi::Array<Var> vars, ffi::Array<Range> doms,       \
@@ -537,8 +588,12 @@ ForFrame ThreadBinding(PrimExpr start, PrimExpr stop, ffi::String thread,
   return ForFrame(n);
 }
 
-ForFrame Grid(ffi::Array<ffi::Variant<PrimExpr, ffi::Tuple<PrimExpr, PrimExpr>>> extents) {
+ForFrame Grid(ffi::Array<ffi::Variant<PrimExpr, ffi::Tuple<PrimExpr, PrimExpr>>> extents,
+              ffi::Optional<PrimType> dtype) {
   using namespace tvm::tirx;
+  if (dtype.has_value()) {
+    CheckExplicitIndexDtype(dtype.value());
+  }
   ffi::ObjectPtr<ForFrameNode> n = ffi::make_object<ForFrameNode>();
   n->vars.reserve(extents.size());
   n->doms.reserve(extents.size());
@@ -546,14 +601,15 @@ ForFrame Grid(ffi::Array<ffi::Variant<PrimExpr, ffi::Tuple<PrimExpr, PrimExpr>>>
   for (const auto& extent : extents) {
     if (auto prim_expr = extent.as<PrimExpr>()) {
       // extent is a single PrimExpr
-      PrimType dtype = prim_expr.value().ty();
-      n->vars.push_back(Var("v", dtype));
-      n->doms.push_back(Range(tvm::IntImm(dtype, 0), prim_expr.value()));
+      PrimType var_ty = dtype.value_or(prim_expr.value().ty());
+      n->vars.push_back(Var("v", var_ty));
+      n->doms.push_back(Range(tvm::IntImm(var_ty, 0), ConvertLoopBound(prim_expr.value(), var_ty)));
     } else if (auto tuple = extent.as<ffi::Tuple<PrimExpr, PrimExpr>>()) {
       // extent is a tuple of two PrimExpr (start, extent)
-      PrimType dtype = tuple.value().get<0>().ty();
-      n->vars.push_back(Var("v", dtype));
-      n->doms.push_back(Range::FromMinExtent(tuple.value().get<0>(), tuple.value().get<1>()));
+      PrimType var_ty = dtype.value_or(tuple.value().get<0>().ty());
+      n->vars.push_back(Var("v", var_ty));
+      n->doms.push_back(Range::FromMinExtent(ConvertLoopBound(tuple.value().get<0>(), var_ty),
+                                             ConvertLoopBound(tuple.value().get<1>(), var_ty)));
     } else {
       TVM_FFI_THROW(InternalError) << "TypeError: Invalid type for grid extent";
     }
@@ -915,30 +971,30 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("script.ir_builder.tirx.Block", Block)
       .def("script.ir_builder.tirx.TilePrimitiveCall", TilePrimitiveCall)
       .def("script.ir_builder.tirx.ClusterId",
-           [](ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent) {
-             return ClusterId(extents, parent);
+           [](ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent, PrimType dtype) {
+             return ClusterId(extents, parent, dtype);
            })
       .def("script.ir_builder.tirx.CtaId",
            [](ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent,
-              ffi::Optional<ffi::Array<PrimExpr>> preferred) {
-             return CtaId(extents, parent, preferred);
-           })
+              ffi::Optional<ffi::Array<PrimExpr>> preferred,
+              PrimType dtype) { return CtaId(extents, parent, preferred, dtype); })
       .def("script.ir_builder.tirx.CtaIdInPair", CtaIdInPair)
       .def("script.ir_builder.tirx.WarpgroupId",
-           [](ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent) {
-             return WarpgroupId(extents, parent);
+           [](ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent, PrimType dtype) {
+             return WarpgroupId(extents, parent, dtype);
            })
       .def("script.ir_builder.tirx.WarpId",
-           [](ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent) {
-             return WarpId(extents, parent);
+           [](ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent, PrimType dtype) {
+             return WarpId(extents, parent, dtype);
            })
       .def("script.ir_builder.tirx.ThreadId",
-           [](ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent) {
-             return ThreadId(extents, parent);
+           [](ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent, PrimType dtype) {
+             return ThreadId(extents, parent, dtype);
            })
       .def("script.ir_builder.tirx.ScopeId",
            [](ffi::Optional<ffi::Array<PrimExpr>> extents, ffi::String parent, ffi::String name,
-              ffi::String cur) { return ScopeId(extents, parent, name, cur); })
+              ffi::String cur,
+              PrimType dtype) { return ScopeId(extents, parent, name, cur, dtype); })
       .def("script.ir_builder.tirx.Init", Init)
       .def("script.ir_builder.tirx.Where", Where)
       .def("script.ir_builder.tirx.Reads", Reads)

--- a/src/tirx/script/printer/block.cc
+++ b/src/tirx/script/printer/block.cc
@@ -257,6 +257,21 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
             kwarg_vals.push_back(d->AsDoc<ExprDoc>(def->preferred_extents.value(),
                                                    def_p->Attr("preferred_extents")));
           }
+          // The scope-id dtype is independent of the extents, so it has to be printed
+          // explicitly whenever it is not the int32 default in order to round-trip.
+          if (!def->def_ids.empty()) {
+            PrimType scope_id_ty = def->def_ids[0].ty();
+            for (auto scope_id : def->def_ids) {
+              TVM_FFI_ICHECK(scope_id.ty() == scope_id_ty)
+                  << "mixed scope-id dtypes are unsupported, got " << scope_id_ty << " and "
+                  << scope_id.ty();
+            }
+            if (scope_id_ty != PrimType::Int(32)) {
+              kwarg_keys.push_back("dtype");
+              kwarg_vals.push_back(
+                  LiteralDoc::Str(DType2Str(scope_id_ty->dtype), def_p->Attr("def_ids")));
+            }
+          }
           ExprDoc rhs = TIR(d, ScopeIdApiName(def->scope))->Call(rhs_args, kwarg_keys, kwarg_vals);
           return AssignDoc(TupleDoc(lhs), rhs, std::nullopt);
         });

--- a/tests/python/tirx/codegen/test_codegen_cuda.py
+++ b/tests/python/tirx/codegen/test_codegen_cuda.py
@@ -1048,5 +1048,48 @@ def test_ptx_ldmatrix(trans, num):
     tvm.testing.run_with_gpu_lock(run_and_check)
 
 
+def test_uint32_loop_var_and_scope_id_emit_unsigned():
+    @T.prim_func
+    def main(A: T.Buffer((128,), "int32")):
+        T.device_entry()
+        _ = T.cta_id([1])
+        tx = T.thread_id([128], dtype="uint32")
+        for k in T.serial(4, dtype="uint32"):
+            A[tx] = A[tx] + T.int32(k)
+
+    src, _ = _get_source(main)
+    # The loop var is declared unsigned and iterates over unsigned bounds.
+    assert re.search(r"for \(uint k = \(uint\)0; k < \(uint\)4;", src), src
+    # The scope id is bound as an unsigned value.
+    assert re.search(r"uint tx = ", src), src
+
+
+def test_uint32_loop_var_runs_correctly():
+    @T.prim_func
+    def main(A: T.Buffer((128,), "int32"), B: T.Buffer((128,), "int32")):
+        T.device_entry()
+        _ = T.cta_id([1])
+        tx = T.thread_id([128], dtype="uint32")
+        acc = T.alloc_buffer((1,), "int32", scope="local")
+        acc[0] = 0
+        for k in T.serial(4, dtype="uint32"):
+            acc[0] = acc[0] + A[tx] + T.int32(k)
+        B[tx] = acc[0]
+
+    _, mod = _get_source(main)
+
+    A_np = np.arange(128, dtype="int32")
+    B_ref = A_np * 4 + (0 + 1 + 2 + 3)
+
+    def run_and_check():
+        dev = tvm.cuda()
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(np.zeros(128, dtype="int32"), device=dev)
+        mod(A, B)
+        np.testing.assert_allclose(B.numpy(), B_ref)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/tirx/test_parser_printer.py
+++ b/tests/python/tirx/test_parser_printer.py
@@ -2759,5 +2759,251 @@ def test_roundtrip_cp_async_bulk_tensor_s2g_reduce():
     assert_structural_equal(func, from_source(code))
 
 
+def _assert_roundtrip(func):
+    code = func.script()
+    assert from_source(code).script() == code
+    assert_structural_equal(func, from_source(code))
+
+
+def test_loop_var_dtype_uint32():
+    # fmt: off
+    @T.prim_func
+    def func(A_ptr: T.handle):
+        A = T.match_buffer(A_ptr, (128,), "float32")
+        for i in T.serial(128, dtype="uint32"):
+            A[i] = T.float32(1)
+    # fmt: on
+
+    loop = func.body
+    assert loop.loop_var.ty == PrimType("uint32")
+    assert loop.min.ty == PrimType("uint32")
+    assert loop.extent.ty == PrimType("uint32")
+    _assert_roundtrip(func)
+
+
+def test_loop_var_dtype_uint32_with_step():
+    # fmt: off
+    @T.prim_func
+    def func(A_ptr: T.handle):
+        A = T.match_buffer(A_ptr, (128,), "float32")
+        for i in T.serial(4, 128, step=2, dtype="uint32"):
+            A[i] = T.float32(1)
+    # fmt: on
+
+    loop = func.body
+    assert loop.loop_var.ty == PrimType("uint32")
+    assert loop.min.ty == PrimType("uint32")
+    assert loop.extent.ty == PrimType("uint32")
+    assert loop.step.ty == PrimType("uint32")
+    _assert_roundtrip(func)
+
+
+@pytest.mark.parametrize("for_kind", ["serial", "parallel", "vectorized", "unroll"])
+def test_loop_var_dtype_uint32_all_for_kinds(for_kind):
+    # fmt: off
+    @T.prim_func
+    def func(A_ptr: T.handle):
+        A = T.match_buffer(A_ptr, (4,), "float32")
+        for i in getattr(T, for_kind)(4, dtype="uint32"):
+            A[i] = T.float32(1)
+    # fmt: on
+
+    assert func.body.loop_var.ty == PrimType("uint32")
+    _assert_roundtrip(func)
+
+
+def test_grid_loop_var_dtype_uint32():
+    # fmt: off
+    @T.prim_func
+    def func(A_ptr: T.handle):
+        A = T.match_buffer(A_ptr, (8, 16), "float32")
+        for i, j in T.grid(8, 16, dtype="uint32"):
+            A[i, j] = T.float32(1)
+    # fmt: on
+
+    outer = func.body
+    assert outer.loop_var.ty == PrimType("uint32")
+    assert outer.body.loop_var.ty == PrimType("uint32")
+    _assert_roundtrip(func)
+
+
+def test_loop_var_dtype_defaults_to_int32():
+    # fmt: off
+    @T.prim_func
+    def func(A_ptr: T.handle):
+        A = T.match_buffer(A_ptr, (128,), "float32")
+        for i in range(128):
+            A[i] = T.float32(1)
+    # fmt: on
+
+    assert func.body.loop_var.ty == PrimType("int32")
+    _assert_roundtrip(func)
+
+
+def test_loop_var_dtype_inferred_from_unsigned_extent():
+    """A uint32 extent makes the loop var uint32 without an explicit dtype."""
+
+    # fmt: off
+    @T.prim_func
+    def func(A_ptr: T.handle, n: T.uint32):
+        A = T.match_buffer(A_ptr, (128,), "float32")
+        for i in range(n):
+            A[i] = T.float32(1)
+    # fmt: on
+
+    assert func.body.loop_var.ty == PrimType("uint32")
+    _assert_roundtrip(func)
+
+
+def test_loop_var_dtype_casts_mismatched_bound():
+    """A non-literal bound of another dtype is cast to the requested loop dtype."""
+
+    # fmt: off
+    @T.prim_func
+    def func(A_ptr: T.handle, n: T.int32):
+        A = T.match_buffer(A_ptr, (128,), "float32")
+        for i in T.serial(n, dtype="uint32"):
+            A[i] = T.float32(1)
+    # fmt: on
+
+    loop = func.body
+    assert loop.loop_var.ty == PrimType("uint32")
+    assert loop.extent.ty == PrimType("uint32")
+    _assert_roundtrip(func)
+
+
+@pytest.mark.parametrize("dtype", ["int64", "uint64", "int16", "float32"])
+def test_loop_var_dtype_rejects_unsupported(dtype):
+    with pytest.raises(Exception, match='must be "int32" or "uint32"'):
+        T.serial(4, dtype=dtype)
+
+
+def test_thread_binding_has_no_dtype_parameter():
+    with pytest.raises(TypeError):
+        T.thread_binding(0, 128, "threadIdx.x", dtype="uint32")
+
+
+def test_hand_built_for_promotes_int_literal_bounds_to_uint32():
+    """The For constructor retypes literal bounds to the loop var's dtype."""
+    loop_var = tvm.tirx.Var("i", "uint32")
+    loop = tvm.tirx.For(loop_var, 0, 128, tvm.tirx.ForKind.SERIAL, tvm.tirx.Evaluate(0))
+    assert loop.min.ty == PrimType("uint32")
+    assert loop.extent.ty == PrimType("uint32")
+
+
+def test_hand_built_for_rejects_negative_literal_for_uint32():
+    loop_var = tvm.tirx.Var("i", "uint32")
+    with pytest.raises(Exception, match="not representable"):
+        tvm.tirx.For(loop_var, -1, 128, tvm.tirx.ForKind.SERIAL, tvm.tirx.Evaluate(0))
+
+
+def test_scope_id_dtype_uint32():
+    # fmt: off
+    @T.prim_func
+    def func(A_ptr: T.handle):
+        A = T.match_buffer(A_ptr, (128,), "float32")
+        T.device_entry()
+        bx = T.cta_id([1])
+        tx = T.thread_id([128], dtype="uint32")
+        A[tx] = T.float32(bx)
+    # fmt: on
+
+    scope_defs = []
+    tvm.tirx.stmt_functor.post_order_visit(
+        func.body,
+        lambda s: (
+            scope_defs.append(getattr(s, "def")) if isinstance(s, tvm.tirx.ScopeIdDefStmt) else None
+        ),
+    )
+    dtypes = {str(d.def_ids[0].ty) for d in scope_defs}
+    assert dtypes == {"int32", "uint32"}
+    # The extents stay int32 regardless of the def var dtype.
+    for d in scope_defs:
+        assert d.extents[0].ty == PrimType("int32")
+
+    code = func.script()
+    assert 'T.thread_id([128], dtype="uint32")' in code
+    assert "T.cta_id([1])" in code
+    _assert_roundtrip(func)
+
+
+def test_scope_id_dtype_uint32_lane_and_warp():
+    # fmt: off
+    @T.prim_func
+    def func(A_ptr: T.handle):
+        A = T.match_buffer(A_ptr, (32,), "float32")
+        T.device_entry()
+        _ = T.cta_id([1])
+        warp = T.warp_id([4], dtype="uint32")
+        lane = T.lane_id([32], dtype="uint32")
+        A[lane] = T.float32(warp)
+    # fmt: on
+
+    code = func.script()
+    assert 'T.warp_id([4], dtype="uint32")' in code
+    assert 'T.lane_id([32], dtype="uint32")' in code
+    _assert_roundtrip(func)
+
+
+def test_scope_id_dtype_uint32_with_preferred():
+    # fmt: off
+    @T.prim_func
+    def func(A_ptr: T.handle):
+        A = T.match_buffer(A_ptr, (4,), "float32")
+        T.device_entry()
+        _ = T.cluster_id([2])
+        cx, cy = T.cta_id_in_cluster([2, 2], preferred=[2, 2], dtype="uint32")
+        tx = T.thread_id([32])
+        if tx == 0:
+            A[cx + cy] = T.float32(1)
+    # fmt: on
+
+    code = func.script()
+    assert 'dtype="uint32"' in code
+    _assert_roundtrip(func)
+
+
+def test_scope_id_dtype_uint32_deferred_extent():
+    """The deferred (extent=None) form carries the dtype too."""
+
+    # fmt: off
+    @T.prim_func
+    def func(A_ptr: T.handle):
+        A = T.match_buffer(A_ptr, (32,), "float32")
+        T.device_entry()
+        _ = T.cta_id([1])
+        lane = T.lane_id(dtype="uint32")
+        warp = T.warp_id([4])
+        A[lane] = T.float32(warp)
+    # fmt: on
+
+    scope_defs = []
+    tvm.tirx.stmt_functor.post_order_visit(
+        func.body,
+        lambda s: (
+            scope_defs.append(getattr(s, "def")) if isinstance(s, tvm.tirx.ScopeIdDefStmt) else None
+        ),
+    )
+    deferred = [d for d in scope_defs if d.extents is None]
+    assert len(deferred) == 1
+    assert deferred[0].def_ids[0].ty == PrimType("uint32")
+    _assert_roundtrip(func)
+
+
+@pytest.mark.parametrize("dtype", ["int64", "float32"])
+def test_scope_id_dtype_rejects_unsupported(dtype):
+    # fmt: off
+    with pytest.raises(Exception, match='must be "int32" or "uint32"'):
+
+        @T.prim_func
+        def func(A_ptr: T.handle):
+            A = T.match_buffer(A_ptr, (128,), "float32")
+            T.device_entry()
+            _ = T.cta_id([1])
+            tx = T.thread_id([128], dtype=dtype)
+            A[tx] = T.float32(1)
+    # fmt: on
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/tirx/transform/test_transform_lower_tirx.py
+++ b/tests/python/tirx/transform/test_transform_lower_tirx.py
@@ -644,6 +644,33 @@ def test_lower_separate_scope_id_def():
     compare(before, after, LowerTIRx)
 
 
+def test_lower_uint32_scope_id_casts_at_bind():
+    """uint32 scope ids get a Cast at the bind; launch params stay int32."""
+
+    @T.prim_func(private=True)
+    def before():
+        T.device_entry()
+        T.cta_id([1])
+        tx = T.thread_id([128], dtype="uint32")
+        for k in T.serial(4, dtype="uint32"):
+            T.evaluate(tx + k)
+
+    @T.prim_func(private=True)
+    def after():
+        blockIdx_x = T.launch_thread("blockIdx.x", 1)
+        threadIdx_x = T.launch_thread("threadIdx.x", 128)
+        warp_id_in_cta: T.let[T.int32] = T.tvm_warp_shuffle(
+            T.uint32(4294967295), threadIdx_x // 32, 0, 32, 32
+        )
+        v: T.let[T.int32] = blockIdx_x
+        tx: T.let[T.uint32] = T.Cast("uint32", threadIdx_x)
+        T.evaluate(v)
+        for k in T.serial(T.uint32(4)):
+            T.evaluate(tx + k)
+
+    compare(before, after, LowerTIRx)
+
+
 def test_lower_exec_context_infers_plain_predicate_for_dispatch():
     import tvm.tirx.operator.tile_primitive as _  # noqa: F401
     from tvm.tirx.operator.tile_primitive.dispatcher import register_dispatch


### PR DESCRIPTION
## Motivation

TIRx pinned both for-loop vars and scope-id vars to `int32`. This adds an explicit per-site `dtype=` so kernels can opt into `uint32`, in order to:

- emit u32 index registers / unsigned address arithmetic in CUDA codegen,
- feed inline-PTX and external-kernel `.u32` operands without a conversion,
- keep uint32 index math free of manual `T.Cast` at every use site.

Supported dtypes are `int32` (the default) and `uint32`. Default behavior is unchanged.

## API

```python
for i in T.serial(128, dtype="uint32"): ...
for i, j in T.grid(8, 16, dtype="uint32"): ...
lane = T.lane_id([32], dtype="uint32")
tx   = T.thread_id([128], dtype="uint32")
```

Available on `serial` / `parallel` / `vectorized` / `unroll` / `grid` and on all scope-id wrappers. `T.thread_binding` stays int32-only — the `IterVar` constructor requires an int-coded extent dtype.

## Changes

- **`src/tirx/ir/stmt.cc`** — `try_promote_imm_dtype` now promotes `IntImm` bounds across signedness as well as width, with a representability check (a negative literal against a `uint32` loop var gives a clear error).
- **`src/tirx/script/builder/ir.cc`**, **`include/tvm/tirx/script/builder/ir.h`** — new `CheckExplicitIndexDtype` / `InferLoopVarDtype` / `ConvertLoopBound` helpers; for-frames and scope-id builders take the new dtype. Literal bounds are retyped, and a non-literal bound of another dtype gets a single `Cast` at the loop header.
- **`src/tirx/script/printer/block.cc`** — print `dtype=` for scope ids. Unlike loops, a scope id's dtype is not recoverable from its extents, so it has to be explicit to round-trip.
- **`python/tvm/tirx/script/builder/ir.py`** — wrappers and docstrings.

Scope-id lowering needs no changes: `ResolveAllScopeBinds` already casts the resolved value to the bind var's dtype, and extents stay int32 so launch-param `IterVar`s are untouched.

Two incidental cleanups: the `KernelId` declaration in `ir.h` had no definition or callers and was removed along with the other stale scope-id declarations; the scope-id printer guards against an empty `def_ids`.

## Bug fixed along the way

`for i in range(<uint32 expr>)` previously failed with `int32 vs uint32` at the `For` constructor's dtype-equality check: the loop var took its signedness from `min` alone (a literal `0`, hence int32) while the extent went through unsigned promotion. Inference now merges signedness the way `PromoteBinaryOpType` does.

## Effect on generated code

```c
uint tx = ((uint)((int)threadIdx.x));
for (uint k = (uint)0; k < (uint)4; ++k) {
  A_ptr[((uint)((int)threadIdx.x))] = ...
```

The int32 -> uint32 round trip is free (both are 32-bit registers) and the PTX is byte-identical to a hand-written `uint tx = threadIdx.x`. What does change is the address arithmetic, which is the point:

```
uint index:  mul.wide.u32
int  index:  mul.wide.s32
```

## Tests

Added 25 tests: round-trip and structural-equality coverage for every for-kind and the scope-id wrappers, dtype inference, rejection of unsupported dtypes, hand-built `For` promotion, a lowering test asserting the bind cast with int32 launch params preserved, and an end-to-end CUDA test checking both the emitted source and numerical results on GPU.

Full `tests/python/tirx/` passes (2719 passed, 73 skipped, 3 xpassed), as do `tirx-base`, `tirx-transform`, `tirx-analysis` and `arith` (1647 passed).
