### PR TITLE
fix(lower-tirx): support widened signed PTX loads

### DIFF
--- a/python/tvm/backend/cuda/ptx/table.py
+++ b/python/tvm/backend/cuda/ptx/table.py
@@ -177,6 +177,7 @@ class ModifierSlot:
 
 LanesFn = Callable[[dict], int]  # modifier map -> registers in this operand's group
 DtypeFn = Callable[[dict], str]  # modifier map -> this operand's PTX type token
+DtypesFn = Callable[[dict], tuple[str, ...]]  # modifier map -> accepted TVM dtypes
 
 
 @dataclass(frozen=True)
@@ -247,6 +248,12 @@ class OperandSlot:
     dataclass hashes a callable field by identity, so a fresh lambda per entry
     would make otherwise-equal slots compare unequal.
 
+    ``dtypes`` optionally narrows or widens the TVM dtype domain independently
+    of the ISA type. This is for operands whose register may legally exceed the
+    instruction type, such as the sign-extending destination of ``ld.s32``.
+    Like ``dtype``, a callable must be pure, total, and module-level. Leaving it
+    unset uses :data:`PTX_TYPE_DTYPES` for the resolved ISA type.
+
     ``lanes`` > 1 makes the operand a brace-enclosed register group. PTX writes
     the group in the operand list (``mov.b64 d, {lo, hi}``), so the group is
     part of the *shape*, never of the dotted modifier text.
@@ -257,6 +264,7 @@ class OperandSlot:
     kind: str = "reg"  # "reg" | "addr" | "ptr" | "imm"
     space: str | None = None
     dtype: str | DtypeFn | None = None
+    dtypes: tuple[str, ...] | DtypesFn | None = None
     # kind="imm" is a value in the instruction *text* (never a C parameter),
     # in one of three states, by who owns the value:
     #   literal set   -- the ISA fixed it; invisible to programs.
@@ -526,6 +534,10 @@ def operand_space(slot: OperandSlot, mod_map: dict) -> str:
 
 def operand_dtypes(slot: OperandSlot, mod_map: dict) -> tuple[str, ...]:
     """The TVM dtypes one operand accepts, canonical first (see PTX_TYPE_DTYPES)."""
+    if callable(slot.dtypes):
+        return slot.dtypes(mod_map)
+    if slot.dtypes is not None:
+        return slot.dtypes
     return PTX_TYPE_DTYPES[operand_type(slot, mod_map)]
 
 
@@ -981,6 +993,13 @@ _WIDE_RESULT = {"u16": "u32", "s16": "s32", "u32": "u64", "s32": "s64"}
 def _wide_dtype(m):
     """`.wide`'s double-width operand type (ISA 9.7.1.3/9.7.1.4)."""
     return _WIDE_RESULT[m["type"]]
+
+
+def _ld_dst_dtypes(m):
+    """Scalar ``ld.s32`` may sign-extend into a wider destination register."""
+    if m["type"] == "s32":
+        return ("int32", "int64")
+    return PTX_TYPE_DTYPES[m["type"]]
 
 
 def _dp_acc_dtype(m):
@@ -3690,7 +3709,7 @@ _ENTRIES = [
         ),
         check=_check_ld,
         operands=(
-            OperandSlot("d", rw="w"),
+            OperandSlot("d", rw="w", dtypes=_ld_dst_dtypes),
             OperandSlot("addr", kind="addr"),
             OperandSlot("cache_policy", dtype="u64", lanes=_present_lanes("cache"), vector=False),
         ),

--- a/tests/python/tirx/codegen/test_ptx_dialect.py
+++ b/tests/python/tirx/codegen/test_ptx_dialect.py
@@ -109,6 +109,28 @@ def test_ptx_ld_st_codegen():
     assert "tvm_builtin_ptx_st_release_gpu_global_b32" in src
 
 
+@requires_nvcc
+def test_ptx_ld_s32_wide_destination_codegen():
+    """A signed scalar load may sign-extend into a wider destination register."""
+
+    @T.prim_func
+    def kernel(a_ptr: T.handle, out_ptr: T.handle):
+        A = T.match_buffer(a_ptr, (32,), "int32")
+        Out = T.match_buffer(out_ptr, (32,), "int64")
+        T.device_entry()
+        T.cta_id([1])
+        tx = T.thread_id([32])
+        wide = T.local_scalar("int64")
+        T.ptx.ld.global_.s32(wide, A.ptr_to([tx]))
+        Out[tx] = wide
+
+    src = _cuda_source(kernel)
+    assert "tvm_builtin_ptx_ld_global_s32_s64(int64_t& __d" in src
+    assert 'asm volatile("ld.global.s32 %0, [%1];" : "=l"(__d)' in src
+    assert "cvt." not in src
+    _assert_ptxas_ok(src)
+
+
 def test_ptx_st_shared_coercion():
     @T.prim_func
     def kernel(out_ptr: T.handle):
@@ -1510,6 +1532,12 @@ def test_ptx_helper_source_golden():
         ' : "memory");\n'
         "}\n"
     )
+    assert render("ld", dtypes=("int64", "uint64"), space="global", type="s32") == (
+        "__forceinline__ __device__ void tvm_builtin_ptx_ld_global_s32_s64"
+        "(int64_t& __d, const void* __addr) {\n"
+        '  asm volatile("ld.global.s32 %0, [%1];" : "=l"(__d) : "l"(__addr) : "memory");\n'
+        "}\n"
+    )
     # 8-bit destination: no asm constraint of its own, so it rides a 16-bit
     # carrier register and is narrowed into the reference afterwards. The asm
     # block still holds exactly one instruction.
@@ -2173,7 +2201,7 @@ def test_ptx_all_variants_render_unique():
                     or f"; {opcode};" in source
                 )
             total += not predicated  # a @p twin is not a separate variant
-    assert total == 198709  # update when the table grows
+    assert total == 199987  # update when the table grows
 
 
 def test_ptx_no_instruction_registered_twice():


### PR DESCRIPTION
## Summary

- Allow scalar `ld.s32` to write either an `int32` or `int64` destination.
- Preserve the existing canonical helpers while generating a distinct 64-bit output helper.
- Certify the expanded PTX dialect surface through nvcc and ptxas.

## Motivation

PTX permits a signed load destination register to be wider than the instruction type, with sign extension to the destination width. TIRx previously rejected `T.ptx.ld.global_.s32` when its writable destination was `int64`, forcing kernels to inject inline CUDA for this single-instruction form.

The consuming migration is [spectrometerHBH/tirx-kernels#66](https://github.com/spectrometerHBH/tirx-kernels/pull/66).

## Validation

- Incremental TVM build.
- `pre-commit run --files python/tvm/backend/cuda/ptx/table.py tests/python/tirx/codegen/test_ptx_dialect.py`.
- Full `test_ptx_dialect.py`: 44 passed, 32 skipped.
- `PTX_CERT=1` full-table certification: 32 passed.
- Dependent STP correctness: 44/44 simple, 42/42 vertical, and 35/35 horizontal configurations.
- Dependent full paired TIRx suite: `2835 passed, 73 skipped, 3 xpassed`.
- Dependent bench-suite run: 82/82 clean workloads with every `flashinfer_cuda / tirx > 0.99`; overall minimum `0.9939865055x`.
