### PR TITLE
feat(tirx): fold the block-scaled tcgen05 descriptors at compile time

### DIFF
--- a/python/tvm/backend/cuda/cpp/descriptors.py
+++ b/python/tvm/backend/cuda/cpp/descriptors.py
@@ -554,3 +554,218 @@ device_intrinsic(
     c_signature="(uint32_t* desc, const uint32_t& sf_id)",
     body="    *desc = (*desc & ~0x60000030) | ((sf_id << 29) | (sf_id << 4));",
 )
+
+
+# ---------------------------------------------------------------------------
+# Compile-time folds of the same descriptors
+#
+# The encoders above are pure-C struct fills, so a call site whose descriptor
+# fields are all known at build time still pays for an opaque device helper the
+# generated CUDA must call and ptxas cannot hoist out of a loop. These fold the
+# identical bit layouts in Python instead, so such a call site can pass a
+# literal. They mirror the runtime encoders' validation exactly: a fold that
+# accepted a combination the runtime encoder rejects would be a silent
+# divergence between two spellings of one hardware format.
+# ---------------------------------------------------------------------------
+
+
+def _dtype_name(dtype) -> str:
+    """Name of a dtype given as a string, a DataType, or an object holding one."""
+    dtype_obj = getattr(dtype, "dtype", None)
+    if dtype_obj is not None:
+        return str(dtype_obj)
+    return str(dtype)
+
+
+# `a_format_` / `b_format_` / `d_format_`, mirroring `format_map` in the
+# runtime encoders above.
+_INSTR_DESC_FORMAT_MAP = {
+    "float16": 0,
+    "bfloat16": 1,
+    "tensor_float32": 2,
+    "tf32": 2,
+    "float8_e4m3fn": 0,
+    "float8_e4m3fnuz": 0,
+    "float8_e5m2": 1,
+    "float6_e2m3fn": 3,
+    "float6_e3m2fn": 4,
+    "float4_e2m1fn": 5,
+    "uint8": 0,
+    "int8": 1,
+    "float32": 1,
+    "int32": 2,
+}
+
+# `scale_format_` of the block-scaled descriptor: 0 = E4M3, 1 = E8M0.
+_INSTR_DESC_SF_FORMAT_MAP = {
+    "float8_e4m3fn": 0,
+    "float8_e4m3fnuz": 0,
+    "float8_e8m0fnu": 1,
+}
+
+# `layout_type_` of SmemDescriptor, keyed by the swizzle enum the runtime
+# encoder switches on (0=none, 1=32B, 2=64B, 3=128B, 4=128B_base32B).
+_SMEM_DESC_LAYOUT_TYPE = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}
+
+# PTXDataType spells tensor-float32 as "tf32".
+_PTX_DTYPE_ALIAS = {"tensor_float32": "tf32"}
+
+
+def _check_instr_desc_trans(a_ptx_name, b_ptx_name, trans_a, trans_b):
+    """Only a few source formats may be MN-major, per the descriptor's comment."""
+    if trans_a and PTXDataType.from_string(a_ptx_name) not in _TCGEN05_MMA_TRANS_DTYPES:
+        raise ValueError(f"Invalid a_dtype for transpose: {a_ptx_name}")
+    if trans_b and PTXDataType.from_string(b_ptx_name) not in _TCGEN05_MMA_TRANS_DTYPES:
+        raise ValueError(f"Invalid b_dtype for transpose: {b_ptx_name}")
+
+
+def _instr_desc_common_bits(M, N, a_format, b_format, trans_a, trans_b, neg_a, neg_b, is_sparse):
+    """The nine fields the dense and block-scaled descriptors share.
+
+    They encode the same hardware bitfield and differ only in what each adds:
+    the dense line owns `saturate_`/`d_format_`, the block-scaled one
+    `scale_format_`. Keeping the shared bits in one place is what stops a
+    correction landing in only one of them.
+    """
+    desc = 0
+    desc |= (int(is_sparse) & 0x1) << 2
+    desc |= (a_format & 0x7) << 7
+    desc |= (b_format & 0x7) << 10
+    desc |= (int(neg_a) & 0x1) << 13
+    desc |= (int(neg_b) & 0x1) << 14
+    desc |= (int(trans_a) & 0x1) << 15
+    desc |= (int(trans_b) & 0x1) << 16
+    desc |= ((N >> 3) & 0x3F) << 17
+    desc |= ((M >> 4) & 0x1F) << 24
+    return desc
+
+
+def encode_instr_descriptor_dense_uint32(
+    M,
+    N,
+    K,
+    d_dtype,
+    a_dtype,
+    b_dtype,
+    trans_a,
+    trans_b,
+    cta_group=1,
+    neg_a=False,
+    neg_b=False,
+    sat_d=False,
+    is_sparse=False,
+):
+    """Compile-time fold of `codegen_cuda_tcgen05_encode_instr_descriptor`.
+
+    Bit layout: `InstrDescriptor` in `python/tvm/backend/cuda/codegen/header.py`.
+
+    The validation is the runtime encoder's, deliberately: cta_group=1 M=128
+    requires N % 16 == 0, which a tile chooser enforcing only N % 8 does not
+    guarantee.
+    """
+    d_name = _dtype_name(d_dtype)
+    a_name = _dtype_name(a_dtype)
+    b_name = _dtype_name(b_dtype)
+    d_ptx = _PTX_DTYPE_ALIAS.get(d_name, d_name)
+    a_ptx = _PTX_DTYPE_ALIAS.get(a_name, a_name)
+    b_ptx = _PTX_DTYPE_ALIAS.get(b_name, b_name)
+
+    kind = _get_tcgen05_mma_kind(d_ptx, a_ptx, b_ptx)
+    if kind not in ("f16", "tf32", "f8f6f4", "i8"):
+        raise ValueError(
+            f"Check failed for Data Type Kind. d_dtype: {d_name}, "
+            f"a_dtype: {a_name}, b_dtype: {b_name}"
+        )
+    _check_tcgen05_mma_matrix_shape(kind, cta_group, int(M), int(N), int(K), is_sparse)
+    _check_instr_desc_trans(a_ptx, b_ptx, trans_a, trans_b)
+
+    desc = _instr_desc_common_bits(
+        M,
+        N,
+        _INSTR_DESC_FORMAT_MAP[a_name],
+        _INSTR_DESC_FORMAT_MAP[b_name],
+        trans_a,
+        trans_b,
+        neg_a,
+        neg_b,
+        is_sparse,
+    )
+    desc |= (int(sat_d) & 0x1) << 3
+    desc |= (_INSTR_DESC_FORMAT_MAP[d_name] & 0x3) << 4
+    return desc & 0xFFFFFFFF
+
+
+def encode_instr_descriptor_block_scaled_uint32(
+    M,
+    N,
+    K,
+    d_dtype,
+    a_dtype,
+    b_dtype,
+    sf_dtype,
+    trans_a,
+    trans_b,
+    cta_group=1,
+    neg_a=False,
+    neg_b=False,
+    is_sparse=False,
+):
+    """Compile-time fold of `codegen_cuda_tcgen05_encode_instr_descriptor_block_scaled`.
+
+    Bit layout: `InstrDescriptorBlockScaled` in
+    `python/tvm/backend/cuda/codegen/header.py`.
+    """
+    d_name = _dtype_name(d_dtype)
+    a_name = _dtype_name(a_dtype)
+    b_name = _dtype_name(b_dtype)
+    sf_name = _dtype_name(sf_dtype)
+    d_ptx = _PTX_DTYPE_ALIAS.get(d_name, d_name)
+    a_ptx = _PTX_DTYPE_ALIAS.get(a_name, a_name)
+    b_ptx = _PTX_DTYPE_ALIAS.get(b_name, b_name)
+
+    kind = _get_tcgen05_mma_kind(d_ptx, a_ptx, b_ptx, sf_name, sf_name)
+    valid_kinds = {"mxf8f6f4", "mxf4", "mxf4nvf4"}
+    if kind not in valid_kinds:
+        raise ValueError(
+            f"Check failed for Data Type Kind. Expected one of {valid_kinds}, but got "
+            f"'{kind}' for d:{d_name}, a:{a_name}, b:{b_name}, sf:{sf_name}"
+        )
+    _check_tcgen05_mma_matrix_shape(kind, cta_group, int(M), int(N), int(K), is_sparse)
+    _check_instr_desc_trans(a_ptx, b_ptx, trans_a, trans_b)
+
+    # mxf4 / mxf4nvf4 pin both operand formats to 1; only mxf8f6f4 reads them
+    # off the dtypes. Same branch as the runtime encoder.
+    if kind == "mxf8f6f4":
+        a_format = _INSTR_DESC_FORMAT_MAP[a_name]
+        b_format = _INSTR_DESC_FORMAT_MAP[b_name]
+    else:
+        a_format = 1
+        b_format = 1
+
+    desc = _instr_desc_common_bits(
+        M, N, a_format, b_format, trans_a, trans_b, neg_a, neg_b, is_sparse
+    )
+    desc |= (_INSTR_DESC_SF_FORMAT_MAP[sf_name] & 0x1) << 23
+    # `a_sf_id_` / `b_sf_id_` stay 0, as the runtime encoder leaves them:
+    # callers that cycle scale-factor ids patch those bits per MMA.
+    return desc & 0xFFFFFFFF
+
+
+def encode_smem_descriptor_base_uint64(ldo, sdo, swizzle):
+    """Compile-time fold of `codegen_cuda_tcgen05_encode_matrix_descriptor`, minus
+    the address.
+
+    `start_address_` is the only runtime input, so the descriptor splits into a
+    constant the caller bakes in and an `addr >> 4` it ORs into bits [0,14).
+    Bit layout: `SmemDescriptor` in `python/tvm/backend/cuda/codegen/header.py`.
+
+    `ldo` / `sdo` are in 16-byte units, matching what the runtime encoder
+    assigns straight into the two offset fields.
+    """
+    desc = 0
+    desc |= (int(ldo) & 0x3FFF) << 16
+    desc |= (int(sdo) & 0x3FFF) << 32
+    desc |= 1 << 46  # version_
+    # base_offset_ [49,52) and lbo_mode_ [52,53) are zero, as the encoder sets.
+    desc |= (_SMEM_DESC_LAYOUT_TYPE[int(swizzle)] & 0x7) << 61
+    return desc & 0xFFFFFFFFFFFFFFFF

