### PR TITLE
test(kernel): accept both MegaMoE kernel names in the registry test

### DIFF
--- a/tests/python/tirx/test_tirx_kernels_registry_correctness.py
+++ b/tests/python/tirx/test_tirx_kernels_registry_correctness.py
@@ -51,7 +51,14 @@ _KERNELS = {
     for kernel_name in sorted({workload["kernel"] for workload in _WORKLOADS})
 }
 _DISTRIBUTED_KERNELS = frozenset(
-    {"allgather_gemm", "deepgemm_fp8_fp4_mega_moe", "gemm_reduce_scatter"}
+    # Both MegaMoE names are listed so the test works across tirx-kernels
+    # checkouts from before and after the sm100_fp8_fp4_mega_moe rename.
+    {
+        "allgather_gemm",
+        "deepgemm_fp8_fp4_mega_moe",
+        "gemm_reduce_scatter",
+        "sm100_fp8_fp4_mega_moe",
+    }
 )
 _XDIST_CUDA_DEVICE = None
 


### PR DESCRIPTION
`tirx-kernels` renames the MegaMoE kernel from `deepgemm_fp8_fp4_mega_moe` to
`sm100_fp8_fp4_mega_moe`, matching the upstream DeepGEMM implementation file and
the naming its sibling SM100 ports use (spectrometerHBH/tirx-kernels#75).

`_DISTRIBUTED_KERNELS` in the registry correctness test hardcodes that name to
decide which kernels need multi-GPU handling, so it now lists both spellings.
Listing both keeps the test working against checkouts from either side of the
rename, which matters because the two repositories are not versioned together —
`_load_workloads` in the same file already tolerates older and newer bench-suite
layouts for the same reason. The stale entry can be dropped once no supported
`tirx-kernels` checkout uses the old name.
