### PR TITLE
fix(lower-tirx): support no-hint mbarrier parity waits

### DIFF
--- a/python/tvm/backend/cuda/ptx/table.py
+++ b/python/tvm/backend/cuda/ptx/table.py
@@ -6240,8 +6240,7 @@ _ENTRIES = [
     # mbarrier.try_wait.parity{.sem.scope}{.ss}.b64 waitComplete, [addr], phaseParity, timeHint;
     #
     # waitComplete is a `.pred` result -- rw="w", dtype="pred", the in-block selp
-    # materialization. try_wait is registered in its timeHint arity only (the
-    # hint is a nanosecond budget the callers always pass).
+    # materialization. try_wait supports both PTX arities: timeHint is optional.
     *[
         InstructionEntry(
             name=f"mbarrier_{act}_parity",
@@ -6264,6 +6263,24 @@ _ENTRIES = [
         )
         for act in ("test_wait", "try_wait")
     ],
+    InstructionEntry(
+        name="mbarrier_try_wait_parity_no_hint",
+        mnemonic="mbarrier",
+        slots=(
+            ModifierSlot("action", ("try_wait",)),
+            ModifierSlot("parity", ("parity",)),
+            ModifierSlot("sem", ("acquire", "relaxed"), optional=True),
+            ModifierSlot("scope", ("cta", "cluster"), optional=True),
+            ModifierSlot("space", ("shared", "shared::cta"), optional=True),
+            ModifierSlot("type", ("b64",)),
+        ),
+        check=_check_mbarrier_sem_scope,
+        operands=(
+            OperandSlot("wait_complete", rw="w", dtype="pred"),
+            OperandSlot("addr", kind="addr"),
+            OperandSlot("phase", dtype="u32"),
+        ),
+    ),
     *[
         InstructionEntry(  # mbarrier.{expect_tx,complete_tx}{.sem.scope}{.space}.b64 [addr], tx;
             name=f"mbarrier_{act}",

--- a/python/tvm/script/tirx.pyi
+++ b/python/tvm/script/tirx.pyi
@@ -781,7 +781,7 @@ class _Chain_max:
     def __call__(self, *args: Any) -> None: ...
 
 class _Chain_mbarrier:
-    """`mbarrier` — 24 entries sharing this mnemonic; PTX puts their difference in the operand
+    """`mbarrier` — 25 entries sharing this mnemonic; PTX puts their difference in the operand
     list, so the call selects one. Shapes: (addr, count); (addr); (addr, tx_count); (state,
     addr, count); (wait_complete, addr, phase); (wait_complete, addr, phase, time_hint);
     (state, addr); (wait_complete, addr, state); (wait_complete, addr, state, time_hint);

--- a/tests/python/tirx/codegen/test_codegen_blackwell.py
+++ b/tests/python/tirx/codegen/test_codegen_blackwell.py
@@ -127,8 +127,12 @@ def test_mbarrier_try_wait_once_codegen():
         T.thread_id([128])
         bar = T.shared_scalar("uint64")
         ok = T.local_scalar("uint32")
+        ok_no_hint = T.local_scalar("uint32")
         T.ptx.mbarrier.try_wait.parity.shared__cta.b64(
             ok, T.address_of(bar), T.uint32(0), T.uint32(0)
+        )
+        T.ptx.mbarrier.try_wait.parity.shared__cta.b64(
+            ok_no_hint, T.address_of(bar), T.uint32(0)
         )
     # fmt: on
 
@@ -137,6 +141,7 @@ def test_mbarrier_try_wait_once_codegen():
         src, _ = _get_source(test_try_wait_once)
         assert "mbarrier.try_wait.parity.shared::cta.b64 pd0, [%1], %2, %3;" in src
         assert "selp.b32 %0, 1, 0, pd0;" in src
+        assert "mbarrier.try_wait.parity.shared::cta.b64 pd0, [%1], %2;" in src
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/codegen/test_ptx_dialect.py
+++ b/tests/python/tirx/codegen/test_ptx_dialect.py
@@ -2201,7 +2201,7 @@ def test_ptx_all_variants_render_unique():
                     or f"; {opcode};" in source
                 )
             total += not predicated  # a @p twin is not a separate variant
-    assert total == 199987  # update when the table grows
+    assert total == 200002  # update when the table grows
 
 
 def test_ptx_no_instruction_registered_twice():


### PR DESCRIPTION
## Summary

- Add the three-operand PTX form of `mbarrier.try_wait.parity` where the time hint is omitted.
- Preserve the existing four-operand form and select the correct entry by operand arity.
- Update the generated TIRx stub and PTX variant-count guard.

## Motivation

FlashInfer's MTP horizontal selective-state-update kernel emits the legal no-hint parity-wait form. TIRx previously exposed only the optional-time-hint spelling as a four-operand entry, forcing the port away from the source instruction sequence.

## Impact

TIRx kernels can now emit both PTX forms without inline CUDA. Existing callers of the time-hint form are unchanged.

## Validation

- Incremental TVM build: PASS.
- Full PTX dialect and Blackwell consistency set: 57 passed, 32 skipped.
- Generated `python/tvm/script/tirx.pyi` freshness gate: PASS.
- PTX variant uniqueness/count gate: PASS (`200002` variants).
- Staged-file pre-commit and branch diff check: PASS.
- Dependent MTP correctness: 43/43 simple, 36/36 vertical, and 36/36 horizontal.
- Dependent paired TIRx full test suite: 3031 passed, 73 skipped, and 3 xpassed with zero failures.
- Dependent combined bench-suite run 29: 123/123 workloads completed with every `flashinfer_cuda / tirx > 0.99`; minimum `1.001906534111x`.