--- a/python/tvm/backend/cuda/tile_primitive/gemm_async/tcgen05.py
+++ b/python/tvm/backend/cuda/tile_primitive/gemm_async/tcgen05.py
@@ -160,6 +160,113 @@ def _encode_instr_descriptor_dense_uint32(
     return desc & 0xFFFFFFFF
 
 
+# Scale-factor formats of the block-scaled descriptor, per its `scale_format_`
+# comment: 0 = E4M3, 1 = E8M0.
+_INSTR_DESC_SF_FORMAT_MAP = {
+    "float8_e4m3fn": 0,
+    "float8_e4m3fnuz": 0,
+    "float8_e8m0fnu": 1,
+}
+
+
+def _encode_instr_descriptor_block_scaled_uint32(
+    M,
+    N,
+    K,
+    d_dtype,
+    a_dtype,
+    b_dtype,
+    sf_dtype,
+    trans_a,
+    trans_b,
+    cta_group=1,
+    neg_a=False,
+    neg_b=False,
+    is_sparse=False,
+):
+    """Compile-time port of the block-scaled ``InstrDescriptor`` packing.
+
+    The block-scaled sibling of :func:`_encode_instr_descriptor_dense_uint32`,
+    for the same reason: a kernel whose descriptor inputs are all compile-time
+    constants should pass a literal ``uint32`` rather than call the runtime
+    encoder, which is a pure-C bitfield fill that becomes an opaque helper in
+    the generated CUDA.
+
+    Bit layout: ``InstrDescriptorBlockScaled`` in
+    ``python/tvm/backend/cuda/cpp/descriptors.py``. Validation mirrors the
+    runtime encoder (``codegen_cuda_tcgen05_encode_instr_descriptor_block_scaled``)
+    so the fold rejects exactly what it rejects.
+    """
+    d_name = _dtype_name(d_dtype)
+    a_name = _dtype_name(a_dtype)
+    b_name = _dtype_name(b_dtype)
+    sf_name = _dtype_name(sf_dtype)
+
+    kind = _get_tcgen05_mma_kind(d_name, a_name, b_name, sf_name, sf_name)
+    valid_kinds = {"mxf8f6f4", "mxf4", "mxf4nvf4"}
+    if kind not in valid_kinds:
+        raise ValueError(
+            f"Check failed for Data Type Kind. Expected one of {valid_kinds}, but got "
+            f"'{kind}' for d:{d_name}, a:{a_name}, b:{b_name}, sf:{sf_name}"
+        )
+    _check_tcgen05_mma_matrix_shape(kind, cta_group, int(M), int(N), int(K), is_sparse)
+
+    # mxf4 / mxf4nvf4 pin both operand formats to 1; only mxf8f6f4 reads them
+    # off the dtypes. Same branch as the runtime encoder.
+    if kind == "mxf8f6f4":
+        a_format = _INSTR_DESC_FORMAT_MAP[a_name]
+        b_format = _INSTR_DESC_FORMAT_MAP[b_name]
+    else:
+        a_format = 1
+        b_format = 1
+
+    if trans_a and PTXDataType.from_string(a_name) not in _TCGEN05_MMA_TRANS_DTYPES:
+        raise ValueError(f"Invalid a_dtype for transpose: {a_name}")
+    if trans_b and PTXDataType.from_string(b_name) not in _TCGEN05_MMA_TRANS_DTYPES:
+        raise ValueError(f"Invalid b_dtype for transpose: {b_name}")
+
+    desc = 0
+    desc |= (int(is_sparse) & 0x1) << 2
+    desc |= (a_format & 0x7) << 7
+    desc |= (b_format & 0x7) << 10
+    desc |= (int(neg_a) & 0x1) << 13
+    desc |= (int(neg_b) & 0x1) << 14
+    desc |= (int(trans_a) & 0x1) << 15
+    desc |= (int(trans_b) & 0x1) << 16
+    desc |= ((N >> 3) & 0x3F) << 17
+    desc |= (_INSTR_DESC_SF_FORMAT_MAP[sf_name] & 0x1) << 23
+    desc |= ((M >> 4) & 0x1F) << 24
+    # a_sf_id_/b_sf_id_ stay 0, as the runtime encoder leaves them: callers that
+    # cycle scale-factor ids patch those bits per MMA.
+    return desc & 0xFFFFFFFF
+
+
+# `layout_type_` of SmemDescriptor, keyed by the swizzle enum the runtime
+# encoder switches on (0=none, 1=32B, 2=64B, 3=128B, 4=128B_base32B).
+_SMEM_DESC_LAYOUT_TYPE = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}
+
+
+def _encode_smem_descriptor_base_uint64(ldo, sdo, swizzle):
+    """Compile-time port of the ``SmemDescriptor`` packing, minus the address.
+
+    Everything but ``start_address_`` is a compile-time constant in a kernel
+    whose tile shape is fixed, so the descriptor splits cleanly into a constant
+    the caller can bake in and a runtime `addr >> 4` it ORs into bits [0,14).
+    Bit layout: ``SmemDescriptor`` in
+    ``python/tvm/backend/cuda/cpp/descriptors.py``.
+
+    ``ldo``/``sdo`` are in 16-byte units, matching what the runtime encoder
+    assigns straight into the two offset fields.
+    """
+    desc = 0
+    desc |= (int(ldo) & 0x3FFF) << 16
+    desc |= (int(sdo) & 0x3FFF) << 32
+    desc |= 1 << 46  # version_
+    # base_offset_ [49,52) and lbo_mode_ [52,53) are zero, as the encoder sets.
+    desc |= (_SMEM_DESC_LAYOUT_TYPE[int(swizzle)] & 0x7) << 61
+    return desc & 0xFFFFFFFFFFFFFFFF
+
+
 def sf_smem_layout(rows, SF_K, sf_per_mma, sf_reuse=1, pipe_depth=None):
     """SMEM-side layout for SF in tcgen05.cp scale-factor copy.
 

--- a/python/tvm/backend/cuda/tile_primitive/gemm_async/tcgen05.py
+++ b/python/tvm/backend/cuda/tile_primitive/gemm_async/tcgen05.py
@@ -46,12 +46,12 @@ from tvm.tirx.operator.tile_primitive import DispatchContext, predicate, registe
 from tvm.tirx.stmt import AllocBuffer, Evaluate, SeqStmt
 from tvm.tirx.tile_primitive import TilePrimitiveCall
 
-from ...codegen.types import PTXDataType
 from ...cpp.descriptors import (
-    _TCGEN05_MMA_TRANS_DTYPES,
     _check_tcgen05_mma_matrix_shape,
+    _dtype_name,
     _get_tcgen05_mma_kind,
     _get_tcgen05_mma_scale_vec_size,
+    encode_instr_descriptor_dense_uint32,
 )
 from ..common import get_st_extent, smem_desc_add_16B_offset
 from ..exec_scope_utils import single_thread
@@ -62,209 +62,6 @@ from ..tma_utils import (
     mma_atom_layout,
     mma_atom_shape,
 )
-
-# Mirror of ``format_map`` in the dense ``encode_instr_descriptor`` codegen
-# (``python/tvm/backend/cuda/cpp/descriptors.py``). Used to fold the
-# runtime-encoded instruction descriptor into a compile-time uint32 when
-# all parameters are dispatch-time constants.
-_INSTR_DESC_FORMAT_MAP = {
-    "float16": 0,
-    "bfloat16": 1,
-    "tensor_float32": 2,
-    "tf32": 2,
-    "float8_e4m3fn": 0,
-    "float8_e4m3fnuz": 0,
-    "float8_e5m2": 1,
-    "float6_e2m3fn": 3,
-    "float6_e3m2fn": 4,
-    "float4_e2m1fn": 5,
-    "uint8": 0,
-    "int8": 1,
-    "float32": 1,
-    "int32": 2,
-}
-
-
-def _dtype_name(dtype) -> str:
-    dtype_obj = getattr(dtype, "dtype", None)
-    if dtype_obj is not None:
-        return str(dtype_obj)
-    return str(dtype)
-
-
-def _encode_instr_descriptor_dense_uint32(
-    M,
-    N,
-    K,
-    d_dtype,
-    a_dtype,
-    b_dtype,
-    trans_a,
-    trans_b,
-    cta_group=1,
-    neg_a=False,
-    neg_b=False,
-    sat_d=False,
-    is_sparse=False,
-):
-    """Compile-time port of the dense ``InstrDescriptor`` bitfield packing.
-
-    See ``python/tvm/backend/cuda/codegen/header.py:InstrDescriptor``
-    for the bit layout. Lets the dispatcher pass a literal ``uint32`` to
-    ``T.ptx["tcgen05.mma..."]`` instead of allocating + encoding a per-dispatch
-    local descriptor on every gemm_async call (which forces an inline ``asm``
-    block that ptxas cannot hoist out of the i_kv loop body).
-
-    Mirrors the runtime encoder's validation
-    (``codegen_cuda_tcgen05_encode_instr_descriptor``): the compile-time fold
-    must not accept kind/shape/trans combinations the runtime encoder would
-    reject — e.g. cta_group=1 M=128 requires N % 16 == 0, which the tile
-    chooser alone does not guarantee (it only enforces N % 8).
-    """
-    d_dtype = _dtype_name(d_dtype)
-    a_dtype = _dtype_name(a_dtype)
-    b_dtype = _dtype_name(b_dtype)
-
-    # PTXDataType spells tensor-float32 as "tf32".
-    _PTX_NAME = {"tensor_float32": "tf32"}
-    d_ptx_name = _PTX_NAME.get(d_dtype, d_dtype)
-    a_ptx_name = _PTX_NAME.get(a_dtype, a_dtype)
-    b_ptx_name = _PTX_NAME.get(b_dtype, b_dtype)
-    kind = _get_tcgen05_mma_kind(d_ptx_name, a_ptx_name, b_ptx_name)
-    if kind not in ("f16", "tf32", "f8f6f4", "i8"):
-        raise ValueError(
-            f"Check failed for Data Type Kind. d_dtype: {d_dtype}, "
-            f"a_dtype: {a_dtype}, b_dtype: {b_dtype}"
-        )
-    _check_tcgen05_mma_matrix_shape(kind, cta_group, int(M), int(N), int(K), is_sparse)
-    if trans_a and PTXDataType.from_string(a_ptx_name) not in _TCGEN05_MMA_TRANS_DTYPES:
-        raise ValueError(f"Invalid a_dtype for transpose: {a_dtype}")
-    if trans_b and PTXDataType.from_string(b_ptx_name) not in _TCGEN05_MMA_TRANS_DTYPES:
-        raise ValueError(f"Invalid b_dtype for transpose: {b_dtype}")
-
-    d_format = _INSTR_DESC_FORMAT_MAP[d_dtype]
-    a_format = _INSTR_DESC_FORMAT_MAP[a_dtype]
-    b_format = _INSTR_DESC_FORMAT_MAP[b_dtype]
-    desc = 0
-    desc |= (int(is_sparse) & 0x1) << 2
-    desc |= (int(sat_d) & 0x1) << 3
-    desc |= (d_format & 0x3) << 4
-    desc |= (a_format & 0x7) << 7
-    desc |= (b_format & 0x7) << 10
-    desc |= (int(neg_a) & 0x1) << 13
-    desc |= (int(neg_b) & 0x1) << 14
-    desc |= (int(trans_a) & 0x1) << 15
-    desc |= (int(trans_b) & 0x1) << 16
-    desc |= ((N >> 3) & 0x3F) << 17
-    desc |= ((M >> 4) & 0x1F) << 24
-    return desc & 0xFFFFFFFF
-
-
-# Scale-factor formats of the block-scaled descriptor, per its `scale_format_`
-# comment: 0 = E4M3, 1 = E8M0.
-_INSTR_DESC_SF_FORMAT_MAP = {
-    "float8_e4m3fn": 0,
-    "float8_e4m3fnuz": 0,
-    "float8_e8m0fnu": 1,
-}
-
-
-def _encode_instr_descriptor_block_scaled_uint32(
-    M,
-    N,
-    K,
-    d_dtype,
-    a_dtype,
-    b_dtype,
-    sf_dtype,
-    trans_a,
-    trans_b,
-    cta_group=1,
-    neg_a=False,
-    neg_b=False,
-    is_sparse=False,
-):
-    """Compile-time port of the block-scaled ``InstrDescriptor`` packing.
-
-    The block-scaled sibling of :func:`_encode_instr_descriptor_dense_uint32`,
-    for the same reason: a kernel whose descriptor inputs are all compile-time
-    constants should pass a literal ``uint32`` rather than call the runtime
-    encoder, which is a pure-C bitfield fill that becomes an opaque helper in
-    the generated CUDA.
-
-    Bit layout: ``InstrDescriptorBlockScaled`` in
-    ``python/tvm/backend/cuda/cpp/descriptors.py``. Validation mirrors the
-    runtime encoder (``codegen_cuda_tcgen05_encode_instr_descriptor_block_scaled``)
-    so the fold rejects exactly what it rejects.
-    """
-    d_name = _dtype_name(d_dtype)
-    a_name = _dtype_name(a_dtype)
-    b_name = _dtype_name(b_dtype)
-    sf_name = _dtype_name(sf_dtype)
-
-    kind = _get_tcgen05_mma_kind(d_name, a_name, b_name, sf_name, sf_name)
-    valid_kinds = {"mxf8f6f4", "mxf4", "mxf4nvf4"}
-    if kind not in valid_kinds:
-        raise ValueError(
-            f"Check failed for Data Type Kind. Expected one of {valid_kinds}, but got "
-            f"'{kind}' for d:{d_name}, a:{a_name}, b:{b_name}, sf:{sf_name}"
-        )
-    _check_tcgen05_mma_matrix_shape(kind, cta_group, int(M), int(N), int(K), is_sparse)
-
-    # mxf4 / mxf4nvf4 pin both operand formats to 1; only mxf8f6f4 reads them
-    # off the dtypes. Same branch as the runtime encoder.
-    if kind == "mxf8f6f4":
-        a_format = _INSTR_DESC_FORMAT_MAP[a_name]
-        b_format = _INSTR_DESC_FORMAT_MAP[b_name]
-    else:
-        a_format = 1
-        b_format = 1
-
-    if trans_a and PTXDataType.from_string(a_name) not in _TCGEN05_MMA_TRANS_DTYPES:
-        raise ValueError(f"Invalid a_dtype for transpose: {a_name}")
-    if trans_b and PTXDataType.from_string(b_name) not in _TCGEN05_MMA_TRANS_DTYPES:
-        raise ValueError(f"Invalid b_dtype for transpose: {b_name}")
-
-    desc = 0
-    desc |= (int(is_sparse) & 0x1) << 2
-    desc |= (a_format & 0x7) << 7
-    desc |= (b_format & 0x7) << 10
-    desc |= (int(neg_a) & 0x1) << 13
-    desc |= (int(neg_b) & 0x1) << 14
-    desc |= (int(trans_a) & 0x1) << 15
-    desc |= (int(trans_b) & 0x1) << 16
-    desc |= ((N >> 3) & 0x3F) << 17
-    desc |= (_INSTR_DESC_SF_FORMAT_MAP[sf_name] & 0x1) << 23
-    desc |= ((M >> 4) & 0x1F) << 24
-    # a_sf_id_/b_sf_id_ stay 0, as the runtime encoder leaves them: callers that
-    # cycle scale-factor ids patch those bits per MMA.
-    return desc & 0xFFFFFFFF
-
-
-# `layout_type_` of SmemDescriptor, keyed by the swizzle enum the runtime
-# encoder switches on (0=none, 1=32B, 2=64B, 3=128B, 4=128B_base32B).
-_SMEM_DESC_LAYOUT_TYPE = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}
-
-
-def _encode_smem_descriptor_base_uint64(ldo, sdo, swizzle):
-    """Compile-time port of the ``SmemDescriptor`` packing, minus the address.
-
-    Everything but ``start_address_`` is a compile-time constant in a kernel
-    whose tile shape is fixed, so the descriptor splits cleanly into a constant
-    the caller can bake in and a runtime `addr >> 4` it ORs into bits [0,14).
-    Bit layout: ``SmemDescriptor`` in
-    ``python/tvm/backend/cuda/cpp/descriptors.py``.
-
-    ``ldo``/``sdo`` are in 16-byte units, matching what the runtime encoder
-    assigns straight into the two offset fields.
-    """
-    desc = 0
-    desc |= (int(ldo) & 0x3FFF) << 16
-    desc |= (int(sdo) & 0x3FFF) << 32
-    desc |= 1 << 46  # version_
-    # base_offset_ [49,52) and lbo_mode_ [52,53) are zero, as the encoder sets.
-    desc |= (_SMEM_DESC_LAYOUT_TYPE[int(swizzle)] & 0x7) << 61
-    return desc & 0xFFFFFFFFFFFFFFFF
 
 
 def sf_smem_layout(rows, SF_K, sf_per_mma, sf_reuse=1, pipe_depth=None):
@@ -1652,7 +1449,7 @@ def gemm_async_tcgen05_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -
         # ``alignas(64) uint descI_local[1]; encode_instr_descriptor(...)``
         # block. The encoded value depends only on (M, N, dtype, transA,
         # transB) which are all constants here.
-        descI_value = _encode_instr_descriptor_dense_uint32(
+        descI_value = encode_instr_descriptor_dense_uint32(
             M=M_mma * cta_group,
             N=N_mma,
             K=MMA_K,

--- a/tests/python/tirx/codegen/test_tcgen05_descriptor_encoders.py
+++ b/tests/python/tirx/codegen/test_tcgen05_descriptor_encoders.py
@@ -16,8 +16,8 @@
 # under the License.
 """The compile-time tcgen05 descriptor encoders must agree with the C ones.
 
