### PR TITLE
[FIX][TIRx] Preserve CUDA sync and unroll directives

### DIFF
--- a/python/tvm/backend/cuda/intrinsics/header.py
+++ b/python/tvm/backend/cuda/intrinsics/header.py
@@ -792,16 +792,13 @@ union InstrDescriptorBlockScaled
         header += R"""
 __forceinline__ __device__ uint32_t tvm_builtin_elect_one_sync() {{
   uint32_t pred = 0;
-  uint32_t laneid = 0;
   asm volatile(
     "{\n"
-    ".reg .b32 %%rx;\n"
     ".reg .pred %%px;\n"
-    "     elect.sync %%rx|%%px, %2;\n"
-    "@%%px mov.s32 %1, 1;\n"
-    "     mov.s32 %0, %%rx;\n"
+    "     elect.sync _|%%px, %1;\n"
+    "@%%px mov.s32 %0, 1;\n"
     "}\n"
-    : "+r"(laneid), "+r"(pred)
+    : "+r"(pred)
     : "r"(0xFFFFFFFF));
   return pred;
 }}

--- a/python/tvm/backend/cuda/intrinsics/sync.py
+++ b/python/tvm/backend/cuda/intrinsics/sync.py
@@ -97,9 +97,9 @@ def _ptx_barrier_cluster_wait(acquire, aligned):
 
 
 # =============================================================================
-# mbarrier.try_wait.parity.shared::cta.b64 — 1 form. Body wraps the asm in a
-# label loop (TIRx convention; the magic ``ticks = 0x989680`` is the timeout
-# hint in ns).
+# mbarrier.try_wait.parity.acquire.cta.shared::cta.b64 — 1 form. Body wraps the
+# asm in a label loop (TIRx convention; the magic ``ticks = 0x989680`` is the
+# timeout hint in ns).
 # =============================================================================
 def _mbarrier_wait_parts(barrier, *_rest):
     """Dispatch on the barrier operand's dtype, as the retired op did.
@@ -131,7 +131,7 @@ device_intrinsic(
         '        "{\\n"\n'
         '        ".reg .pred                P1;\\n"\n'
         '        "LAB_WAIT:\\n"\n'
-        '        "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1, %2;\\n"\n'
+        '        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64 P1, [%0], %1, %2;\\n"\n'
         '        "@P1                       bra.uni DONE;\\n"\n'
         '        "bra.uni                   LAB_WAIT;\\n"\n'
         '        "DONE:\\n"\n'

--- a/python/tvm/backend/cuda/op.py
+++ b/python/tvm/backend/cuda/op.py
@@ -396,7 +396,7 @@ def _validate_mbarrier_arrive_attrs(sem, scope, space, remote):
 
 
 def cuda_mbarrier_wait(bar, phase):
-    """TVM intrinsic to call mbarrier.try_wait.parity repeatedly until it returns true
+    """Retry ``mbarrier.try_wait.parity.acquire.cta`` until it returns true.
 
     Parameters
     ----------

--- a/python/tvm/backend/cuda/script.py
+++ b/python/tvm/backend/cuda/script.py
@@ -138,8 +138,8 @@ class CUDANamespace:
         self.wgmma = CudaWgmmaNamespace()
         self.tcgen05 = CudaTcgen05Namespace()
         self.any_sync = _op_wrapper(_cuda_op.cuda_any_sync)
-        # elect.sync plus the two movs that materialize its d|p pair: a
-        # multi-statement asm block, so it belongs here rather than T.ptx.
+        # elect.sync plus the predicated mov that materializes its predicate:
+        # a multi-statement asm block, so it belongs here rather than T.ptx.
         # The warp-specialization passes match this op to build predicates.
         self.elect_sync: Callable[..., Any] = _op_wrapper(_cuda_op.cuda_elect_sync)
         # `mov.u32 d, %sreg` -- one PTX instruction, but the special-register

--- a/python/tvm/tirx/script/builder/ir.py
+++ b/python/tvm/tirx/script/builder/ir.py
@@ -1174,7 +1174,7 @@ def serial(
     *,
     annotations: dict[str, Any] | None = None,
     step: Expr | None = None,
-    unroll: bool | None = None,
+    unroll: bool | int | None = None,
     dtype: str | None = None,
 ) -> frame.ForFrame:
     """The serial For statement.
@@ -1193,11 +1193,12 @@ def serial(
     step : Expr
         The optional step value of iteration.
 
-    unroll : bool, optional
+    unroll : bool or int, optional
         If True, adds ``{"pragma_unroll": True}`` annotation, which asks CUDA codegen
         to emit ``#pragma unroll`` while preserving the loop as a C++ ``for``.
         If False, adds ``{"disable_unroll": True}`` annotation.
-        Shorthand for ``annotations={"disable_unroll": True}``.
+        If a positive integer, emits ``#pragma unroll N``. Boolean values are
+        handled separately from integers, so ``False`` keeps disabling unrolling.
 
     dtype : str, optional
         The dtype of the loop variable, either ``"int32"`` or ``"uint32"``. When
@@ -1212,10 +1213,17 @@ def serial(
     """
     if unroll is not None:
         annotations = dict(annotations) if annotations else {}
-        if unroll:
-            annotations["pragma_unroll"] = True
+        if isinstance(unroll, bool):
+            if unroll:
+                annotations["pragma_unroll"] = True
+            else:
+                annotations["disable_unroll"] = True
+        elif isinstance(unroll, int):
+            if unroll < 1:
+                raise ValueError("unroll must be a positive integer")
+            annotations["pragma_unroll"] = unroll
         else:
-            annotations["disable_unroll"] = True
+            raise TypeError("unroll must be a bool, a positive integer, or None")
     if stop is None:
         stop = start
         if is_prim_expr(start):

--- a/src/backend/cuda/codegen/codegen_cuda.cc
+++ b/src/backend/cuda/codegen/codegen_cuda.cc
@@ -311,9 +311,18 @@ void CodeGenCUDA::VisitStmt_(const tirx::ForNode* op) {
   if (op->annotations.count("disable_unroll")) {
     PrintIndent();
     stream << "#pragma unroll 1\n";
-  } else if (op->kind == tirx::ForKind::kUnrolled || op->annotations.count("pragma_unroll")) {
+  } else if (op->kind == tirx::ForKind::kUnrolled) {
     PrintIndent();
     stream << "#pragma unroll\n";
+  } else if (auto it = op->annotations.find("pragma_unroll"); it != op->annotations.end()) {
+    PrintIndent();
+    stream << "#pragma unroll";
+    if (auto count = (*it).second.as<int64_t>()) {
+      stream << " " << count.value();
+    } else if (const auto* count = (*it).second.as<IntImmNode>()) {
+      stream << " " << count->value;
+    }
+    stream << "\n";
   }
   PrintIndent();
   std::string vid = AllocVarID(op->loop_var.get());
@@ -1605,7 +1614,11 @@ void CodeGenCUDA::VisitStmt_(const AttrStmtNode* op) {
     return;
   } else if (op->attr_key == "pragma_unroll") {
     PrintIndent();
-    stream << "#pragma unroll\n";
+    stream << "#pragma unroll";
+    if (const auto* count = op->value.as<IntImmNode>(); count && count->value != 1) {
+      stream << " " << count->value;
+    }
+    stream << "\n";
     this->VisitStmt(op->body);
     return;
   } else if (op->attr_key == tirx::attr::thread_extent) {

--- a/src/tirx/script/printer/for_loop.cc
+++ b/src/tirx/script/printer/for_loop.cc
@@ -116,7 +116,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
       if (annotations.has_value()) {
         // Check for the special cases:
         // - annotations == {"disable_unroll": True}: print as unroll=False
-        // - annotations == {"pragma_unroll": True}: print as unroll=True
+        // - annotations == {"pragma_unroll": value}: print as unroll=value
         bool printed_as_unroll = false;
         if (loop->annotations.size() == 1 && loop->annotations.count("disable_unroll")) {
           kwargs_keys.push_back("unroll");
@@ -124,7 +124,8 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
           printed_as_unroll = true;
         } else if (loop->annotations.size() == 1 && loop->annotations.count("pragma_unroll")) {
           kwargs_keys.push_back("unroll");
-          kwargs_values.push_back(LiteralDoc::Boolean(true, loop_p->Attr("annotations")));
+          kwargs_values.push_back(
+              d->AsDoc<ExprDoc>(loop->annotations["pragma_unroll"], loop_p->Attr("annotations")));
           printed_as_unroll = true;
         }
         if (!printed_as_unroll) {

--- a/src/tirx/transform/lower_tirx_opaque.cc
+++ b/src/tirx/transform/lower_tirx_opaque.cc
@@ -136,7 +136,8 @@ class TIRxOpaqueLower : public StmtExprMutator {
   /*!
    * \brief Handle loop annotation dict.
    * (1) if the attr key is prefixed by `pragma_`, move to ordered kv list
-   *     (lowered to `AttrStmt` by legacy TE schedule convention).
+   *     (lowered to `AttrStmt` by legacy TE schedule convention), except for
+   *     `pragma_unroll`, whose bool-or-integer value must remain on the loop.
    * (2) non-pragma loop annotations are preserved.
    * \return New annotation dict with preserved keys. Also update pragma attr pairs ordered by key.
    */
@@ -147,7 +148,9 @@ class TIRxOpaqueLower : public StmtExprMutator {
     pragma_attrs->clear();
     for (const auto& kv : annotations) {
       const ffi::String& key = kv.first;
-      if (tirx::attr::IsPragmaKey(key)) {
+      if (key == "pragma_unroll") {
+        preserved_annotations.Set(key, kv.second);
+      } else if (tirx::attr::IsPragmaKey(key)) {
         pragma_attrs->emplace_back(key, ConvertAttrValue(key, kv.second));
       } else {
         // loop annotations are always preserved (no SBlock annotation dropping here)

--- a/tests/python/tirx/codegen/test_codegen_cuda.py
+++ b/tests/python/tirx/codegen/test_codegen_cuda.py
@@ -239,6 +239,19 @@ def test_serial_pragma_unroll_codegen():
     assert "break;" in src
 
 
+def test_serial_pragma_unroll_count_codegen():
+    @T.prim_func
+    def main(A: T.Buffer((4,), "int32")):
+        T.device_entry()
+        tx = T.thread_id([32])
+        if tx == 0:
+            for i in T.serial(4, unroll=2):
+                A[i] = A[i] + 1
+
+    src, _ = _get_source(main)
+    assert re.search(r"#pragma unroll 2\s*for \(", src)
+
+
 def test_serial_disable_unroll_pragma_immediately_precedes_dynamic_for():
     @T.prim_func
     def main(A: T.Buffer((4,), "int32")):
@@ -598,7 +611,7 @@ def test_ptx_sync_and_clc_codegen():
     assert "cp.async.mbarrier.arrive.noinc.shared::cta.b64" in src
     # The spin-wait moved to T.cuda.mbarrier_wait, which takes its timeout as a
     # parameter rather than baking 10000000 into the asm text.
-    assert "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1, %2;" in src
+    assert "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64 P1, [%0], %1, %2;" in src
     assert "tvm_builtin_cuda_mbarrier_wait" in src
     # (No assertion on the timeout local: T.cuda.mbarrier_wait keeps the
     # `ticks = 0x989680` hint the TIRx spin-wait convention specifies.)

--- a/tests/python/tirx/codegen/test_codegen_hopper.py
+++ b/tests/python/tirx/codegen/test_codegen_hopper.py
@@ -367,7 +367,9 @@ def test_ptx_elect_sync():
 
     src, mod = _get_source(func)
     print(src)
-    assert "elect.sync %%rx|%%px, %2;" in src
+    assert "elect.sync _|%%px, %1;" in src
+    assert ".reg .b32 %%rx;" not in src
+    assert "mov.s32 %0, %%rx;" not in src
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/test_parser_printer.py
+++ b/tests/python/tirx/test_parser_printer.py
@@ -2297,6 +2297,28 @@ def test_roundtrip_serial_unroll_true():
     assert_structural_equal(test, from_source(code))
 
 
+def test_roundtrip_serial_unroll_count():
+    """T.serial(N, unroll=2) should preserve the requested unroll count."""
+
+    # fmt: off
+    @T.prim_func
+    def test(A_ptr: T.handle) -> None:
+        A = T.match_buffer(A_ptr, (128,), "float32", scope="global")
+        T.device_entry()
+        cta_id = T.cta_id([1])
+        warp_id = T.warp_id([1])
+        lane_id = T.lane_id([32])
+        for _ in T.serial(10, unroll=2):
+            Tx.cta.fill(A[0:32], T.float32(0))
+        # fmt: on
+
+    code = test.script()
+    assert "unroll=2" in code, f"printer should emit unroll=2, got:\n{code}"
+    assert "annotations" not in code, "printer should NOT emit annotations dict"
+    assert from_source(code).script() == code
+    assert_structural_equal(test, from_source(code))
+
+
 def test_roundtrip_serial_unroll_false_with_other_annotations():
     """When other annotations exist alongside disable_unroll, fall back to full dict."""
 


### PR DESCRIPTION
## Summary

- Lower `T.cuda.elect_sync()` to the predicate-only PTX form without materializing the unused elected lane ID.
- Make the existing `T.cuda.mbarrier_wait()` helper use `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64`.
- Add positive integer support to `T.serial(..., unroll=N)` and preserve it through script printing, TIRx lowering, and CUDA code generation.

## Why

Optimized CUDA kernels need to preserve synchronization semantics and exact unroll directives without rewriting generated CUDA source. The previous elect helper emitted an unused result, the existing CTA wait lacked acquire semantics, and `T.serial` could only request a bare unroll pragma.

## Validation

- Incremental TVM build
- Targeted parser/printer and CUDA codegen tests
- Full `tests/python/tirx/` suite: 2703 passed, 73 skipped, 3 xpassed
- Changed-file pre-commit hooks
- TinyGEMM2 SM100 correctness, Compute Sanitizer, SASS, NCU, and eight-workload performance validation in the downstream kernel repository