-``_encode_smem_descriptor_base_uint64`` and
-``_encode_instr_descriptor_block_scaled_uint32`` re-derive, in Python, bit
+``encode_smem_descriptor_base_uint64`` and
+``encode_instr_descriptor_block_scaled_uint32`` re-derive, in Python, bit
 layouts that otherwise live only in a C struct (``cuda/cpp/descriptors.py``). A
 kernel whose descriptor inputs are all compile-time constants uses them to bake
 a literal instead of calling the runtime encoder, which is an opaque helper in
@@ -32,9 +32,9 @@ import pytest
 
 import tvm
 import tvm.testing
-from tvm.backend.cuda.tile_primitive.gemm_async.tcgen05 import (
-    _encode_instr_descriptor_block_scaled_uint32,
-    _encode_smem_descriptor_base_uint64,
+from tvm.backend.cuda.cpp.descriptors import (
+    encode_instr_descriptor_block_scaled_uint32,
+    encode_smem_descriptor_base_uint64,
 )
 from tvm.script import tirx as T
 from tvm.testing import env
@@ -88,7 +88,7 @@ def test_smem_descriptor_matches_runtime_encoder(ldo, sdo, swizzle):
             out[1] = T.cast(T.cuda.cvta_generic_to_shared(smem.ptr_to([0])), "uint64")
 
     got = _compile_and_run(kernel, 2)
-    want = _encode_smem_descriptor_base_uint64(ldo, sdo, swizzle) | ((int(got[1]) >> 4) & 0x3FFF)
+    want = encode_smem_descriptor_base_uint64(ldo, sdo, swizzle) | ((int(got[1]) >> 4) & 0x3FFF)
     assert int(got[0]) == want, (
         f"runtime {int(got[0]):#018x} != compile-time {want:#018x} "
         f"for ldo={ldo} sdo={sdo} swizzle={swizzle}"
@@ -137,7 +137,7 @@ def test_instr_descriptor_block_scaled_matches_runtime_encoder(
             out[0] = T.cast(desc, "uint64")
 
     got = _compile_and_run(kernel, 1)
-    want = _encode_instr_descriptor_block_scaled_uint32(
+    want = encode_instr_descriptor_block_scaled_uint32(
         M=m,
         N=n,
         K=k,

--- a/tests/python/tirx/codegen/test_tcgen05_descriptor_encoders.py
+++ b/tests/python/tirx/codegen/test_tcgen05_descriptor_encoders.py
@@ -1,0 +1,160 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""The compile-time tcgen05 descriptor encoders must agree with the C ones.
+
+``_encode_smem_descriptor_base_uint64`` and
+``_encode_instr_descriptor_block_scaled_uint32`` re-derive, in Python, bit
+layouts that otherwise live only in a C struct (``cuda/cpp/descriptors.py``). A
+kernel whose descriptor inputs are all compile-time constants uses them to bake
+a literal instead of calling the runtime encoder, which is an opaque helper in
+the generated CUDA.
+
+Re-deriving a bit layout by hand is exactly the kind of thing that is silently
+wrong, so these run both encoders on the same inputs and compare.
+"""
+
+import numpy as np
+import pytest
+
+import tvm
+import tvm.testing
+from tvm.backend.cuda.tile_primitive.gemm_async.tcgen05 import (
+    _encode_instr_descriptor_block_scaled_uint32,
+    _encode_smem_descriptor_base_uint64,
+)
+from tvm.script import tirx as T
+from tvm.testing import env
+
+TARGET = tvm.target.Target("cuda")
+
+
+def _compile_and_run(kernel, n_out):
+    with TARGET:
+        mod = tvm.compile(tvm.IRModule({"main": kernel}), target=TARGET, tir_pipeline="tirx")
+    result = {}
+
+    def go():
+        dev = tvm.cuda(0)
+        out = tvm.runtime.tensor(np.zeros(n_out, dtype="uint64"), device=dev)
+        mod(out)
+        result["out"] = out.numpy()
+
+    tvm.testing.run_with_gpu_lock(go)
+    return result["out"]
+
+
+# One case per axis the SMEM encoder branches on: every swizzle enum, and
+# offsets that exercise both 14-bit fields.
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+@pytest.mark.parametrize(
+    "ldo,sdo,swizzle",
+    [(0, 8, 0), (0, 8, 3), (64, 128, 2), (32, 64, 1), (16, 16, 4)],
+)
+def test_smem_descriptor_matches_runtime_encoder(ldo, sdo, swizzle):
+    """`base | (addr >> 4)` must reproduce the C bitfield fill exactly."""
+
+    @T.prim_func
+    def kernel(out_ptr: T.handle):
+        out = T.match_buffer(out_ptr, (2,), "uint64")
+        T.device_entry()
+        T.cta_id([1])
+        tx = T.thread_id([32])
+        smem = T.alloc_buffer((64,), "uint32", scope="shared")
+        smem[tx] = T.uint32(0)
+        smem[tx + 32] = T.uint32(0)
+        if tx == 0:
+            desc = T.local_scalar("uint64")
+            T.cuda.tcgen05.encode_matrix_descriptor(
+                T.address_of(desc), smem.ptr_to([0]), ldo=ldo, sdo=sdo, swizzle=swizzle
+            )
+            out[0] = desc
+            # The shared address is the encoder's only runtime input; hand it
+            # back so the comparison can OR it into the Python constant.
+            out[1] = T.cast(T.cuda.cvta_generic_to_shared(smem.ptr_to([0])), "uint64")
+
+    got = _compile_and_run(kernel, 2)
+    want = _encode_smem_descriptor_base_uint64(ldo, sdo, swizzle) | ((int(got[1]) >> 4) & 0x3FFF)
+    assert int(got[0]) == want, (
+        f"runtime {int(got[0]):#018x} != compile-time {want:#018x} "
+        f"for ldo={ldo} sdo={sdo} swizzle={swizzle}"
+    )
+
+
+# (M, N, K, a_dtype, b_dtype, trans_a, trans_b, cta_group)
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+@pytest.mark.parametrize(
+    "m,n,k,a_dtype,b_dtype,trans_a,trans_b,cta_group",
+    [
+        (128, 224, 32, "float8_e4m3fn", "float8_e4m3fn", False, False, 1),
+        (128, 128, 32, "float8_e4m3fn", "float8_e4m3fn", True, True, 1),
+        (256, 256, 32, "float8_e4m3fn", "float8_e5m2", False, True, 2),
+        (128, 64, 64, "float4_e2m1fn", "float4_e2m1fn", False, False, 1),
+    ],
+)
+def test_instr_descriptor_block_scaled_matches_runtime_encoder(
+    m, n, k, a_dtype, b_dtype, trans_a, trans_b, cta_group
+):
+    @T.prim_func
+    def kernel(out_ptr: T.handle):
+        out = T.match_buffer(out_ptr, (1,), "uint64")
+        T.device_entry()
+        T.cta_id([1])
+        tx = T.thread_id([32])
+        if tx == 0:
+            desc = T.local_scalar("uint32")
+            T.cuda.tcgen05.encode_instr_descriptor_block_scaled(
+                T.address_of(desc),
+                d_dtype="float32",
+                a_dtype=a_dtype,
+                b_dtype=b_dtype,
+                sfa_dtype="float8_e8m0fnu",
+                sfb_dtype="float8_e8m0fnu",
+                sfa_tmem_addr=0,
+                sfb_tmem_addr=0,
+                M=m,
+                N=n,
+                K=k,
+                trans_a=trans_a,
+                trans_b=trans_b,
+                n_cta_groups=cta_group,
+            )
+            out[0] = T.cast(desc, "uint64")
+
+    got = _compile_and_run(kernel, 1)
+    want = _encode_instr_descriptor_block_scaled_uint32(
+        M=m,
+        N=n,
+        K=k,
+        d_dtype="float32",
+        a_dtype=a_dtype,
+        b_dtype=b_dtype,
+        sf_dtype="float8_e8m0fnu",
+        trans_a=trans_a,
+        trans_b=trans_b,
+        cta_group=cta_group,
+    )
+    assert int(got[0]) == want, (
+        f"runtime {int(got[0]):#010x} != compile-time {want:#010x} "
+        f"for M={m} N={n} a={a_dtype} b={b_dtype} trans=({trans_a},{trans_b}) "
+        f"cta_group={cta_group}"
+    )
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
`encode_instr_descriptor_dense_uint32` already exists so a gemm_async dispatch can hand `T.ptx["tcgen05.mma..."]` a literal instead of allocating and encoding a descriptor on every call — the runtime encoder is a pure-C bitfield fill, which becomes an opaque helper the generated CUDA has to call and ptxas cannot hoist out of a loop.

A kernel driving the **block-scaled** MMA wants the same deal, and so does the SMEM matrix descriptor, whose only runtime input is the shared address. This adds both:

- `encode_instr_descriptor_block_scaled_uint32` — the block-scaled sibling. It repeats the runtime encoder's validation (kind, matrix shape, per-dtype transpose legality) so the fold cannot accept a combination the runtime encoder would reject.
- `encode_smem_descriptor_base_uint64` — everything except `start_address_`; the caller ORs in `addr >> 4`.

### Where they live

All three folds sit in `cuda/cpp/descriptors.py`, next to the runtime encoders they mirror and one file away from the `codegen/header.py` unions that define the bit layouts. They started out in `tile_primitive/gemm_async/tcgen05.py`, which was the wrong home twice over: the folds already imported four private helpers upward from `descriptors.py`, and the module's own docstring claims the charter ("Matrix and instruction descriptor encoding for wgmma / tcgen05… `tile_primitive/gemm_async/tcgen05.py` reuses them"). The one in-tree caller now imports the dense fold back.

Co-locating them also lets the dense and block-scaled folds share what they always shared — the transpose-dtype check and the nine descriptor bits that are identical between them — instead of keeping two hand-maintained copies of a layout that must not drift. The dense fold picks up the new device parity test over those bits as a result.

The three are public because a kernel outside this repo consumes two of them; an underscore-private name is not an API another repository should be pinned to.

### Why the test

The folds re-derive, in Python, bit layouts that otherwise live only in the C structs. That is exactly the kind of duplication that is silently wrong, so `tests/python/tirx/codegen/test_tcgen05_descriptor_encoders.py` runs each against its C counterpart on device and compares the words: five cases covering every swizzle enum and both offset fields, four covering the MMA shapes including `cta_group=2` and the `mxf4` kinds.

### Context

Driven by the SM100 FP8/FP4 1D1D GEMM port in `tirx-kernels`, whose descriptor inputs are all build-time constants — it folds all four of its descriptors and keeps only `addr >> 4` at run time.

Everything else that port needed (`elect.sync`, `shfl.sync`, and the `pipe` spelling for `d|p` destinations) already landed in #20110, so this is the only piece left.
